### PR TITLE
XD-3250: Use prefixed @ConfigurationProperties

### DIFF
--- a/spring-cloud-stream-samples/source/src/main/java/source/TimeSource.java
+++ b/spring-cloud-stream-samples/source/src/main/java/source/TimeSource.java
@@ -31,6 +31,8 @@ import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
+import org.springframework.scheduling.Trigger;
+import org.springframework.scheduling.support.PeriodicTrigger;
 
 /**
  * @author Dave Syer
@@ -47,7 +49,14 @@ public class TimeSource {
 	public MessageChannel output;
 
 	@Bean
-	@InboundChannelAdapter(value = "output", autoStartup = "false", poller = @Poller(fixedDelay = "${fixedDelay}", maxMessagesPerPoll = "1"))
+	public Trigger trigger() {
+		PeriodicTrigger periodicTrigger = new PeriodicTrigger(options.getFixedDelay(), options.getTimeUnit());
+		periodicTrigger.setInitialDelay(options.getInitialDelay());
+		return periodicTrigger;
+	}
+
+	@Bean
+	@InboundChannelAdapter(value = "output", autoStartup = "false", poller = @Poller(trigger = "trigger", maxMessagesPerPoll = "${module.maxMessages}"))
 	public MessageSource<String> timerMessageSource() {
 		return () -> new GenericMessage<>(new SimpleDateFormat(this.options.getFormat()).format(new Date()));
 	}

--- a/spring-cloud-stream-samples/source/src/main/java/source/TimeSourceOptionsMetadata.java
+++ b/spring-cloud-stream-samples/source/src/main/java/source/TimeSourceOptionsMetadata.java
@@ -16,9 +16,12 @@
 
 package source;
 
+import java.util.concurrent.TimeUnit;
+
 import javax.validation.constraints.Min;
 import javax.validation.constraints.Pattern;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.xd.module.options.validation.DateFormat;
 
 /**
@@ -27,6 +30,7 @@ import org.springframework.xd.module.options.validation.DateFormat;
  * @author Eric Bottard
  * @author Gary Russell
  */
+@ConfigurationProperties(prefix = "module.")
 public class TimeSourceOptionsMetadata {
 
 	/**
@@ -47,7 +51,7 @@ public class TimeSourceOptionsMetadata {
 	/**
 	 * the time unit for the fixed and initial delays
 	 */
-	private String timeUnit = "SECONDS";
+	private TimeUnit timeUnit = TimeUnit.SECONDS;
 
 	/**
 	 * the maximum messages per poll; -1 for unlimited
@@ -71,14 +75,12 @@ public class TimeSourceOptionsMetadata {
 		this.initialDelay = initialDelay;
 	}
 
-	@Pattern(regexp = "(?i)(NANOSECONDS|MICROSECONDS|MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)",
-			message = "timeUnit must be one of NANOSECONDS, MICROSECONDS, MILLISECONDS, SECONDS, MINUTES, HOURS, DAYS (case-insensitive)")
-	public String getTimeUnit() {
+	public TimeUnit getTimeUnit() {
 		return this.timeUnit;
 	}
 
-	public void setTimeUnit(String timeUnit) {
-		this.timeUnit = timeUnit.toUpperCase();
+	public void setTimeUnit(TimeUnit timeUnit) {
+		this.timeUnit = timeUnit;
 	}
 
 	@DateFormat

--- a/spring-cloud-stream-samples/source/src/main/resources/application.yml
+++ b/spring-cloud-stream-samples/source/src/main/resources/application.yml
@@ -1,6 +1,11 @@
 server:
   port: 8081
-fixedDelay: 5000
+module:
+  # module options that are not read from @ConfigurationProperties classes
+  # such as the ones below (used in SI annotation attributes) have to have
+  # their default set here (in addition to the class, which is only to
+  # generate correct json metadata)
+  maxMessages: 1
 spring:
   cloud:
     channels:


### PR DESCRIPTION
Introduce prefixed module options. This PR also shows some implications/limitations of this model.

To be used in conjunction with an XD PR to come.