### PR TITLE
Minor suggestions

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/annotation/EnableModule.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/annotation/EnableModule.java
@@ -26,8 +26,8 @@ import java.lang.annotation.Target;
 import org.springframework.cloud.stream.config.AggregateBuilderConfiguration;
 import org.springframework.cloud.stream.config.ChannelBindingAdapterConfiguration;
 import org.springframework.cloud.stream.config.CodecConfiguration;
-import org.springframework.cloud.stream.config.EnableModuleConfiguration;
-import org.springframework.cloud.stream.config.LifecycleConfiguration;
+import org.springframework.cloud.stream.config.ModuleRegistrar;
+import org.springframework.cloud.stream.config.ChannelBindingAdapterRunner;
 import org.springframework.cloud.stream.config.RabbitServiceConfiguration;
 import org.springframework.cloud.stream.config.RedisServiceConfiguration;
 import org.springframework.context.annotation.Configuration;
@@ -47,8 +47,8 @@ import org.springframework.integration.annotation.MessageEndpoint;
 @Configuration
 @MessageEndpoint
 @Import({RedisServiceConfiguration.class, RabbitServiceConfiguration.class,
-	ChannelBindingAdapterConfiguration.class, CodecConfiguration.class, LifecycleConfiguration.class,
-	AggregateBuilderConfiguration.class, EnableModuleConfiguration.class})
+	ChannelBindingAdapterConfiguration.class, CodecConfiguration.class, ChannelBindingAdapterRunner.class,
+	AggregateBuilderConfiguration.class, ModuleRegistrar.class})
 public @interface EnableModule {
 
 	Class<?>[] value() default {};

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/AggregateBuilderConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/AggregateBuilderConfiguration.java
@@ -18,8 +18,7 @@ package org.springframework.cloud.stream.config;
 
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.ApplicationArguments;
-import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.cloud.stream.aggregate.AggregateBuilder;
 import org.springframework.cloud.stream.aggregate.AggregateConfigurer;
 import org.springframework.context.annotation.Bean;
@@ -30,7 +29,7 @@ import org.springframework.context.annotation.Configuration;
  *
  */
 @Configuration
-public class AggregateBuilderConfiguration implements ApplicationRunner {
+public class AggregateBuilderConfiguration implements CommandLineRunner {
 
 	@Autowired
 	private ListableBeanFactory beanFactory;
@@ -41,7 +40,7 @@ public class AggregateBuilderConfiguration implements ApplicationRunner {
 	}
 
 	@Override
-	public void run(ApplicationArguments args) throws Exception {
+	public void run(String... args) throws Exception {
 		for (AggregateConfigurer configurer : this.beanFactory.getBeansOfType(AggregateConfigurer.class).values()) {
 			configurer.configure(aggregateBuilder());
 		}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/AggregateBuilderConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/AggregateBuilderConfiguration.java
@@ -18,7 +18,8 @@ package org.springframework.cloud.stream.config;
 
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
 import org.springframework.cloud.stream.aggregate.AggregateBuilder;
 import org.springframework.cloud.stream.aggregate.AggregateConfigurer;
 import org.springframework.context.annotation.Bean;
@@ -29,7 +30,7 @@ import org.springframework.context.annotation.Configuration;
  *
  */
 @Configuration
-public class AggregateBuilderConfiguration implements CommandLineRunner {
+public class AggregateBuilderConfiguration implements ApplicationRunner {
 
 	@Autowired
 	private ListableBeanFactory beanFactory;
@@ -40,11 +41,10 @@ public class AggregateBuilderConfiguration implements CommandLineRunner {
 	}
 
 	@Override
-	public void run(String... args) throws Exception {
+	public void run(ApplicationArguments args) throws Exception {
 		for (AggregateConfigurer configurer : this.beanFactory.getBeansOfType(AggregateConfigurer.class).values()) {
 			configurer.configure(aggregateBuilder());
 		}
 		aggregateBuilder().build();
 	}
-
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingAdapterRunner.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingAdapterRunner.java
@@ -17,15 +17,14 @@
 package org.springframework.cloud.stream.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.ApplicationArguments;
-import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.cloud.stream.adapter.ChannelBindingAdapter;
 
 /**
  * @author Dave Syer
  *
  */
-public class ChannelBindingAdapterRunner implements ApplicationRunner {
+public class ChannelBindingAdapterRunner implements CommandLineRunner {
 
 	@Autowired
 	private ChannelBindingProperties module;
@@ -34,7 +33,7 @@ public class ChannelBindingAdapterRunner implements ApplicationRunner {
 	private ChannelBindingAdapter adapter;
 
 	@Override
-	public void run(ApplicationArguments args) throws Exception {
+	public void run(String... args) throws Exception {
 		if (!adapter.isRunning() && module.isAutoStartup()) {
 			adapter.start();
 		}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingAdapterRunner.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingAdapterRunner.java
@@ -17,16 +17,15 @@
 package org.springframework.cloud.stream.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
 import org.springframework.cloud.stream.adapter.ChannelBindingAdapter;
-import org.springframework.context.annotation.Configuration;
 
 /**
  * @author Dave Syer
  *
  */
-@Configuration
-public class LifecycleConfiguration implements CommandLineRunner {
+public class ChannelBindingAdapterRunner implements ApplicationRunner {
 
 	@Autowired
 	private ChannelBindingProperties module;
@@ -35,10 +34,9 @@ public class LifecycleConfiguration implements CommandLineRunner {
 	private ChannelBindingAdapter adapter;
 
 	@Override
-	public void run(String... args) throws Exception {
+	public void run(ApplicationArguments args) throws Exception {
 		if (!adapter.isRunning() && module.isAutoStartup()) {
 			adapter.start();
 		}
 	}
-
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ModuleRegistrar.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ModuleRegistrar.java
@@ -22,7 +22,6 @@ import java.util.List;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.cloud.stream.annotation.EnableModule;
 import org.springframework.cloud.stream.utils.MessageChannelBeanDefinitionRegistryUtils;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.util.ClassUtils;
@@ -32,8 +31,7 @@ import org.springframework.util.MultiValueMap;
  * @author Marius Bogoevici
  * @author Dave Syer
  */
-@Configuration
-public class EnableModuleConfiguration implements ImportBeanDefinitionRegistrar {
+public class ModuleRegistrar implements ImportBeanDefinitionRegistrar {
 
 	@Override
 	public void registerBeanDefinitions(AnnotationMetadata metadata,


### PR DESCRIPTION
 - Use `ApplicationRunner` instead of `CommandLineRunner` for adapter lifecycle start
 - Remove `Configuration` annotation for `LifecycleConfiguration` and `EnableModuleConfiguration` as these aren't configuration classes
 - Rename the above classes after their functionality