### PR TITLE
Rename kafka binder classes

### DIFF
--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/IntegerEncoderDecoder.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/IntegerEncoderDecoder.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.xd.dirt.integration.kafka;
+package org.springframework.cloud.stream.binder.kafka;
 
 import kafka.serializer.Decoder;
 import kafka.serializer.Encoder;

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.xd.dirt.integration.kafka;
+package org.springframework.cloud.stream.binder.kafka;
 
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/WindowingOffsetManager.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/WindowingOffsetManager.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.xd.dirt.integration.kafka;
+package org.springframework.cloud.stream.binder.kafka;
 
 import java.io.IOException;
 import java.util.Collection;

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/resources/META-INF/spring-cloud-stream/binder/kafka-binder.xml
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/resources/META-INF/spring-cloud-stream/binder/kafka-binder.xml
@@ -11,7 +11,7 @@
 	</bean>
 
 
-	<bean id="messageBus" class="org.springframework.xd.dirt.integration.kafka.KafkaMessageChannelBinder">
+	<bean id="messageBus" class="org.springframework.cloud.stream.binder.kafka.KafkaMessageChannelBinder">
 		<constructor-arg ref="zookeeperConnect"/>
 		<constructor-arg value="${xd.messagebus.kafka.brokers}"/>
 		<constructor-arg value="${xd.messagebus.kafka.zkAddress}"/>

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
@@ -46,11 +46,10 @@ import org.springframework.messaging.Message;
 import org.springframework.cloud.stream.binder.BinderProperties;
 import org.springframework.cloud.stream.binder.Binder;
 import org.springframework.cloud.stream.binder.Spy;
-import org.springframework.xd.dirt.integration.kafka.KafkaMessageChannelBinder;
 
 
 /**
- * Integration tests for the {@link org.springframework.xd.dirt.integration.kafka.KafkaMessageChannelBinder}.
+ * Integration tests for the {@link KafkaMessageChannelBinder}.
  *
  * @author Eric Bottard
  * @author Marius Bogoevici

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaTestBinder.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaTestBinder.java
@@ -21,12 +21,11 @@ import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.integration.kafka.support.ZookeeperConnect;
 import org.springframework.xd.dirt.integration.bus.serializer.MultiTypeCodec;
 import org.springframework.xd.dirt.integration.bus.serializer.kryo.PojoCodec;
-import org.springframework.xd.dirt.integration.kafka.KafkaMessageChannelBinder;
 import org.springframework.xd.tuple.serializer.kryo.TupleKryoRegistrar;
 
 
 /**
- * Test support class for {@link org.springframework.xd.dirt.integration.kafka.KafkaMessageChannelBinder}.
+ * Test support class for {@link KafkaMessageChannelBinder}.
  * Creates a binder that uses a test {@link TestKafkaCluster kafka cluster}.
  * @author Eric Bottard
  * @author Marius Bogoevici

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/RawModeKafkaBinderTests.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/RawModeKafkaBinderTests.java
@@ -45,7 +45,6 @@ import org.springframework.messaging.support.GenericMessage;
 import org.springframework.cloud.stream.binder.Binding;
 import org.springframework.cloud.stream.binder.BinderProperties;
 import org.springframework.cloud.stream.binder.Binder;
-import org.springframework.xd.dirt.integration.kafka.KafkaMessageChannelBinder;
 import org.springframework.cloud.stream.binder.TestUtils;
 
 /**

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/TestKafkaCluster.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/TestKafkaCluster.java
@@ -35,7 +35,6 @@ import org.apache.curator.test.TestingServer;
 
 import org.springframework.util.Assert;
 import org.springframework.util.SocketUtils;
-import org.springframework.xd.dirt.integration.kafka.KafkaMessageChannelBinder;
 
 import java.io.IOException;
 import java.util.Collections;


### PR DESCRIPTION
 - Move pkg name to `org.springframework.cloud.stream.binder.kafka`