### PR TITLE
Explicit module annotations

### DIFF
--- a/spring-cloud-stream-samples/double/src/main/java/config/SinkModuleDefinition.java
+++ b/spring-cloud-stream-samples/double/src/main/java/config/SinkModuleDefinition.java
@@ -18,7 +18,8 @@ package config;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.cloud.stream.annotation.EnableModule;
+
+import org.springframework.cloud.stream.annotation.EnableSinkModule;
 import org.springframework.cloud.stream.annotation.Sink;
 import org.springframework.integration.annotation.ServiceActivator;
 
@@ -26,7 +27,7 @@ import org.springframework.integration.annotation.ServiceActivator;
  * @author Dave Syer
  * @author Marius Bogoevici
  */
-@EnableModule(Sink.class)
+@EnableSinkModule
 public class SinkModuleDefinition {
 
 	private static Logger logger = LoggerFactory.getLogger(SinkModuleDefinition.class);

--- a/spring-cloud-stream-samples/double/src/main/java/config/SourceModuleDefinition.java
+++ b/spring-cloud-stream-samples/double/src/main/java/config/SourceModuleDefinition.java
@@ -20,7 +20,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cloud.stream.annotation.EnableModule;
+import org.springframework.cloud.stream.annotation.EnableSourceModule;
 import org.springframework.cloud.stream.annotation.Source;
 import org.springframework.context.annotation.Bean;
 import org.springframework.integration.annotation.InboundChannelAdapter;
@@ -32,7 +32,7 @@ import org.springframework.messaging.support.GenericMessage;
  * @author Dave Syer
  * @author Marius Bogoevici
  */
-@EnableModule(Source.class)
+@EnableSourceModule
 public class SourceModuleDefinition {
 
 	@Value("${format:YYYY/MM/dd hh:mm:ss}")

--- a/spring-cloud-stream-samples/sink/src/main/java/sink/LogSink.java
+++ b/spring-cloud-stream-samples/sink/src/main/java/sink/LogSink.java
@@ -18,7 +18,8 @@ package sink;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.cloud.stream.annotation.EnableModule;
+
+import org.springframework.cloud.stream.annotation.EnableSinkModule;
 import org.springframework.cloud.stream.annotation.Sink;
 import org.springframework.integration.annotation.ServiceActivator;
 
@@ -26,7 +27,7 @@ import org.springframework.integration.annotation.ServiceActivator;
  * @author Dave Syer
  *
  */
-@EnableModule(Sink.class)
+@EnableSinkModule
 public class LogSink {
 
 	private static Logger logger = LoggerFactory.getLogger(LogSink.class);

--- a/spring-cloud-stream-samples/sink/src/test/java/demo/ModuleApplicationTests.java
+++ b/spring-cloud-stream-samples/sink/src/test/java/demo/ModuleApplicationTests.java
@@ -4,13 +4,11 @@ import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.cloud.stream.annotation.ModuleChannels;
-import org.springframework.cloud.stream.annotation.Output;
 import org.springframework.cloud.stream.annotation.Sink;
-import org.springframework.cloud.stream.annotation.Source;
-import org.springframework.messaging.MessageChannel;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -26,12 +24,6 @@ public class ModuleApplicationTests {
 	@Autowired
 	@ModuleChannels(LogSink.class)
 	private Sink sink;
-
-	@Autowired
-	private Sink same;
-
-	@Output(Source.OUTPUT)
-	private MessageChannel output;
 
 	@Test
 	public void contextLoads() {

--- a/spring-cloud-stream-samples/source/src/main/java/source/TimeSource.java
+++ b/spring-cloud-stream-samples/source/src/main/java/source/TimeSource.java
@@ -16,9 +16,12 @@
 
 package source;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cloud.stream.annotation.EnableModule;
+import org.springframework.cloud.stream.annotation.EnableSourceModule;
 import org.springframework.cloud.stream.annotation.Source;
 import org.springframework.context.annotation.Bean;
 import org.springframework.integration.annotation.InboundChannelAdapter;
@@ -26,15 +29,12 @@ import org.springframework.integration.annotation.Poller;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.messaging.support.GenericMessage;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
-
 /**
  * @author Dave Syer
  * @author Glenn Renfro
  *
  */
-@EnableModule(Source.class)
+@EnableSourceModule
 @EnableConfigurationProperties(TimeSourceOptionsMetadata.class)
 public class TimeSource {
 

--- a/spring-cloud-stream-samples/tap/src/main/java/config/TappingLoggingSink.java
+++ b/spring-cloud-stream-samples/tap/src/main/java/config/TappingLoggingSink.java
@@ -18,7 +18,8 @@ package config;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.cloud.stream.annotation.EnableModule;
+
+import org.springframework.cloud.stream.annotation.EnableSinkModule;
 import org.springframework.cloud.stream.annotation.Sink;
 import org.springframework.integration.annotation.ServiceActivator;
 
@@ -26,7 +27,7 @@ import org.springframework.integration.annotation.ServiceActivator;
  * @author Dave Syer
  * @author Marius Bogoevici
  */
-@EnableModule(Sink.class)
+@EnableSinkModule
 public class TappingLoggingSink {
 
 	private static Logger logger = LoggerFactory.getLogger(TappingLoggingSink.class);

--- a/spring-cloud-stream-samples/transform/src/main/java/transform/LoggingTransformer.java
+++ b/spring-cloud-stream-samples/transform/src/main/java/transform/LoggingTransformer.java
@@ -18,8 +18,9 @@ package transform;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.cloud.stream.annotation.EnableModule;
+import org.springframework.cloud.stream.annotation.EnableProcessorModule;
 import org.springframework.cloud.stream.annotation.Processor;
 import org.springframework.integration.annotation.ServiceActivator;
 
@@ -27,7 +28,7 @@ import org.springframework.integration.annotation.ServiceActivator;
  * @author Dave Syer
  *
  */
-@EnableModule(Processor.class)
+@EnableProcessorModule
 @ConfigurationProperties("module.logging")
 public class LoggingTransformer {
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/annotation/EnableProcessorModule.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/annotation/EnableProcessorModule.java
@@ -16,13 +16,21 @@
 
 package org.springframework.cloud.stream.annotation;
 
-import org.springframework.messaging.MessageChannel;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-public interface Source {
-	
-	public static final String OUTPUT = "output";
-	
-	@Output(Source.OUTPUT)
-	MessageChannel output();
+/**
+ * Annotation that identifies a class as a processor module.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@EnableModule(Processor.class)
+public @interface EnableProcessorModule {
 
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/annotation/EnableSinkModule.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/annotation/EnableSinkModule.java
@@ -16,13 +16,21 @@
 
 package org.springframework.cloud.stream.annotation;
 
-import org.springframework.messaging.MessageChannel;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-public interface Source {
-	
-	public static final String OUTPUT = "output";
-	
-	@Output(Source.OUTPUT)
-	MessageChannel output();
+/**
+ * Annotation that identifies a class as a sink module.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@EnableModule(Sink.class)
+public @interface EnableSinkModule {
 
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/annotation/EnableSourceModule.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/annotation/EnableSourceModule.java
@@ -16,13 +16,21 @@
 
 package org.springframework.cloud.stream.annotation;
 
-import org.springframework.messaging.MessageChannel;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-public interface Source {
-	
-	public static final String OUTPUT = "output";
-	
-	@Output(Source.OUTPUT)
-	MessageChannel output();
+/**
+ * Annotation that identifies a class as a source module.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@EnableModule(Source.class)
+public @interface EnableSourceModule {
 
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/annotation/Sink.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/annotation/Sink.java
@@ -20,7 +20,7 @@ import org.springframework.messaging.SubscribableChannel;
 
 public interface Sink {
 
-	public static String INPUT = "input";
+	public static final String INPUT = "input";
 
 	@Input(Sink.INPUT)
 	SubscribableChannel input();

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingAdapterConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingAdapterConfiguration.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
+
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.aop.target.LazyInitTargetSource;
 import org.springframework.beans.factory.BeanFactoryUtils;
@@ -32,18 +33,17 @@ import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.cloud.stream.adapter.ChannelBindingAdapter;
-import org.springframework.cloud.stream.adapter.ChannelLocator;
 import org.springframework.cloud.stream.adapter.InputChannelBinding;
 import org.springframework.cloud.stream.adapter.OutputChannelBinding;
 import org.springframework.cloud.stream.annotation.Input;
 import org.springframework.cloud.stream.annotation.Output;
+import org.springframework.cloud.stream.binder.Binder;
 import org.springframework.cloud.stream.binder.BinderAwareRouterBeanPostProcessor;
 import org.springframework.cloud.stream.endpoint.ChannelsEndpoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.util.Assert;
-import org.springframework.cloud.stream.binder.Binder;
 
 /**
  * @author Dave Syer
@@ -59,8 +59,6 @@ public class ChannelBindingAdapterConfiguration {
 	@Autowired
 	private ConfigurableListableBeanFactory beanFactory;
 
-	private ChannelLocator channelLocator;
-
 	@Autowired
 	private Binder<MessageChannel> binder;
 
@@ -69,9 +67,6 @@ public class ChannelBindingAdapterConfiguration {
 		ChannelBindingAdapter adapter = new ChannelBindingAdapter(this.module, this.binder);
 		adapter.setOutputChannels(getOutputChannels());
 		adapter.setInputChannels(getInputChannels());
-		if (this.channelLocator != null) {
-			adapter.setChannelLocator(this.channelLocator);
-		}
 		return adapter;
 	}
 


### PR DESCRIPTION
 - Introduce explicit module annotations like `EnableSourceModule`,
`EnableSinkModule` and `EnableProcessorModule` and have them use
`EnableModule` with the class value specified.
    - The reasoning here is that the user doesn't need to know about the
module class (value) when enabling module. This will also simplify the
annotation based on the module kind.
 - Some code cleanup