### PR TITLE
Add auto-config for Local binder

### DIFF
--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-local/src/main/java/org/springframework/cloud/stream/binder/local/config/LocalBinderAutoConfiguration.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-local/src/main/java/org/springframework/cloud/stream/binder/local/config/LocalBinderAutoConfiguration.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.binder.local.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.stream.binder.Binder;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.PropertySource;
+
+/**
+ * Auto configuration for Local (in-memory) {@link Binder}.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+@Configuration
+@ConditionalOnMissingBean(Binder.class)
+@Import(LocalMessageChannelBinderConfiguration.class)
+@PropertySource("classpath:/META-INF/spring-cloud-stream/local-binder.properties")
+public class LocalBinderAutoConfiguration {
+}

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-local/src/main/resources/META-INF/spring-cloud-stream/local-binder.properties
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-local/src/main/resources/META-INF/spring-cloud-stream/local-binder.properties
@@ -1,0 +1,5 @@
+spring.cloud.stream.binder.local.polling:                     1000
+spring.cloud.stream.binder.local.executor.corePoolSize:       0
+spring.cloud.stream.binder.local.executor.maxPoolSize:        400
+#spring.cloud.stream.binder.local.executor.queueSize:         # defaults to Integer.MAX_VALUE
+spring.cloud.stream.binder.local.executor.keepAliveSeconds:   60

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-local/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-local/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration:\
+org.springframework.cloud.stream.binder.local.config.LocalBinderAutoConfiguration

--- a/spring-cloud-stream/pom.xml
+++ b/spring-cloud-stream/pom.xml
@@ -46,6 +46,7 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream-binder-local</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
 - Make `local` binder compile dependency as optional
 - Add `local` binder auto configuration
    - This imports local binder properties and binder
 - Add `spring.factories` to enable auto configuration when this archive
is on the classpath