### PR TITLE
ModuleRunner enhancements

### DIFF
--- a/spring-cloud-stream-module-launcher/pom.xml
+++ b/spring-cloud-stream-module-launcher/pom.xml
@@ -31,6 +31,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>

--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncherConfiguration.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncherConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.module.resolver.AetherModuleResolver;
 import org.springframework.cloud.stream.module.resolver.ModuleResolver;
+import org.springframework.cloud.stream.module.resolver.ModuleResolverProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -34,11 +35,11 @@ import org.springframework.context.annotation.Configuration;
  * @author Ilayaperumal Gopinathan
  */
 @Configuration
-@EnableConfigurationProperties(ModuleLauncherProperties.class)
+@EnableConfigurationProperties(ModuleResolverProperties.class)
 public class ModuleLauncherConfiguration {
 
 	@Autowired
-	private ModuleLauncherProperties properties;
+	private ModuleResolverProperties properties;
 
 	/**
 	 * Sets up the default Aether-based module resolver, unless overridden.

--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncherProperties.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncherProperties.java
@@ -16,12 +16,12 @@
 
 package org.springframework.cloud.stream.module.launcher;
 
-import java.io.File;
+import org.hibernate.validator.constraints.NotEmpty;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
- * Contains configuration properties for the module launcher.
+ * Configuration properties for {@link ModuleLauncher}.
  *
  * @author Ilayaperumal Gopinathan
  * @author Marius Bogoevici
@@ -30,30 +30,17 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class ModuleLauncherProperties {
 
 	/**
-	 * File path to a locally available maven repository, where modules will be downloaded.
+	 * Array of modules that need to be launched.
 	 */
-	private File localRepository = new File(System.getProperty("user.home")
-			+ File.separator + ".m2" + File.separator + "repository");
+	private String[] modules;
 
-	/**
-	 * Location of comma separated remote maven repositories from which modules will be downloaded, if not available locally.
-	 */
-	private String[] remoteRepositories = new String[] {"https://repo.spring.io/libs-snapshot"};
-
-	public void setRemoteRepositories(String[] remoteRepositories) {
-		this.remoteRepositories = remoteRepositories;
+	public void setModules(String[] modules) {
+		this.modules = modules;
 	}
 
-	protected String[] getRemoteRepositories() {
-		return remoteRepositories;
-	}
-
-	public void setLocalRepository(File localRepository) {
-		this.localRepository = localRepository;
-	}
-
-	protected File getLocalRepository() {
-		return localRepository;
+	@NotEmpty(message = "A list of modules must be specified.")
+	public String[] getModules() {
+		return modules;
 	}
 
 }

--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncherRunner.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncherRunner.java
@@ -18,44 +18,38 @@ package org.springframework.cloud.stream.module.launcher;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.springframework.beans.factory.InitializingBean;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Component;
-import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
+ * Spring boot {@link ApplicationRunner} that triggers {@link ModuleLauncher} to launch the modules.
+ *
  * @author Marius Bogoevici
+ * @author Ilayaperumal Gopinathan
  */
 @Component
-@ConfigurationProperties
-public class ModuleLauncherRunner implements ApplicationRunner, InitializingBean {
+@EnableConfigurationProperties(ModuleLauncherProperties.class)
+public class ModuleLauncherRunner implements ApplicationRunner {
 
 	private final static Log log = LogFactory.getLog(ModuleLauncherRunner.class);
 
 	@Autowired
+	private ModuleLauncherProperties moduleLauncherProperties;
+
+	@Autowired
 	private ModuleLauncher moduleLauncher;
-
-	private String[] modules;
-
-	public void setModules(String[] modules) {
-		this.modules = modules;
-	}
-
-	@Override
-	public void afterPropertiesSet() throws Exception {
-		Assert.notEmpty(this.modules, "A list of modules must be specified");
-	}
 
 	@Override
 	public void run(ApplicationArguments applicationArguments) throws Exception {
-		String[] launchedModules = this.modules;
+		String[] launchedModules = moduleLauncherProperties.getModules();
 		if (log.isInfoEnabled()) {
 			log.info("Launching: "
-					+ StringUtils.arrayToCommaDelimitedString(this.modules)
+					+ StringUtils.arrayToCommaDelimitedString(launchedModules)
 					+ " with arguments: "
 					+ StringUtils.arrayToCommaDelimitedString(applicationArguments
 							.getSourceArgs()));

--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/resolver/ModuleResolverProperties.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/resolver/ModuleResolverProperties.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.resolver;
+
+import java.io.File;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for {@link ModuleResolver}.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+@ConfigurationProperties
+public class ModuleResolverProperties {
+
+	/**
+	 * File path to a locally available maven repository, where modules will be downloaded.
+	 */
+	private File localRepository = new File(System.getProperty("user.home") + File.separator + ".m2" +
+			File.separator + "repository");
+
+	/**
+	 * Location of comma separated remote maven repositories from which modules will be downloaded, if not available locally.
+	 */
+	private String[] remoteRepositories = new String[] {"https://repo.spring.io/libs-snapshot"};
+
+	public void setRemoteRepositories(String[] remoteRepositories) {
+		this.remoteRepositories = remoteRepositories;
+	}
+
+	public String[] getRemoteRepositories() {
+		return remoteRepositories;
+	}
+	public void setLocalRepository(File localRepository) {
+		this.localRepository = localRepository;
+	}
+
+	public File getLocalRepository() {
+		return localRepository;
+	}
+
+}


### PR DESCRIPTION
 - Move the launcher property `modules` to `ModuleLauncherProperties`
   - This will make the `ModuleRunner` to be `Component` bean only; Also, it only needs to enable the configuration properties of `ModuleLauncherProperties`