### PR TITLE
Fix dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,13 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
+				<groupId>org.springframework.integration</groupId>
+				<artifactId>spring-integration-bom</artifactId>
+				<version>${spring-integration.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-parent</artifactId>
 				<version>${spring-boot.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,11 +20,7 @@
 	<properties>
 		<java.version>1.7</java.version>
 		<spring-boot.version>1.3.0.BUILD-SNAPSHOT</spring-boot.version>
-		<spring-cloud.version>Brixton.BUILD-SNAPSHOT</spring-cloud.version>
-		<spring-xd.version>1.2.1.BUILD-SNAPSHOT</spring-xd.version>
-		<spring-framework.version>4.2.0.RC2</spring-framework.version>
 		<spring-integration.version>4.2.0.BUILD-SNAPSHOT</spring-integration.version>
-		<spring-cloud-spring-service-connector.version>1.2.0.BUILD-SNAPSHOT</spring-cloud-spring-service-connector.version>
 		<spring-cloud-lattice.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-lattice.version>
 	</properties>
 	<modules>
@@ -43,18 +39,6 @@
 				<version>${spring-boot.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-starter-parent</artifactId>
-				<version>${spring-cloud.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-spring-service-connector</artifactId>
-				<version>${spring-cloud-spring-service-connector.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
@@ -93,13 +77,18 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-stream-module-launcher</artifactId>
+				<artifactId>spring-cloud-stream-binder-spi</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.springframework</groupId>
-				<artifactId>spring-messaging</artifactId>
-				<version>${spring-framework.version}</version>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-stream-binder-test</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-stream-module-launcher</artifactId>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.integration</groupId>

--- a/spring-cloud-stream-binders/pom.xml
+++ b/spring-cloud-stream-binders/pom.xml
@@ -18,6 +18,7 @@
 	<properties>
 		<kafka.version>0.8.2.1</kafka.version>
 		<curator.version>2.6.0</curator.version>
+		<spring-xd.version>1.2.1.BUILD-SNAPSHOT</spring-xd.version>
 	</properties>
 	<modules>
 		<module>spring-cloud-stream-binder-spi</module>
@@ -31,15 +32,9 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-stream-binder-spi</artifactId>
-				<version>${project.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-stream-binder-test</artifactId>
-				<version>${project.version}</version>
-				<scope>test</scope>
+				<groupId>org.springframework.xd</groupId>
+				<artifactId>spring-xd-tuple</artifactId>
+				<version>${spring-xd.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.kafka</groupId>

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/pom.xml
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/pom.xml
@@ -54,7 +54,6 @@
 		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-amqp</artifactId>
-			<version>${spring-integration.version}</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/pom.xml
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/pom.xml
@@ -54,18 +54,15 @@
 		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-redis</artifactId>
-			<version>${spring-integration.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
-			<version>2.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.xd</groupId>
 			<artifactId>spring-xd-tuple</artifactId>
-			<version>${spring-xd.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-spi/pom.xml
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-spi/pom.xml
@@ -22,7 +22,6 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
-			<version>${spring-framework.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.integration</groupId>
@@ -31,17 +30,14 @@
 		<dependency>
 			<groupId>org.springframework.retry</groupId>
 			<artifactId>spring-retry</artifactId>
-			<version>1.1.0.RELEASE</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.4.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.3.6</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-test/pom.xml
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-test/pom.xml
@@ -36,12 +36,10 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
-			<version>${spring-framework.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.xd</groupId>
 			<artifactId>spring-xd-tuple</artifactId>
-			<version>${spring-xd.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-stream-codec/pom.xml
+++ b/spring-cloud-stream-codec/pom.xml
@@ -30,10 +30,12 @@
 		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-core</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-logging</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
In order to join the Spring Cloud release train we have to align the
dependencies and (more importantly) the dependency management strategy.
The strategy is to not put version  ids in `<dependencies>` (only
in `<dependencyManagement>`) where possible. And more importantly
we cannot use the releae train itself (creates a cycle).

This change achieves most of that (and mkae it possible for client
apps to use spring-cloud-starter-parent:Brixton.BUILD-SNAPSHOT)