### PR TITLE
Support comma separated remote repos

### DIFF
--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncherConfiguration.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncherConfiguration.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.stream.module.launcher;
 
-import java.util.Collections;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -25,6 +23,7 @@ import org.springframework.cloud.stream.module.resolver.AetherModuleResolver;
 import org.springframework.cloud.stream.module.resolver.ModuleResolver;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
 
 /**
  * Configuration class that has the beans required for module launcher.
@@ -45,8 +44,8 @@ public class ModuleLauncherConfiguration {
 	@Bean
 	@ConditionalOnMissingBean(ModuleResolver.class)
 	public ModuleResolver moduleResolver() {
-		return new AetherModuleResolver(properties.getLocalRepository(), Collections.singletonMap(
-				"remoteRepository", properties.getRemoteRepository()));
+		return new AetherModuleResolver(properties.getLocalRepository(),
+				StringUtils.commaDelimitedListToSet(properties.getRemoteRepositories()));
 	}
 
 	@Bean

--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncherConfiguration.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncherConfiguration.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.stream.module.launcher;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -23,7 +26,8 @@ import org.springframework.cloud.stream.module.resolver.AetherModuleResolver;
 import org.springframework.cloud.stream.module.resolver.ModuleResolver;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.util.StringUtils;
+import org.springframework.util.AlternativeJdkIdGenerator;
+import org.springframework.util.IdGenerator;
 
 /**
  * Configuration class that has the beans required for module launcher.
@@ -35,6 +39,8 @@ import org.springframework.util.StringUtils;
 @EnableConfigurationProperties(ModuleLauncherProperties.class)
 public class ModuleLauncherConfiguration {
 
+	private final IdGenerator idGenerator = new AlternativeJdkIdGenerator();
+
 	@Autowired
 	private ModuleLauncherProperties properties;
 
@@ -44,8 +50,11 @@ public class ModuleLauncherConfiguration {
 	@Bean
 	@ConditionalOnMissingBean(ModuleResolver.class)
 	public ModuleResolver moduleResolver() {
-		return new AetherModuleResolver(properties.getLocalRepository(),
-				StringUtils.commaDelimitedListToSet(properties.getRemoteRepositories()));
+		Map<String, String> repositoriesMap = new HashMap<>();
+		for (String repository: properties.getRemoteRepositories()) {
+			repositoriesMap.put(idGenerator.generateId().toString(), repository);
+		}
+		return new AetherModuleResolver(properties.getLocalRepository(), repositoriesMap);
 	}
 
 	@Bean

--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncherProperties.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncherProperties.java
@@ -38,13 +38,13 @@ public class ModuleLauncherProperties {
 	/**
 	 * Location of comma separated remote maven repositories from which modules will be downloaded, if not available locally.
 	 */
-	private String remoteRepositories = "https://repo.spring.io/libs-snapshot";
+	private String[] remoteRepositories = new String[] {"https://repo.spring.io/libs-snapshot"};
 
-	public void setRemoteRepositories(String remoteRepositories) {
+	public void setRemoteRepositories(String[] remoteRepositories) {
 		this.remoteRepositories = remoteRepositories;
 	}
 
-	protected String getRemoteRepositories() {
+	protected String[] getRemoteRepositories() {
 		return remoteRepositories;
 	}
 

--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncherProperties.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncherProperties.java
@@ -36,16 +36,16 @@ public class ModuleLauncherProperties {
 			+ File.separator + ".m2" + File.separator + "repository");
 
 	/**
-	 * Location of a remote maven repository from which modules will be downloaded, if not available locally.
+	 * Location of comma separated remote maven repositories from which modules will be downloaded, if not available locally.
 	 */
-	private String remoteRepository = "https://repo.spring.io/libs-snapshot";
+	private String remoteRepositories = "https://repo.spring.io/libs-snapshot";
 
-	public void setRemoteRepository(String remoteRepository) {
-		this.remoteRepository = remoteRepository;
+	public void setRemoteRepositories(String remoteRepositories) {
+		this.remoteRepositories = remoteRepositories;
 	}
 
-	protected String getRemoteRepository() {
-		return remoteRepository;
+	protected String getRemoteRepositories() {
+		return remoteRepositories;
 	}
 
 	public void setLocalRepository(File localRepository) {

--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/resolver/AetherModuleResolver.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/resolver/AetherModuleResolver.java
@@ -18,7 +18,7 @@ package org.springframework.cloud.stream.module.resolver;
 import java.io.File;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -54,6 +54,7 @@ import org.springframework.util.StringUtils;
  * @author David Turanski
  * @author Mark Fisher
  * @author Marius Bogoevici
+ * @author Ilayaperumal Gopinathan
  */
 public class AetherModuleResolver implements ModuleResolver {
 
@@ -70,16 +71,16 @@ public class AetherModuleResolver implements ModuleResolver {
 	/**
 	 * Create an instance specifying the locations of the local and remote repositories.
 	 * @param localRepository the root path of the local maven repository
-	 * @param remoteRepositories a Map containing pairs of (repository ID,repository URL). This
+	 * @param remoteRepositoriesSet a set of remote repositories. This
 	 * may be null or empty if the local repository is off line.
 	 */
-	public AetherModuleResolver(File localRepository, Map<String, String> remoteRepositories) {
+	public AetherModuleResolver(File localRepository, Set<String> remoteRepositoriesSet) {
 		Assert.notNull(localRepository, "Local repository path cannot be null");
 		if (log.isDebugEnabled()) {
 			log.debug("Local repository: " + localRepository);
-			if (!CollectionUtils.isEmpty(remoteRepositories)) {
+			if (!CollectionUtils.isEmpty(remoteRepositoriesSet)) {
 				// just listing the values, ids are simply informative
-				log.debug("Remote repositories: " + StringUtils.collectionToCommaDelimitedString(remoteRepositories.values()));
+				log.debug("Remote repositories: " + StringUtils.collectionToCommaDelimitedString(remoteRepositoriesSet));
 			}
 		}
 		if (!localRepository.exists()) {
@@ -88,10 +89,10 @@ public class AetherModuleResolver implements ModuleResolver {
 		}
 		this.localRepository = localRepository;
 		this.remoteRepositories = new LinkedList<>();
-		if (!CollectionUtils.isEmpty(remoteRepositories)) {
-			for (Map.Entry<String, String> remoteRepo : remoteRepositories.entrySet()) {
-				RemoteRepository remoteRepository = new RemoteRepository.Builder(remoteRepo.getKey(),
-						DEFAULT_CONTENT_TYPE, remoteRepo.getValue()).build();
+		if (!CollectionUtils.isEmpty(remoteRepositoriesSet)) {
+			for (String remoteRepo : remoteRepositoriesSet) {
+				RemoteRepository remoteRepository = new RemoteRepository.Builder("",
+						DEFAULT_CONTENT_TYPE, remoteRepo).build();
 				this.remoteRepositories.add(remoteRepository);
 			}
 		}

--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/resolver/AetherModuleResolver.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/resolver/AetherModuleResolver.java
@@ -18,7 +18,7 @@ package org.springframework.cloud.stream.module.resolver;
 import java.io.File;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -54,7 +54,6 @@ import org.springframework.util.StringUtils;
  * @author David Turanski
  * @author Mark Fisher
  * @author Marius Bogoevici
- * @author Ilayaperumal Gopinathan
  */
 public class AetherModuleResolver implements ModuleResolver {
 
@@ -71,16 +70,16 @@ public class AetherModuleResolver implements ModuleResolver {
 	/**
 	 * Create an instance specifying the locations of the local and remote repositories.
 	 * @param localRepository the root path of the local maven repository
-	 * @param remoteRepositoriesSet a set of remote repositories. This
+	 * @param remoteRepositories a Map containing pairs of (repository ID,repository URL). This
 	 * may be null or empty if the local repository is off line.
 	 */
-	public AetherModuleResolver(File localRepository, Set<String> remoteRepositoriesSet) {
+	public AetherModuleResolver(File localRepository, Map<String, String> remoteRepositories) {
 		Assert.notNull(localRepository, "Local repository path cannot be null");
 		if (log.isDebugEnabled()) {
 			log.debug("Local repository: " + localRepository);
-			if (!CollectionUtils.isEmpty(remoteRepositoriesSet)) {
+			if (!CollectionUtils.isEmpty(remoteRepositories)) {
 				// just listing the values, ids are simply informative
-				log.debug("Remote repositories: " + StringUtils.collectionToCommaDelimitedString(remoteRepositoriesSet));
+				log.debug("Remote repositories: " + StringUtils.collectionToCommaDelimitedString(remoteRepositories.values()));
 			}
 		}
 		if (!localRepository.exists()) {
@@ -89,10 +88,10 @@ public class AetherModuleResolver implements ModuleResolver {
 		}
 		this.localRepository = localRepository;
 		this.remoteRepositories = new LinkedList<>();
-		if (!CollectionUtils.isEmpty(remoteRepositoriesSet)) {
-			for (String remoteRepo : remoteRepositoriesSet) {
-				RemoteRepository remoteRepository = new RemoteRepository.Builder("",
-						DEFAULT_CONTENT_TYPE, remoteRepo).build();
+		if (!CollectionUtils.isEmpty(remoteRepositories)) {
+			for (Map.Entry<String, String> remoteRepo : remoteRepositories.entrySet()) {
+				RemoteRepository remoteRepository = new RemoteRepository.Builder(remoteRepo.getKey(),
+						DEFAULT_CONTENT_TYPE, remoteRepo.getValue()).build();
 				this.remoteRepositories.add(remoteRepository);
 			}
 		}
@@ -119,7 +118,7 @@ public class AetherModuleResolver implements ModuleResolver {
 			classifier = "";
 		}
 		Assert.hasText(version, "'version' cannot be blank.");
-	
+
 		Artifact artifact = new DefaultArtifact(groupId, artifactId, classifier, extension, version);
 		RepositorySystemSession session = newRepositorySystemSession(repositorySystem,
 				localRepository.getAbsolutePath());

--- a/spring-cloud-stream-module-launcher/src/test/java/org/springframework/cloud/stream/module/resolver/AetherModuleResolverTests.java
+++ b/spring-cloud-stream-module-launcher/src/test/java/org/springframework/cloud/stream/module/resolver/AetherModuleResolverTests.java
@@ -24,8 +24,8 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -70,10 +70,10 @@ public class AetherModuleResolverTests {
 	public void testResolveRemote() throws IOException {
 		ClassPathResource cpr = new ClassPathResource("local-repo");
 		File localRepository = cpr.getFile();
-		Set<String> remoteRepos = new HashSet<>();
-		remoteRepos.add("http://repo.spring.io/spring-cloud-stream-modules");
+		Map<String, String> remoteRepos = new HashMap<>();
+		remoteRepos.put("modules", "http://repo.spring.io/spring-cloud-stream-modules");
 		AetherModuleResolver defaultModuleResolver = new AetherModuleResolver(localRepository, remoteRepos);
-		Resource resource = defaultModuleResolver.resolve("org.springframework.cloud.stream.module", "time-source", 
+		Resource resource = defaultModuleResolver.resolve("org.springframework.cloud.stream.module", "time-source",
 				"1.0.0.BUILD-SNAPSHOT", "exec", "jar");
 		assertTrue(resource.exists());
 		assertEquals(resource.getFile().getName(), "time-source-1.0.0.BUILD-SNAPSHOT-exec.jar");
@@ -85,9 +85,9 @@ public class AetherModuleResolverTests {
 		File localRepository = cpr.getFile();
 		ClassPathResource stubJarResource = new ClassPathResource("__files/foo.jar");
 		String stubFileName = stubJarResource.getFile().getName();
-		Set<String> remoteRepos = new HashSet<>();
-		remoteRepos.add("http://localhost:" + port + "/repo0");
-		remoteRepos.add("http://localhost:" + port + "/repo1");
+		Map<String, String> remoteRepos = new HashMap<>();
+		remoteRepos.put("repo0", "http://localhost:" + port + "/repo0");
+		remoteRepos.put("repo1", "http://localhost:" + port + "/repo1");
 		stubFor(get(urlEqualTo("/repo1/org/bar/foo/1.0.0/foo-1.0.0.jar"))
 				.willReturn(aResponse()
 						.withStatus(200)

--- a/spring-cloud-stream-module-launcher/src/test/java/org/springframework/cloud/stream/module/resolver/AetherModuleResolverTests.java
+++ b/spring-cloud-stream-module-launcher/src/test/java/org/springframework/cloud/stream/module/resolver/AetherModuleResolverTests.java
@@ -15,12 +15,18 @@
 
 package org.springframework.cloud.stream.module.resolver;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -29,12 +35,7 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.util.SocketUtils;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 
 /**
  * @author David Turanski
@@ -69,8 +70,8 @@ public class AetherModuleResolverTests {
 	public void testResolveRemote() throws IOException {
 		ClassPathResource cpr = new ClassPathResource("local-repo");
 		File localRepository = cpr.getFile();
-		Map<String, String> remoteRepos = new HashMap<>();
-		remoteRepos.put("modules", "http://repo.spring.io/spring-cloud-stream-modules");
+		Set<String> remoteRepos = new HashSet<>();
+		remoteRepos.add("http://repo.spring.io/spring-cloud-stream-modules");
 		AetherModuleResolver defaultModuleResolver = new AetherModuleResolver(localRepository, remoteRepos);
 		Resource resource = defaultModuleResolver.resolve("org.springframework.cloud.stream.module", "time-source", 
 				"1.0.0.BUILD-SNAPSHOT", "exec", "jar");
@@ -84,9 +85,9 @@ public class AetherModuleResolverTests {
 		File localRepository = cpr.getFile();
 		ClassPathResource stubJarResource = new ClassPathResource("__files/foo.jar");
 		String stubFileName = stubJarResource.getFile().getName();
-		Map<String, String> remoteRepos = new HashMap<>();
-		remoteRepos.put("repo0", "http://localhost:" + port + "/repo0");
-		remoteRepos.put("repo1", "http://localhost:" + port + "/repo1");
+		Set<String> remoteRepos = new HashSet<>();
+		remoteRepos.add("http://localhost:" + port + "/repo0");
+		remoteRepos.add("http://localhost:" + port + "/repo1");
 		stubFor(get(urlEqualTo("/repo1/org/bar/foo/1.0.0/foo-1.0.0.jar"))
 				.willReturn(aResponse()
 						.withStatus(200)


### PR DESCRIPTION
 - Change `remoteRepository` option to `remoteRepositories` that accepts comma separated string values.
 - AetherModuleResolver would expect set of remote repositories and create `RemoteRepository` list
for the given set.