### PR TITLE
Re-instate lazy lookup for Binder in DestinationResolver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,13 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
+				<groupId>org.springframework.integration</groupId>
+				<artifactId>spring-integration-bom</artifactId>
+				<version>${spring-integration.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-parent</artifactId>
 				<version>${spring-boot.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,11 +20,7 @@
 	<properties>
 		<java.version>1.7</java.version>
 		<spring-boot.version>1.3.0.BUILD-SNAPSHOT</spring-boot.version>
-		<spring-cloud.version>Brixton.BUILD-SNAPSHOT</spring-cloud.version>
-		<spring-xd.version>1.2.1.BUILD-SNAPSHOT</spring-xd.version>
-		<spring-framework.version>4.2.0.RC2</spring-framework.version>
 		<spring-integration.version>4.2.0.BUILD-SNAPSHOT</spring-integration.version>
-		<spring-cloud-spring-service-connector.version>1.2.0.BUILD-SNAPSHOT</spring-cloud-spring-service-connector.version>
 		<spring-cloud-lattice.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-lattice.version>
 	</properties>
 	<modules>
@@ -43,18 +39,6 @@
 				<version>${spring-boot.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-starter-parent</artifactId>
-				<version>${spring-cloud.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-spring-service-connector</artifactId>
-				<version>${spring-cloud-spring-service-connector.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
@@ -93,13 +77,18 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-stream-module-launcher</artifactId>
+				<artifactId>spring-cloud-stream-binder-spi</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.springframework</groupId>
-				<artifactId>spring-messaging</artifactId>
-				<version>${spring-framework.version}</version>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-stream-binder-test</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-stream-module-launcher</artifactId>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.integration</groupId>

--- a/spring-cloud-stream-binders/pom.xml
+++ b/spring-cloud-stream-binders/pom.xml
@@ -18,6 +18,7 @@
 	<properties>
 		<kafka.version>0.8.2.1</kafka.version>
 		<curator.version>2.6.0</curator.version>
+		<spring-xd.version>1.2.1.BUILD-SNAPSHOT</spring-xd.version>
 	</properties>
 	<modules>
 		<module>spring-cloud-stream-binder-spi</module>
@@ -31,15 +32,9 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-stream-binder-spi</artifactId>
-				<version>${project.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-stream-binder-test</artifactId>
-				<version>${project.version}</version>
-				<scope>test</scope>
+				<groupId>org.springframework.xd</groupId>
+				<artifactId>spring-xd-tuple</artifactId>
+				<version>${spring-xd.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.kafka</groupId>

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/pom.xml
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/pom.xml
@@ -54,7 +54,6 @@
 		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-amqp</artifactId>
-			<version>${spring-integration.version}</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/pom.xml
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/pom.xml
@@ -54,18 +54,15 @@
 		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-redis</artifactId>
-			<version>${spring-integration.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
-			<version>2.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.xd</groupId>
 			<artifactId>spring-xd-tuple</artifactId>
-			<version>${spring-xd.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-spi/pom.xml
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-spi/pom.xml
@@ -22,7 +22,6 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
-			<version>${spring-framework.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.integration</groupId>
@@ -31,17 +30,14 @@
 		<dependency>
 			<groupId>org.springframework.retry</groupId>
 			<artifactId>spring-retry</artifactId>
-			<version>1.1.0.RELEASE</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.4.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.3.6</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-test/pom.xml
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-test/pom.xml
@@ -36,12 +36,10 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
-			<version>${spring-framework.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.xd</groupId>
 			<artifactId>spring-xd-tuple</artifactId>
-			<version>${spring-xd.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-stream-codec/pom.xml
+++ b/spring-cloud-stream-codec/pom.xml
@@ -30,10 +30,12 @@
 		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-core</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-logging</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderAwareRouterBeanPostProcessor.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderAwareRouterBeanPostProcessor.java
@@ -17,29 +17,24 @@
 package org.springframework.cloud.stream.binder;
 
 import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.integration.router.AbstractMappingMessageRouter;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.core.DestinationResolver;
 
 /**
  * A {@link BeanPostProcessor} that sets a {@link BinderAwareChannelResolver} on any bean of type
  * {@link AbstractMappingMessageRouter} within the context.
- * 
+ *
  * @author Mark Fisher
  * @author Gary Russell
  */
-public class BinderAwareRouterBeanPostProcessor implements BeanPostProcessor, BeanFactoryAware {
+public class BinderAwareRouterBeanPostProcessor implements BeanPostProcessor {
 
-	private final BinderAwareChannelResolver channelResolver;
+	private final DestinationResolver<MessageChannel> channelResolver;
 
-	public BinderAwareRouterBeanPostProcessor(BinderAwareChannelResolver channelResolver) {
+	public BinderAwareRouterBeanPostProcessor(DestinationResolver<MessageChannel> channelResolver) {
 		this.channelResolver = channelResolver;
-	}
-
-	@Override
-	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
-		channelResolver.setBeanFactory(beanFactory);
 	}
 
 	@Override
@@ -50,7 +45,7 @@ public class BinderAwareRouterBeanPostProcessor implements BeanPostProcessor, Be
 	@Override
 	public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
 		if (bean instanceof AbstractMappingMessageRouter) {
-			((AbstractMappingMessageRouter) bean).setChannelResolver(channelResolver);
+			((AbstractMappingMessageRouter) bean).setChannelResolver(this.channelResolver);
 		}
 		return bean;
 	}


### PR DESCRIPTION
It's important not to depend on something heavyweight like a Binder in a
BeanPostProcessor. The usual trick (as implemented here) is to do a lazy
lookup of the thing that is eventually injected in the post processes
beans.

Rebased ontop of gh-79