### PR TITLE
Add binding tests

### DIFF
--- a/spring-cloud-stream/pom.xml
+++ b/spring-cloud-stream/pom.xml
@@ -46,6 +46,7 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream-binder-local</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/utils/MessageChannelBeanDefinitionRegistryUtils.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/utils/MessageChannelBeanDefinitionRegistryUtils.java
@@ -94,12 +94,12 @@ public abstract class MessageChannelBeanDefinitionRegistryUtils {
 				Input input = AnnotationUtils.findAnnotation(method, Input.class);
 				if (input != null) {
 					String name = getName(input, method);
-					registerInputChannelBeanDefinition(name, input.value(), registry);
+					registerInputChannelBeanDefinition(input.value(), name, registry);
 				}
 				Output output = AnnotationUtils.findAnnotation(method, Output.class);
 				if (output != null) {
 					String name = getName(output, method);
-					registerOutputChannelBeanDefinition(name, output.value(), registry);
+					registerOutputChannelBeanDefinition(output.value(), name, registry);
 				}
 			}
 

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/ArbitraryInterfaceBindingTestsWithBindingTargets.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/ArbitraryInterfaceBindingTestsWithBindingTargets.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.Properties;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.cloud.stream.annotation.EnableModule;
+import org.springframework.cloud.stream.annotation.ModuleChannels;
+import org.springframework.cloud.stream.utils.MockBinderConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Marius Bogoevici
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(ArbitraryInterfaceBindingTestsWithBindingTargets.TestFooChannels.class)
+public class ArbitraryInterfaceBindingTestsWithBindingTargets {
+
+	@Autowired
+	@ModuleChannels(ArbitraryInterfaceBindingTestsWithBindingTargets.TestFooChannels.class)
+	public FooChannels fooChannels;
+
+	@Autowired
+	private Binder binder;
+
+	@Test
+	public void testArbitraryInterfaceChannelsBound() {
+		verify(binder).bindConsumer(eq("someQueue.0"), eq(fooChannels.foo()), Mockito.<Properties>any());
+		verify(binder).bindConsumer(eq("someQueue.1"), eq(fooChannels.bar()), Mockito.<Properties>any());
+		verify(binder).bindProducer(eq("someQueue.2"), eq(fooChannels.baz()), Mockito.<Properties>any());
+		verify(binder).bindProducer(eq("someQueue.3"), eq(fooChannels.qux()), Mockito.<Properties>any());
+		verifyNoMoreInteractions(binder);
+	}
+
+	@EnableModule(FooChannels.class)
+	@EnableAutoConfiguration
+	@Import(MockBinderConfiguration.class)
+	@PropertySource("classpath:/org/springframework/cloud/stream/binder/arbitrary-binding-test.properties")
+	public static class TestFooChannels {
+
+	}
+
+}

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/ArbitraryInterfaceBindingTestsWithDefaults.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/ArbitraryInterfaceBindingTestsWithDefaults.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.Properties;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.cloud.stream.annotation.EnableModule;
+import org.springframework.cloud.stream.annotation.ModuleChannels;
+import org.springframework.cloud.stream.utils.MockBinderConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Marius Bogoevici
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(ArbitraryInterfaceBindingTestsWithDefaults.TestFooChannels.class)
+public class ArbitraryInterfaceBindingTestsWithDefaults {
+
+	@Autowired
+	@ModuleChannels(ArbitraryInterfaceBindingTestsWithDefaults.TestFooChannels.class)
+	public FooChannels fooChannels;
+
+	@Autowired
+	private Binder binder;
+
+	@Test
+	public void testArbitraryInterfaceChannelsBound() {
+		verify(binder).bindConsumer(eq("foo"), eq(fooChannels.foo()), Mockito.<Properties>any());
+		verify(binder).bindConsumer(eq("bar"), eq(fooChannels.bar()), Mockito.<Properties>any());
+		verify(binder).bindProducer(eq("baz"), eq(fooChannels.baz()), Mockito.<Properties>any());
+		verify(binder).bindProducer(eq("qux"), eq(fooChannels.qux()), Mockito.<Properties>any());
+		verifyNoMoreInteractions(binder);
+	}
+
+	@EnableModule(FooChannels.class)
+	@EnableAutoConfiguration
+	@Import(MockBinderConfiguration.class)
+	public static class TestFooChannels {
+
+	}
+
+}

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/FooChannels.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/FooChannels.java
@@ -28,12 +28,12 @@ public interface FooChannels {
 	@Input
 	MessageChannel foo();
 
-	@Input//(value = "bar")
+	@Input
 	MessageChannel bar();
 
 	@Output
 	MessageChannel baz();
 
-	@Output//(value = "qux")
+	@Output
 	MessageChannel qux();
 }

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/FooChannels.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/FooChannels.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder;
+
+import org.springframework.cloud.stream.annotation.Input;
+import org.springframework.cloud.stream.annotation.Output;
+import org.springframework.messaging.MessageChannel;
+
+/**
+ * @author Marius Bogoevici
+ */
+public interface FooChannels {
+
+	@Input
+	MessageChannel foo();
+
+	@Input//(value = "bar")
+	MessageChannel bar();
+
+	@Output
+	MessageChannel baz();
+
+	@Output//(value = "qux")
+	MessageChannel qux();
+}

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/ProcessorBindingTestsWithBindingTargets.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/ProcessorBindingTestsWithBindingTargets.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+import java.util.Properties;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.cloud.stream.annotation.EnableModule;
+import org.springframework.cloud.stream.annotation.ModuleChannels;
+import org.springframework.cloud.stream.annotation.Processor;
+import org.springframework.cloud.stream.utils.MockBinderConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Marius Bogoevici
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(ProcessorBindingTestsWithBindingTargets.TestProcessor.class)
+public class ProcessorBindingTestsWithBindingTargets {
+
+	@Autowired
+	private Binder binder;
+
+	@Autowired @ModuleChannels(TestProcessor.class)
+	private Processor testProcessor;
+
+	@Test
+	public void testSourceOutputChannelBound() {
+		verify(binder).bindConsumer(eq("testtock.0"), eq(testProcessor.input()), Mockito.<Properties>any());
+		verify(binder).bindProducer(eq("testtock.1"), eq(testProcessor.output()), Mockito.<Properties>any());
+	}
+
+	@EnableModule(Processor.class)
+	@EnableAutoConfiguration
+	@Import(MockBinderConfiguration.class)
+	@PropertySource("classpath:/org/springframework/cloud/stream/binder/processor-binding-test.properties")
+	public static class TestProcessor {
+
+	}
+}

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/ProcessorBindingTestsWithDefaults.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/ProcessorBindingTestsWithDefaults.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.Properties;
+
+import org.apache.catalina.core.ApplicationContext;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.cloud.stream.annotation.EnableModule;
+import org.springframework.cloud.stream.annotation.ModuleChannels;
+import org.springframework.cloud.stream.annotation.Processor;
+import org.springframework.cloud.stream.utils.MockBinderConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Marius Bogoevici
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(ProcessorBindingTestsWithDefaults.TestProcessor.class)
+public class ProcessorBindingTestsWithDefaults {
+
+	@Autowired
+	private Binder binder;
+
+	@Autowired @ModuleChannels(TestProcessor.class)
+	private Processor processor;
+
+	@Test
+	public void testSourceOutputChannelBound() {
+		Mockito.verify(binder).bindConsumer(eq("input"), eq(processor.input()), Mockito.<Properties>any());
+		Mockito.verify(binder).bindProducer(eq("output"), eq(processor.output()), Mockito.<Properties>any());
+		verifyNoMoreInteractions(binder);
+	}
+
+	@EnableModule(Processor.class)
+	@EnableAutoConfiguration
+	@Import(MockBinderConfiguration.class)
+	public static class TestProcessor {
+
+	}
+}

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/SinkBindingTestsWithBindingTargets.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/SinkBindingTestsWithBindingTargets.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.Properties;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.cloud.stream.annotation.EnableModule;
+import org.springframework.cloud.stream.annotation.ModuleChannels;
+import org.springframework.cloud.stream.annotation.Sink;
+import org.springframework.cloud.stream.utils.MockBinderConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Marius Bogoevici
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(SinkBindingTestsWithBindingTargets.TestSink.class)
+public class SinkBindingTestsWithBindingTargets {
+
+	@Autowired
+	private Binder binder;
+
+	@Autowired @ModuleChannels(TestSink.class)
+	private Sink testSink;
+
+	@Test
+	public void testSourceOutputChannelBound() {
+		verify(binder).bindConsumer(eq("testtock"), eq(testSink.input()), Mockito.<Properties>any());
+		verifyNoMoreInteractions(binder);
+	}
+
+	@EnableModule(Sink.class)
+	@EnableAutoConfiguration
+	@Import(MockBinderConfiguration.class)
+	@PropertySource("classpath:/org/springframework/cloud/stream/binder/sink-binding-test.properties")
+	public static class TestSink {
+
+	}
+}

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/SinkBindingTestsWithDefaults.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/SinkBindingTestsWithDefaults.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.Properties;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.cloud.stream.annotation.EnableModule;
+import org.springframework.cloud.stream.annotation.ModuleChannels;
+import org.springframework.cloud.stream.annotation.Processor;
+import org.springframework.cloud.stream.annotation.Sink;
+import org.springframework.cloud.stream.utils.MockBinderConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Marius Bogoevici
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(SinkBindingTestsWithDefaults.TestSink.class)
+public class SinkBindingTestsWithDefaults {
+
+	@Autowired
+	private Binder binder;
+
+	@Autowired @ModuleChannels(TestSink.class)
+	private Sink testSink;
+
+	@Test
+	public void testSourceOutputChannelBound() {
+		verify(binder).bindConsumer(eq("input"), eq(testSink.input()), Mockito.<Properties>any());
+		verifyNoMoreInteractions(binder);
+	}
+
+	@EnableModule(Sink.class)
+	@EnableAutoConfiguration
+	@Import(MockBinderConfiguration.class)
+	public static class TestSink {
+
+	}
+}

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/SourceBindingTestsWithBindingTargets.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/SourceBindingTestsWithBindingTargets.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.Properties;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.cloud.stream.annotation.EnableModule;
+import org.springframework.cloud.stream.annotation.ModuleChannels;
+import org.springframework.cloud.stream.annotation.Source;
+import org.springframework.cloud.stream.utils.MockBinderConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Marius Bogoevici
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(SourceBindingTestsWithBindingTargets.TestSource.class)
+public class SourceBindingTestsWithBindingTargets {
+
+	@Autowired
+	private Binder binder;
+
+	@Autowired @ModuleChannels(TestSource.class)
+	private Source testSource;
+
+	@Test
+	public void testSourceOutputChannelBound() {
+		verify(binder).bindProducer(eq("testtock"), eq(testSource.output()), Mockito.<Properties>any());
+		verifyNoMoreInteractions(binder);
+	}
+
+	@EnableModule(Source.class)
+	@EnableAutoConfiguration
+	@Import(MockBinderConfiguration.class)
+	@PropertySource("classpath:/org/springframework/cloud/stream/binder/source-binding-test.properties")
+	public static class TestSource {
+
+	}
+}

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/SourceBindingTestsWithDefaults.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/SourceBindingTestsWithDefaults.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.Properties;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.cloud.stream.annotation.EnableModule;
+import org.springframework.cloud.stream.annotation.ModuleChannels;
+import org.springframework.cloud.stream.annotation.Source;
+import org.springframework.cloud.stream.utils.MockBinderConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Marius Bogoevici
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(SourceBindingTestsWithDefaults.TestSource.class)
+public class SourceBindingTestsWithDefaults {
+
+	@Autowired
+	private Binder binder;
+
+	@Autowired @ModuleChannels(TestSource.class)
+	private Source testSource;
+
+	@Test
+	public void testSourceOutputChannelBound() {
+		verify(binder).bindProducer(eq("output"), eq(testSource.output()), Mockito.<Properties>any());
+		verifyNoMoreInteractions(binder);
+	}
+
+	@EnableModule(Source.class)
+	@EnableAutoConfiguration
+	@Import(MockBinderConfiguration.class)
+	public static class TestSource {
+
+	}
+}

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/interceptor/BoundChannelsInterceptedTest.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/interceptor/BoundChannelsInterceptedTest.java
@@ -26,27 +26,26 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.cloud.stream.annotation.EnableModule;
-import org.springframework.cloud.stream.annotation.Input;
 import org.springframework.cloud.stream.annotation.ModuleChannels;
 import org.springframework.cloud.stream.annotation.Sink;
-import org.springframework.cloud.stream.binder.Binder;
 import org.springframework.cloud.stream.utils.MockBinderConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.config.GlobalChannelInterceptor;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
+ * Verifies that interceptors used by modules are applied correctly to generated channels.
+ *
  * @author Marius Bogoevici
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(ChannelsInterceptedTests.Foo.class)
-public class ChannelsInterceptedTests {
+@SpringApplicationConfiguration(BoundChannelsInterceptedTest.Foo.class)
+public class BoundChannelsInterceptedTest {
 
 	public static final Message<?> TEST_MESSAGE = MessageBuilder.withPayload("bar").build();
 
@@ -54,11 +53,11 @@ public class ChannelsInterceptedTests {
 	ChannelInterceptor channelInterceptor;
 
 	@Autowired
-	@ModuleChannels(ChannelsInterceptedTests.Foo.class)
+	@ModuleChannels(BoundChannelsInterceptedTest.Foo.class)
 	public Sink fooSink;
 
 	@Test
-	public void testChannelsIntercepted() {
+	public void testBoundChannelsIntercepted() {
 		fooSink.input().send(TEST_MESSAGE);
 		Mockito.verify(channelInterceptor).preSend(TEST_MESSAGE, fooSink.input());
 		Mockito.verifyNoMoreInteractions(channelInterceptor);

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/interceptor/BoundChannelsInterceptedTest.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/interceptor/BoundChannelsInterceptedTest.java
@@ -17,6 +17,8 @@
 package org.springframework.cloud.stream.interceptor;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -59,8 +61,8 @@ public class BoundChannelsInterceptedTest {
 	@Test
 	public void testBoundChannelsIntercepted() {
 		fooSink.input().send(TEST_MESSAGE);
-		Mockito.verify(channelInterceptor).preSend(TEST_MESSAGE, fooSink.input());
-		Mockito.verifyNoMoreInteractions(channelInterceptor);
+		verify(channelInterceptor).preSend(TEST_MESSAGE, fooSink.input());
+		verifyNoMoreInteractions(channelInterceptor);
 	}
 
 

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/interceptor/ChannelsInterceptedTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/interceptor/ChannelsInterceptedTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.interceptor;
+
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.cloud.stream.annotation.EnableModule;
+import org.springframework.cloud.stream.annotation.Input;
+import org.springframework.cloud.stream.annotation.ModuleChannels;
+import org.springframework.cloud.stream.annotation.Sink;
+import org.springframework.cloud.stream.binder.Binder;
+import org.springframework.cloud.stream.utils.MockBinderConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.integration.config.GlobalChannelInterceptor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Marius Bogoevici
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(ChannelsInterceptedTests.Foo.class)
+public class ChannelsInterceptedTests {
+
+	public static final Message<?> TEST_MESSAGE = MessageBuilder.withPayload("bar").build();
+
+	@Autowired
+	ChannelInterceptor channelInterceptor;
+
+	@Autowired
+	@ModuleChannels(ChannelsInterceptedTests.Foo.class)
+	public Sink fooSink;
+
+	@Test
+	public void testChannelsIntercepted() {
+		fooSink.input().send(TEST_MESSAGE);
+		Mockito.verify(channelInterceptor).preSend(TEST_MESSAGE, fooSink.input());
+		Mockito.verifyNoMoreInteractions(channelInterceptor);
+	}
+
+
+	@SpringBootApplication
+	@EnableModule(Sink.class)
+	@Import(MockBinderConfiguration.class)
+	public static class Foo {
+
+		@ServiceActivator(inputChannel = Sink.INPUT)
+		public void fooSink(Message<?> message) {
+		}
+
+		@GlobalChannelInterceptor @Bean
+		public ChannelInterceptor globalChannelInterceptor() {
+			return mock(ChannelInterceptor.class);
+		}
+
+	}
+}

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/utils/MockBinderConfiguration.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/utils/MockBinderConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.utils;
+
+import org.mockito.Mockito;
+
+import org.springframework.cloud.stream.binder.Binder;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * A simple configuration that creates mock {@link org.springframework.cloud.stream.binder.Binder}s.
+ *
+ * @author Marius Bogoevici
+ */
+public class MockBinderConfiguration {
+
+	@Bean
+	public Binder<?> binder() {
+		return Mockito.mock(Binder.class);
+	}
+}

--- a/spring-cloud-stream/src/test/resources/org/springframework/cloud/stream/binder/arbitrary-binding-test.properties
+++ b/spring-cloud-stream/src/test/resources/org/springframework/cloud/stream/binder/arbitrary-binding-test.properties
@@ -1,0 +1,4 @@
+spring.cloud.stream.bindings.foo=someQueue.0
+spring.cloud.stream.bindings.bar=someQueue.1
+spring.cloud.stream.bindings.baz=someQueue.2
+spring.cloud.stream.bindings.qux=someQueue.3

--- a/spring-cloud-stream/src/test/resources/org/springframework/cloud/stream/binder/processor-binding-test.properties
+++ b/spring-cloud-stream/src/test/resources/org/springframework/cloud/stream/binder/processor-binding-test.properties
@@ -1,0 +1,2 @@
+spring.cloud.stream.bindings.input=testtock.0
+spring.cloud.stream.bindings.output=testtock.1

--- a/spring-cloud-stream/src/test/resources/org/springframework/cloud/stream/binder/sink-binding-test.properties
+++ b/spring-cloud-stream/src/test/resources/org/springframework/cloud/stream/binder/sink-binding-test.properties
@@ -1,0 +1,1 @@
+spring.cloud.stream.bindings.input=testtock

--- a/spring-cloud-stream/src/test/resources/org/springframework/cloud/stream/binder/source-binding-test.properties
+++ b/spring-cloud-stream/src/test/resources/org/springframework/cloud/stream/binder/source-binding-test.properties
@@ -1,0 +1,1 @@
+spring.cloud.stream.bindings.output=testtock


### PR DESCRIPTION
An evolution of https://github.com/spring-cloud/spring-cloud-stream/pull/94

- Adds binding tests for Source, Sink, Processor and arbitrary interfaces
- while quite repetitive, the three interfaces above will be used quite extensively so deserve individual testing;
- Fixes an issue where using @Input/@Output without a value caused a bean registration failure;
- Adds test for channel interception;
