### PR TITLE
Use @ as maven resource filtering token

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,24 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-resources-plugin</artifactId>
+					<configuration>
+						<!-- Prevents ${foo} placeholders from being interpolated by maven in application.yml-->
+						<delimiters>
+							<delimiter>@</delimiter>
+						</delimiters>
+						<useDefaultDelimiters>false</useDefaultDelimiters>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+
 	<profiles>
 		<profile>
 			<id>spring</id>


### PR DESCRIPTION
Trivia: what is the name of the binding in this module:
```
delay: 5
name: foo
spring:
  cloud:
    stream:
      bindings:
        input: ${name}
```

You got it wrong, it's not `foo`, it's whatever the `${project.name}` of the maven project is, because of maven filtering. This PR stops this non-sense by forcing the use of `@name@` if we actually want maven filtering  