### PR TITLE
Remove cloud connector dependencies from S-C-S

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,6 @@
 		<spring-boot.version>1.3.0.BUILD-SNAPSHOT</spring-boot.version>
 		<spring-framework.version>4.2.1.BUILD-SNAPSHOT</spring-framework.version>
 		<spring-integration.version>4.2.0.BUILD-SNAPSHOT</spring-integration.version>
-		<spring-cloud-lattice.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-lattice.version>
 	</properties>
 	<modules>
 		<module>spring-cloud-stream</module>
@@ -48,11 +47,6 @@
 				<version>${spring-boot.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-lattice-connector</artifactId>
-				<version>${spring-cloud-lattice.version}</version>
 			</dependency>
 		    <dependency>
 			  <groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/pom.xml
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/pom.xml
@@ -39,7 +39,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-lattice-connector</artifactId>
+			<artifactId>spring-cloud-core</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/pom.xml
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/pom.xml
@@ -39,7 +39,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-lattice-connector</artifactId>
+			<artifactId>spring-cloud-core</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/spring-cloud-stream/pom.xml
+++ b/spring-cloud-stream/pom.xml
@@ -33,18 +33,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-spring-service-connector</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-lattice-connector</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream-binder-local</artifactId>
 			<optional>true</optional>
 		</dependency>


### PR DESCRIPTION
 - Remove lattice and cf connector dependencies from core S-C-S and binder
  - The idea is to have these dependencies defined in s-c-s-modules so that they
are specified in one place