### PR TITLE
Pre-register default bindings for channels

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingProperties.java
@@ -22,7 +22,6 @@ import java.util.Properties;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.util.StringUtils;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -36,9 +35,6 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 public class ChannelBindingProperties {
 
 	public static final String PATH = "path";
-
-	@Value("${spring.application.name:}")
-	private String applicationName;
 
 	private Properties consumerProperties = new Properties();
 
@@ -85,8 +81,8 @@ public class ChannelBindingProperties {
 				}
 			}
 		}
-		// the default path of the binding is the channel name itself
-		return (StringUtils.hasText(applicationName) ? applicationName + "." : "") + channelName;
+		// just return the channel name if not found
+		return channelName;
 	}
 
 	public String getTapChannelName(String channelName) {

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ModuleRegistrar.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ModuleRegistrar.java
@@ -46,9 +46,7 @@ public class ModuleRegistrar implements ImportBeanDefinitionRegistrar, Environme
 
 	@Override
 	public void setEnvironment(Environment environment) {
-		if (environment instanceof ConfigurableEnvironment) {
-			this.environment = (ConfigurableEnvironment) environment;
-		}
+		this.environment = (ConfigurableEnvironment) environment;
 	}
 
 	@Override
@@ -68,10 +66,8 @@ public class ModuleRegistrar implements ImportBeanDefinitionRegistrar, Environme
 			defaultChannelNameProperties.put(SPRING_CLOUD_STREAM_BINDINGS_PREFIX + "." + registeredChannelName,
 					"${spring.application.name:spring.cloud.stream}" + "." + registeredChannelName);
 		}
-		if (environment != null) {
-			environment.getPropertySources().addLast(
-					new PropertiesPropertySource("default-spring-cloud-stream-channel-bindings", defaultChannelNameProperties));
-		}
+		environment.getPropertySources().addLast(
+				new PropertiesPropertySource("default-spring-cloud-stream-channel-bindings", defaultChannelNameProperties));
 	}
 
 	private List<Class<?>> collectClasses(List<Object> list) {

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/utils/MessageChannelBeanDefinitionRegistryUtils.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/utils/MessageChannelBeanDefinitionRegistryUtils.java
@@ -18,6 +18,8 @@ package org.springframework.cloud.stream.utils;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.aopalliance.intercept.MethodInterceptor;
@@ -85,8 +87,9 @@ public abstract class MessageChannelBeanDefinitionRegistryUtils {
 		registry.registerBeanDefinition(name, rootBeanDefinition);
 	}
 
-	public static void registerChannelBeanDefinitions(Class<?> type,
+	public static List<String> registerChannelBeanDefinitions(Class<?> type,
 			final BeanDefinitionRegistry registry) {
+		final List<String> channelNames = new ArrayList<>();
 		ReflectionUtils.doWithMethods(type, new MethodCallback() {
 			@Override
 			public void doWith(Method method) throws IllegalArgumentException,
@@ -95,15 +98,18 @@ public abstract class MessageChannelBeanDefinitionRegistryUtils {
 				if (input != null) {
 					String name = getName(input, method);
 					registerInputChannelBeanDefinition(input.value(), name, registry);
+					channelNames.add(name);
 				}
 				Output output = AnnotationUtils.findAnnotation(method, Output.class);
 				if (output != null) {
 					String name = getName(output, method);
 					registerOutputChannelBeanDefinition(output.value(), name, registry);
+					channelNames.add(name);
 				}
 			}
 
 		});
+		return channelNames;
 	}
 
 	public static void registerChannelsQualifiedBeanDefinitions(Class<?> parent, Class<?> type,

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/config/ChannelBindingAdapterConfigurationTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/config/ChannelBindingAdapterConfigurationTests.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import java.util.List;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/config/ChannelBindingAdapterConfigurationTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/config/ChannelBindingAdapterConfigurationTests.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 


### PR DESCRIPTION
Pre-setting defaults via a PropertySource also allows them to be properly overridden by environment variables