### PR TITLE
[Not ready for merge yet] Remove binding defaults

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingProperties.java
@@ -22,6 +22,7 @@ import java.util.Properties;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -41,6 +42,9 @@ public class ChannelBindingProperties {
 	private Properties producerProperties = new Properties();
 
 	private Map<String,Object> bindings = new HashMap<>();
+
+	@Value("${spring.application.name:}")
+	private String applicationName;
 
 	public Properties getConsumerProperties() {
 		return this.consumerProperties;
@@ -81,8 +85,8 @@ public class ChannelBindingProperties {
 				}
 			}
 		}
-		// just return the channel name if not found
-		return channelName;
+		// the default path of the binding is the channel name itself
+		return (StringUtils.hasText(applicationName) ? applicationName + "." : "") + channelName;
 	}
 
 	public String getTapChannelName(String channelName) {

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ModuleRegistrar.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ModuleRegistrar.java
@@ -18,16 +18,11 @@ package org.springframework.cloud.stream.config;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
 
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.cloud.stream.annotation.EnableModule;
 import org.springframework.cloud.stream.utils.MessageChannelBeanDefinitionRegistryUtils;
-import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
-import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.core.env.Environment;
-import org.springframework.core.env.PropertiesPropertySource;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.MultiValueMap;
@@ -36,36 +31,19 @@ import org.springframework.util.MultiValueMap;
  * @author Marius Bogoevici
  * @author Dave Syer
  */
-public class ModuleRegistrar implements ImportBeanDefinitionRegistrar, EnvironmentAware {
-
-	public static final String SPRING_CLOUD_STREAM_BINDINGS_PREFIX = "spring.cloud.stream.bindings";
-
-	private ConfigurableEnvironment environment;
-
-	@Override
-	public void setEnvironment(Environment environment) {
-		this.environment = (ConfigurableEnvironment) environment;
-	}
+public class ModuleRegistrar implements ImportBeanDefinitionRegistrar {
 
 	@Override
 	public void registerBeanDefinitions(AnnotationMetadata metadata,
 			BeanDefinitionRegistry registry) {
 		MultiValueMap<String, Object> attributes = metadata.getAllAnnotationAttributes(
 				EnableModule.class.getName(), false);
-		List<String> registeredChannelNames = new ArrayList<>();
 		for (Class<?> type : collectClasses(attributes.get("value"))) {
-			registeredChannelNames.addAll(MessageChannelBeanDefinitionRegistryUtils.registerChannelBeanDefinitions(type, registry));
+			MessageChannelBeanDefinitionRegistryUtils.registerChannelBeanDefinitions(type, registry);
 			MessageChannelBeanDefinitionRegistryUtils.registerChannelsQualifiedBeanDefinitions(
 					ClassUtils.resolveClassName(metadata.getClassName(), null), type,
 					registry);
 		}
-		Properties defaultChannelNameProperties = new Properties();
-		for (String registeredChannelName : registeredChannelNames) {
-			defaultChannelNameProperties.put(SPRING_CLOUD_STREAM_BINDINGS_PREFIX + "." + registeredChannelName,
-					"${spring.application.name:spring.cloud.stream}" + "." + registeredChannelName);
-		}
-		environment.getPropertySources().addLast(
-				new PropertiesPropertySource("default-spring-cloud-stream-channel-bindings", defaultChannelNameProperties));
 	}
 
 	private List<Class<?>> collectClasses(List<Object> list) {

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/utils/MessageChannelBeanDefinitionRegistryUtils.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/utils/MessageChannelBeanDefinitionRegistryUtils.java
@@ -18,12 +18,11 @@ package org.springframework.cloud.stream.utils;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
+
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
@@ -87,9 +86,8 @@ public abstract class MessageChannelBeanDefinitionRegistryUtils {
 		registry.registerBeanDefinition(name, rootBeanDefinition);
 	}
 
-	public static List<String> registerChannelBeanDefinitions(Class<?> type,
+	public static void registerChannelBeanDefinitions(Class<?> type,
 			final BeanDefinitionRegistry registry) {
-		final List<String> channelNames = new ArrayList<>();
 		ReflectionUtils.doWithMethods(type, new MethodCallback() {
 			@Override
 			public void doWith(Method method) throws IllegalArgumentException,
@@ -98,18 +96,15 @@ public abstract class MessageChannelBeanDefinitionRegistryUtils {
 				if (input != null) {
 					String name = getName(input, method);
 					registerInputChannelBeanDefinition(input.value(), name, registry);
-					channelNames.add(name);
 				}
 				Output output = AnnotationUtils.findAnnotation(method, Output.class);
 				if (output != null) {
 					String name = getName(output, method);
 					registerOutputChannelBeanDefinition(output.value(), name, registry);
-					channelNames.add(name);
 				}
 			}
 
 		});
-		return channelNames;
 	}
 
 	public static void registerChannelsQualifiedBeanDefinitions(Class<?> parent, Class<?> type,


### PR DESCRIPTION
 - With spring-boot support unresolved property names with `_`,
we don't need explicit property source that registers
the default values for binding channel names.