### PR TITLE
[Do not merge, Discussion Only] WIP Classpath enhancement

### DIFF
--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/boot/loader/MultiJarLauncher.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/boot/loader/MultiJarLauncher.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.loader;
+
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.List;
+
+import org.springframework.boot.loader.archive.Archive;
+import org.springframework.boot.loader.util.AsciiBytes;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * A {@link Launcher} that provides a public {@link #launch(String[])} method.
+ *
+ * @author Marius Bogoevici
+ * @author Eric Bottard
+ */
+public class MultiJarLauncher extends Launcher {
+
+	private final List<Archive> archives;
+
+	/**
+	 * A list of archives, the first of which is expected to be a Spring boot uberJar
+	 * 
+	 * @param archives
+	 */
+	public MultiJarLauncher(List<Archive> archives) {
+		Assert.notEmpty(archives, "A list of archives must be provided");
+		this.archives = archives;
+	}
+
+	@Override
+	protected String getMainClass() throws Exception {
+		return archives.get(0).getManifest().getMainAttributes().getValue("Start-Class");
+	}
+
+	@Override
+	protected List<Archive> getClassPathArchives() throws Exception {
+		return archives;
+	}
+
+	@Override
+	// TODO: this method is protected in Spring Boot but we need it to be public here
+	public void launch(String[] args) {
+		super.launch(args);
+	}
+
+	@Override
+	protected void launch(String[] args, String mainClass, ClassLoader classLoader)
+			throws Exception {
+		if (ClassUtils.isPresent(
+				"org.apache.catalina.webresources.TomcatURLStreamHandlerFactory",
+				classLoader)) {
+			// Ensure the method is invoked on a class that is loaded by the provided
+			// class loader (not the current context class loader):
+			Method method = ReflectionUtils
+					.findMethod(
+							classLoader
+							.loadClass("org.apache.catalina.webresources.TomcatURLStreamHandlerFactory"),
+							"disable");
+			ReflectionUtils.invokeMethod(method, null);
+		}
+		super.launch(args, mainClass, classLoader);
+	}
+
+	@Override
+	protected ClassLoader createClassLoader(URL[] urls) throws Exception {
+		ClassLoader systemClassLoader = ClassLoader.getSystemClassLoader();
+		// try to retrieve the extension classloader
+		ClassLoader extensionClassLoader = systemClassLoader != null ? systemClassLoader.getParent() : null;
+		// set the classloader for the module as the extension classloader if available
+		// fall back to the system classloader (which can also be null) if not available
+		ClassLoader classLoaderForModule = extensionClassLoader != null ? extensionClassLoader : systemClassLoader;
+		return new LaunchedURLClassLoader(urls, classLoaderForModule);
+	}
+
+}

--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncher.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncher.java
@@ -240,7 +240,7 @@ public class ModuleLauncher {
 	}
 
 	private class ModuleAggregatorRunner implements Runnable {
-		
+
 		private final ClassLoader classLoader;
 
 		private final String[] parentArgs;
@@ -267,7 +267,8 @@ public class ModuleLauncher {
 						mainClasses.toArray(new Class<?>[mainClasses.size()]),
 						parentArgs, arguments.toArray(new String[][] {}));
 			} catch (Exception e) {
-				log.error("failed to launch aggregated modules :" + StringUtils.collectionToCommaDelimitedString(mainClasses), e);
+				log.error("failed to launch aggregated modules :"
+						+ StringUtils.collectionToCommaDelimitedString(mainClasses), e);
 				throw new RuntimeException(e);
 			}
 		}

--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncher.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncher.java
@@ -31,8 +31,10 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.boot.loader.LaunchedURLClassLoader;
 import org.springframework.boot.loader.ModuleJarLauncher;
+import org.springframework.boot.loader.MultiJarLauncher;
 import org.springframework.boot.loader.archive.Archive;
 import org.springframework.boot.loader.archive.JarFileArchive;
+import org.springframework.cloud.stream.module.resolver.Coordinates;
 import org.springframework.cloud.stream.module.resolver.ModuleResolver;
 import org.springframework.cloud.stream.module.utils.ClassloaderUtils;
 import org.springframework.core.io.Resource;
@@ -62,10 +64,14 @@ public class ModuleLauncher {
 
 	private static final String DEFAULT_EXTENSION = "jar";
 
-	private static final String DEFAULT_CLASSIFIER = "exec";
+	private static final String DEFAULT_MODULE_CLASSIFIER = "exec";
 
 	private static final Pattern COORDINATES_PATTERN =
 			Pattern.compile("([^: ]+):([^: ]+)(:([^: ]*)(:([^: ]+))?)?:([^: ]+)");
+
+	private static final String INCLUDE_DEPENDENCIES_ARG = "includes";
+
+	private static final String EXCLUDE_DEPENDENCIES_ARG = "excludes";
 
 	private final ModuleResolver moduleResolver;
 
@@ -90,12 +96,11 @@ public class ModuleLauncher {
 	 * @param parentArgs a list of arguments for the whole aggregate
 	 */
 	public void launch(List<ModuleLaunchRequest> moduleLaunchRequests, boolean aggregate, String parentArgs[]) {
-		List<ModuleLaunchRequest> reversed = new ArrayList<>(moduleLaunchRequests);
-		Collections.reverse(reversed);
 		if (moduleLaunchRequests.size() == 1 || !aggregate) {
 			launchIndividualModules(moduleLaunchRequests);
 		}
 		else {
+			//TODO add support for CP enhancement for aggregated modules
 			launchAggregatedModules(moduleLaunchRequests, parentArgs);
 		}
 	}
@@ -163,11 +168,22 @@ public class ModuleLauncher {
 		}
 	}
 
-	public void launchIndividualModules(List<ModuleLaunchRequest> reversed) {
+	public void launchIndividualModules(List<ModuleLaunchRequest> moduleLaunchRequests) {
+		List<ModuleLaunchRequest> reversed = new ArrayList<>(moduleLaunchRequests);
+		Collections.reverse(reversed);
 		for (ModuleLaunchRequest moduleLaunchRequest : reversed) {
 			String module = moduleLaunchRequest.getModule();
 			moduleLaunchRequest.addArgument("spring.jmx.default-domain", module.replace("/", ".").replace(":", "."));
-			launchModule(module, toArgArray(moduleLaunchRequest.getArguments()));
+			Map<String, String> arguments = moduleLaunchRequest.getArguments();
+			if (arguments.containsKey(INCLUDE_DEPENDENCIES_ARG) || arguments.containsKey(EXCLUDE_DEPENDENCIES_ARG)) {
+				String includes = arguments.get(INCLUDE_DEPENDENCIES_ARG);
+				String excludes = arguments.get(EXCLUDE_DEPENDENCIES_ARG);
+				launchModuleWithDependencies(module, toArgArray(arguments),
+						StringUtils.commaDelimitedListToStringArray(includes),
+						StringUtils.commaDelimitedListToStringArray(excludes));
+			} else {
+				launchModule(module, toArgArray(arguments));
+			}
 		}
 	}
 
@@ -183,16 +199,44 @@ public class ModuleLauncher {
 		}
 	}
 
-	private Resource resolveModule(String coordinates) {
+	private void launchModuleWithDependencies(String module, String[] args, String[] includes, String[] excludes) {
+		try {
+			Resource[] libraries = this.moduleResolver.resolve(toCoordinates(module, DEFAULT_MODULE_CLASSIFIER), toCoordinateArray(includes), null);
+			List<Archive> archives = new ArrayList<>();
+			for (Resource library : libraries) {
+				archives.add(new JarFileArchive(library.getFile()));
+			}
+			MultiJarLauncher jarLauncher = new MultiJarLauncher(archives);
+			jarLauncher.launch(args);
+		}
+		catch (IOException e) {
+			throw new RuntimeException("failed to launch module: " + module, e);
+		}
+	}
+
+	private Resource resolveModule(String moduleCoordinates) {
+		Coordinates coordinates = toCoordinates(moduleCoordinates, DEFAULT_MODULE_CLASSIFIER);
+		return this.moduleResolver.resolve(coordinates);
+	}
+
+	private Coordinates toCoordinates(String coordinates, String defaultClassifier) {
 		Matcher matcher = COORDINATES_PATTERN.matcher(coordinates);
 		Assert.isTrue(matcher.matches(), "Bad artifact coordinates " + coordinates
 				+ ", expected format is <groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>");
 		String groupId = matcher.group(1);
 		String artifactId = matcher.group(2);
 		String extension = StringUtils.hasLength(matcher.group(4)) ? matcher.group(4) : DEFAULT_EXTENSION;
-		String classifier = StringUtils.hasLength(matcher.group(6)) ? matcher.group(6) : DEFAULT_CLASSIFIER;
+		String classifier = StringUtils.hasLength(matcher.group(6)) ? matcher.group(6) : defaultClassifier;
 		String version = matcher.group(7);
-		return this.moduleResolver.resolve(groupId, artifactId, extension, classifier, version);
+		return new Coordinates(groupId, artifactId, extension, classifier, version);
+	}
+
+	private Coordinates[] toCoordinateArray(String[] coordinateList) {
+		List<Coordinates> result = new ArrayList<>();
+		for (String coordinates : coordinateList) {
+			result.add(toCoordinates(coordinates,""));
+		}
+		return result.toArray(new Coordinates[result.size()]);
 	}
 
 	private class ModuleAggregatorRunner implements Runnable {

--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/resolver/AetherModuleResolver.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/resolver/AetherModuleResolver.java
@@ -180,7 +180,9 @@ public class AetherModuleResolver implements ModuleResolver {
 				for (Coordinates include : includes) {
 					collectRequest.addDependency(new Dependency(toArtifact(include), JavaScopes.RUNTIME));
 				}
-				DependencyResult dependencyResult = repositorySystem.resolveDependencies(session, new DependencyRequest(collectRequest, null));
+				collectRequest.setRepositories(remoteRepositories);
+				DependencyResult dependencyResult =
+						repositorySystem.resolveDependencies(session, new DependencyRequest(collectRequest, null));
 				for (ArtifactResult artifactResult : dependencyResult.getArtifactResults()) {
 					// we are only interested in the jars or zips
 					if ("jar".equalsIgnoreCase(artifactResult.getArtifact().getExtension())) {

--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/resolver/AetherModuleResolver.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/resolver/AetherModuleResolver.java
@@ -150,10 +150,10 @@ public class AetherModuleResolver implements ModuleResolver {
 
 	@Override
 	public Resource[] resolve(Coordinates root, Coordinates[] includes, CoordinatesFilter[] excludes) {
-		Assert.hasText(root.getGroupId(), "'groupId' cannot be blank.");
-		Assert.hasText(root.getArtifactId(), "'artifactId' cannot be blank.");
-		Assert.hasText(root.getExtension(), "'extension' cannot be blank.");
-		Assert.hasText(root.getVersion(), "'version' cannot be blank.");
+		validateCoordinates(root);
+		for (Coordinates include : includes) {
+			validateCoordinates(include);
+		}
 
 		List<Resource> result = new ArrayList<>();
 
@@ -194,6 +194,13 @@ public class AetherModuleResolver implements ModuleResolver {
 			}
 		}
 		return result.toArray(new Resource[result.size()]);
+	}
+
+	private void validateCoordinates(Coordinates coordinates) {
+		Assert.hasText(coordinates.getGroupId(), "'groupId' cannot be blank.");
+		Assert.hasText(coordinates.getArtifactId(), "'artifactId' cannot be blank.");
+		Assert.hasText(coordinates.getExtension(), "'extension' cannot be blank.");
+		Assert.hasText(coordinates.getVersion(), "'version' cannot be blank.");
 	}
 
 	public FileSystemResource toResource(ArtifactResult resolvedArtifact) {

--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/resolver/AetherModuleResolver.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/resolver/AetherModuleResolver.java
@@ -182,7 +182,10 @@ public class AetherModuleResolver implements ModuleResolver {
 				}
 				DependencyResult dependencyResult = repositorySystem.resolveDependencies(session, new DependencyRequest(collectRequest, null));
 				for (ArtifactResult artifactResult : dependencyResult.getArtifactResults()) {
-					result.add(toResource(artifactResult));
+					// we are only interested in the jars or zips
+					if ("jar".equalsIgnoreCase(artifactResult.getArtifact().getExtension())) {
+						result.add(toResource(artifactResult));
+					}
 				}
 			} catch (DependencyResolutionException e) {
 				throw new RuntimeException(e);

--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/resolver/Coordinates.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/resolver/Coordinates.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.resolver;
+
+/**
+ * Encapsulates a group of Maven coordinates.
+ *
+ * @author Marius Bogoevici
+ * @author Eric Bottard
+ */
+public class Coordinates {
+
+	private final String groupId;
+
+	private final String artifactId;
+
+	private final String extension;
+
+	private String classifier;
+
+	private final String version;
+
+	/**
+	 * @param groupId the groupId
+	 * @param artifactId the artifactId
+	 * @param extension the file extension
+	 * @param classifier classifier
+	 * @param version the version
+	 */
+	public Coordinates(String groupId, String artifactId, String extension, String classifier, String version) {
+		this.groupId = groupId;
+		this.artifactId = artifactId;
+		this.extension = extension;
+		this.classifier = classifier;
+		this.version = version;
+	}
+
+	public String getGroupId() {
+		return groupId;
+	}
+
+	public String getArtifactId() {
+		return artifactId;
+	}
+
+	public String getExtension() {
+		return extension;
+	}
+
+	public String getClassifier() {
+		return classifier;
+	}
+
+	public String getVersion() {
+		return version;
+	}
+}

--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/resolver/CoordinatesFilter.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/resolver/CoordinatesFilter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.resolver;
+
+/**
+ * Strategy for filtering out artifacts during dependency resolution.
+ *
+ * TODO: this currently just a stub
+ * @author Marius Bogoevici
+ * @author Eric Bottard
+ */
+public interface CoordinatesFilter {
+
+	boolean reject(Coordinates coordinates);
+}

--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/resolver/ModuleResolver.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/resolver/ModuleResolver.java
@@ -23,19 +23,28 @@ import org.springframework.core.io.Resource;
  * uber-jar based on its Maven coordinates.
  *
  * @author David Turanski
+ * @author Marius Bogoevici
+ * @author Eric Bottard
  */
 public interface ModuleResolver {
 
 	/**
 	 * Retrieve a resource given its coordinates.
 	 *
-	 * @param groupId the groupId
-	 * @param artifactId the artifactId
-	 * @param extension the file extension
-	 * @param classifier classifier
-	 * @param version the version
+	 * @param coordinates the coordinates of a resource
 	 * @return the resource
 	 */
-	Resource resolve(String groupId, String artifactId, String extension, String classifier, String version);
+	Resource resolve(Coordinates coordinates);
+
+	/**
+	 * Retrieve a set of resources given its coordinates, along with additional dependencies. Exclusion rules
+	 * can be provided as well.
+	 *
+	 * @param root the coordinates of the main resource
+	 * @param includes a list of coordinates to include along the main resource
+	 * @param excludes a list of exclusion rules as strategies
+	 * @return the main resource and the additional dependencies
+	 */
+	Resource[] resolve(Coordinates root, Coordinates[] includes, CoordinatesFilter[] excludes);
 
 }

--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/resolver/ModuleResolver.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/resolver/ModuleResolver.java
@@ -37,14 +37,16 @@ public interface ModuleResolver {
 	Resource resolve(Coordinates coordinates);
 
 	/**
-	 * Retrieve a set of resources given its coordinates, along with additional dependencies. Exclusion rules
+	 * Retrieve a set of resources given its coordinates, along with additional dependencies.
+	 * Exclusion rules patterns (conforming to {@link org.eclipse.aether.util.filter.PatternExclusionsDependencyFilter}
 	 * can be provided as well.
 	 *
 	 * @param root the coordinates of the main resource
 	 * @param includes a list of coordinates to include along the main resource
-	 * @param excludes a list of exclusion rules as strategies
+	 * @param excludePatterns a list of exclusion patterns
+	 * @see org.eclipse.aether.util.filter.PatternExclusionsDependencyFilter
 	 * @return the main resource and the additional dependencies
 	 */
-	Resource[] resolve(Coordinates root, Coordinates[] includes, CoordinatesFilter[] excludes);
+	Resource[] resolve(Coordinates root, Coordinates[] includes, String[] excludePatterns);
 
 }

--- a/spring-cloud-stream-module-launcher/src/test/java/org/springframework/cloud/stream/module/resolver/AetherModuleResolverTests.java
+++ b/spring-cloud-stream-module-launcher/src/test/java/org/springframework/cloud/stream/module/resolver/AetherModuleResolverTests.java
@@ -53,7 +53,7 @@ public class AetherModuleResolverTests {
 		ClassPathResource cpr = new ClassPathResource("local-repo");
 		File localRepository = cpr.getFile();
 		AetherModuleResolver defaultModuleResolver = new AetherModuleResolver(localRepository, null);
-		Resource resource = defaultModuleResolver.resolve("foo.bar", "foo-bar", "jar", "", "1.0.0");
+		Resource resource = defaultModuleResolver.resolve(new Coordinates("foo.bar", "foo-bar", "jar", "", "1.0.0"));
 		assertTrue(resource.exists());
 		assertEquals(resource.getFile().getName(), "foo-bar-1.0.0.jar");
 	}
@@ -63,7 +63,7 @@ public class AetherModuleResolverTests {
 		ClassPathResource cpr = new ClassPathResource("local-repo");
 		File localRepository = cpr.getFile();
 		AetherModuleResolver defaultModuleResolver = new AetherModuleResolver(localRepository, null);
-		defaultModuleResolver.resolve("niente", "nada", "jar", "", "zilch");
+		defaultModuleResolver.resolve(new Coordinates("niente", "nada", "jar", "", "zilch"));
 	}
 
 	@Test
@@ -74,8 +74,8 @@ public class AetherModuleResolverTests {
 		Map<String, String> remoteRepos = new HashMap<>();
 		remoteRepos.put("modules", "http://repo.spring.io/libs-snapshot");
 		AetherModuleResolver defaultModuleResolver = new AetherModuleResolver(localRepository, remoteRepos);
-		Resource resource = defaultModuleResolver.resolve("org.springframework.cloud.stream.module", "time-source",
-				"jar", "exec", "1.0.0.BUILD-SNAPSHOT");
+		Resource resource = defaultModuleResolver.resolve(
+				new Coordinates("org.springframework.cloud.stream.module", "time-source", "jar", "exec", "1.0.0.BUILD-SNAPSHOT"));
 		assertTrue(resource.exists());
 		assertEquals(resource.getFile().getName(), "time-source-1.0.0.BUILD-SNAPSHOT-exec.jar");
 	}
@@ -94,7 +94,7 @@ public class AetherModuleResolverTests {
 						.withStatus(200)
 						.withBodyFile(stubFileName)));
 		AetherModuleResolver defaultModuleResolver = new AetherModuleResolver(localRepository, remoteRepos);
-		Resource resource = defaultModuleResolver.resolve("org.bar", "foo", "jar", "", "1.0.0");
+		Resource resource = defaultModuleResolver.resolve(new Coordinates("org.bar", "foo", "jar", "", "1.0.0"));
 		assertTrue(resource.exists());
 		assertEquals(resource.getFile().getName(), "foo-1.0.0.jar");
 	}


### PR DESCRIPTION
Provides support for adding JARs to a module's class path at launch

To test:

Build/install `spring-cloud-stream` 

To use (in this case, let's pretend the `time-source` module has been rebuilt without the redis binder):
```
java -jar spring-cloud-stream-module-launcher/target/spring-cloud-stream-module-launcher-1.0.0.BUILD-SNAPSHOT.jar \
--modules=org.springframework.cloud.stream.module:time-source:1.0.0.BUILD-SNAPSHOT \
--args.0.includes=org.springframework.cloud:spring-cloud-stream-binder-redis:1.0.0.BUILD-SNAPSHOT
```