### PR TITLE
Samples cleanup

### DIFF
--- a/spring-cloud-stream-samples/double/pom.xml
+++ b/spring-cloud-stream-samples/double/pom.xml
@@ -7,7 +7,7 @@
 	<packaging>jar</packaging>
 
 	<name>spring-cloud-stream-sample-double</name>
-	<description>Demo project for Spring XD module</description>
+	<description>Demo project for Aggregate Builder</description>
 
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
@@ -16,9 +16,7 @@
 	</parent>
 
 	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<start-class>demo.SinkApplication</start-class>
-		<java.version>1.8</java.version>
+		<start-class>demo.DoubleApplication</start-class>
 	</properties>
 
 	<dependencies>

--- a/spring-cloud-stream-samples/extended/pom.xml
+++ b/spring-cloud-stream-samples/extended/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>spring-cloud-stream-sample-extended</artifactId>
 	<packaging>jar</packaging>
 	<name>spring-cloud-stream-sample-extended</name>
-	<description>Demo project for Spring XD module</description>
+	<description>Demo project for extended module using aggregate builder</description>
 
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
@@ -15,9 +15,7 @@
 	</parent>
 
 	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<start-class>demo.SinkApplication</start-class>
-		<java.version>1.8</java.version>
+		<start-class>extended.ExtendedApplication</start-class>
 	</properties>
 
 	<dependencies>

--- a/spring-cloud-stream-samples/extended/src/main/java/extended/ExtendedApplication.java
+++ b/spring-cloud-stream-samples/extended/src/main/java/extended/ExtendedApplication.java
@@ -21,9 +21,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.stream.aggregate.AggregateBuilder;
 import org.springframework.cloud.stream.aggregate.AggregateConfigurer;
 
-import sink.LogSink;
-import source.TimeSource;
-import transform.LoggingTransformer;
+import demo.LogSink;
+import demo.LoggingTransformer;
+import demo.TimeSource;
 
 @SpringBootApplication
 public class ExtendedApplication implements AggregateConfigurer {

--- a/spring-cloud-stream-samples/pom.xml
+++ b/spring-cloud-stream-samples/pom.xml
@@ -14,6 +14,10 @@
 	  <artifactId>spring-cloud-stream-parent</artifactId>
 	  <version>1.0.0.BUILD-SNAPSHOT</version>
 	</parent>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<java.version>1.8</java.version>
+	</properties>
 	<modules>
 		<module>source</module>
 		<module>sink</module>

--- a/spring-cloud-stream-samples/sink/pom.xml
+++ b/spring-cloud-stream-samples/sink/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>spring-cloud-stream-sample-sink</artifactId>
 	<packaging>jar</packaging>
 	<name>spring-cloud-stream-sample-sink</name>
-	<description>Demo project for Spring XD module</description>
+	<description>Demo project for Sink module</description>
 
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
@@ -15,9 +15,7 @@
 	</parent>
 
 	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<start-class>demo.SinkApplication</start-class>
-		<java.version>1.8</java.version>
 	</properties>
 
 	<dependencies>

--- a/spring-cloud-stream-samples/sink/src/main/java/demo/LogSink.java
+++ b/spring-cloud-stream-samples/sink/src/main/java/demo/LogSink.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package config;
+package demo;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,14 +24,14 @@ import org.springframework.integration.annotation.ServiceActivator;
 
 /**
  * @author Dave Syer
- * @author Marius Bogoevici
+ *
  */
 @EnableModule(Sink.class)
-public class TappingLoggingSink {
+public class LogSink {
 
-	private static Logger logger = LoggerFactory.getLogger(TappingLoggingSink.class);
+	private static Logger logger = LoggerFactory.getLogger(LogSink.class);
 
-	@ServiceActivator(inputChannel = Sink.INPUT)
+	@ServiceActivator(inputChannel=Sink.INPUT)
 	public void loggerSink(Object payload) {
 		logger.info("Received: " + payload);
 	}

--- a/spring-cloud-stream-samples/sink/src/main/java/demo/SinkApplication.java
+++ b/spring-cloud-stream-samples/sink/src/main/java/demo/SinkApplication.java
@@ -18,12 +18,8 @@ package demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
-
-import sink.LogSink;
 
 @SpringBootApplication
-@ComponentScan(basePackageClasses=LogSink.class)
 public class SinkApplication {
 
 	public static void main(String[] args) {

--- a/spring-cloud-stream-samples/sink/src/test/java/demo/ModuleApplicationTests.java
+++ b/spring-cloud-stream-samples/sink/src/test/java/demo/ModuleApplicationTests.java
@@ -31,8 +31,6 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
-import sink.LogSink;
-
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = SinkApplication.class)
 @WebAppConfiguration

--- a/spring-cloud-stream-samples/source/pom.xml
+++ b/spring-cloud-stream-samples/source/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>spring-cloud-stream-sample-source</artifactId>
 	<packaging>jar</packaging>
 	<name>spring-cloud-stream-sample-source</name>
-	<description>Demo project for Spring XD module</description>
+	<description>Demo project for source module</description>
 
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
@@ -15,9 +15,7 @@
 	</parent>
 
 	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<start-class>demo.SourceApplication</start-class>
-		<java.version>1.8</java.version>
 	</properties>
 
 	<dependencies>

--- a/spring-cloud-stream-samples/source/src/main/java/demo/DateFormat.java
+++ b/spring-cloud-stream-samples/source/src/main/java/demo/DateFormat.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package source;
+package demo;
 
 import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.*;

--- a/spring-cloud-stream-samples/source/src/main/java/demo/SourceApplication.java
+++ b/spring-cloud-stream-samples/source/src/main/java/demo/SourceApplication.java
@@ -18,12 +18,8 @@ package demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
-
-import source.TimeSource;
 
 @SpringBootApplication
-@ComponentScan(basePackageClasses=TimeSource.class)
 public class SourceApplication {
 
 	public static void main(String[] args) {

--- a/spring-cloud-stream-samples/source/src/main/java/demo/TimeSource.java
+++ b/spring-cloud-stream-samples/source/src/main/java/demo/TimeSource.java
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-package source;
+package demo;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -25,9 +28,6 @@ import org.springframework.integration.annotation.InboundChannelAdapter;
 import org.springframework.integration.annotation.Poller;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.messaging.support.GenericMessage;
-
-import java.text.SimpleDateFormat;
-import java.util.Date;
 
 /**
  * @author Dave Syer

--- a/spring-cloud-stream-samples/source/src/main/java/demo/TimeSourceOptionsMetadata.java
+++ b/spring-cloud-stream-samples/source/src/main/java/demo/TimeSourceOptionsMetadata.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package source;
+package demo;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.Pattern;

--- a/spring-cloud-stream-samples/tap/pom.xml
+++ b/spring-cloud-stream-samples/tap/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>spring-cloud-stream-sample-tap</artifactId>
 	<packaging>jar</packaging>
 	<name>spring-cloud-stream-sample-tap</name>
-	<description>Demo project for Spring XD module</description>
+	<description>Demo project for tap module</description>
 
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
@@ -15,9 +15,7 @@
 	</parent>
 
 	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<start-class>demo.TapApplication</start-class>
-		<java.version>1.8</java.version>
 	</properties>
 
 	<dependencies>

--- a/spring-cloud-stream-samples/tap/src/main/java/demo/TapApplication.java
+++ b/spring-cloud-stream-samples/tap/src/main/java/demo/TapApplication.java
@@ -18,12 +18,8 @@ package demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
-
-import config.TappingLoggingSink;
 
 @SpringBootApplication
-@ComponentScan(basePackageClasses= TappingLoggingSink.class)
 public class TapApplication {
 
 	public static void main(String[] args) {

--- a/spring-cloud-stream-samples/tap/src/main/java/demo/TappingLoggingSink.java
+++ b/spring-cloud-stream-samples/tap/src/main/java/demo/TappingLoggingSink.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package sink;
+package demo;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,14 +24,14 @@ import org.springframework.integration.annotation.ServiceActivator;
 
 /**
  * @author Dave Syer
- *
+ * @author Marius Bogoevici
  */
 @EnableModule(Sink.class)
-public class LogSink {
+public class TappingLoggingSink {
 
-	private static Logger logger = LoggerFactory.getLogger(LogSink.class);
+	private static Logger logger = LoggerFactory.getLogger(TappingLoggingSink.class);
 
-	@ServiceActivator(inputChannel=Sink.INPUT)
+	@ServiceActivator(inputChannel = Sink.INPUT)
 	public void loggerSink(Object payload) {
 		logger.info("Received: " + payload);
 	}

--- a/spring-cloud-stream-samples/transform/pom.xml
+++ b/spring-cloud-stream-samples/transform/pom.xml
@@ -7,7 +7,7 @@
 	<packaging>jar</packaging>
 
 	<name>spring-cloud-stream-sample-transform</name>
-	<description>Demo project for Spring XD module</description>
+	<description>Demo project for transform module</description>
 
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
@@ -16,9 +16,7 @@
 	</parent>
 
 	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<start-class>demo.TransformApplication</start-class>
-		<java.version>1.8</java.version>
 	</properties>
 
 	<dependencies>

--- a/spring-cloud-stream-samples/transform/src/main/java/demo/LoggingTransformer.java
+++ b/spring-cloud-stream-samples/transform/src/main/java/demo/LoggingTransformer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package transform;
+package demo;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/spring-cloud-stream-samples/transform/src/main/java/demo/TransformApplication.java
+++ b/spring-cloud-stream-samples/transform/src/main/java/demo/TransformApplication.java
@@ -18,12 +18,8 @@ package demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
-
-import transform.LoggingTransformer;
 
 @SpringBootApplication
-@ComponentScan(basePackageClasses=LoggingTransformer.class)
 public class TransformApplication {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
 - Move common properties to samples parent
 - Avoid explicit `ComponentScan` by moving all the classes to the same package