### PR TITLE
Support underscore delimiter in module args

### DIFF
--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLaunchRequest.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLaunchRequest.java
@@ -33,7 +33,7 @@ public class ModuleLaunchRequest {
 
 	public ModuleLaunchRequest(String module, Map<String, String> arguments) {
 		this.module = module;
-		this.arguments = arguments != null ? new HashMap<>(arguments) : new HashMap<String, String>();
+		this.arguments = arguments != null ? arguments : new HashMap<String, String>();
 	}
 
 	public String getModule() {

--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncherConfiguration.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncherConfiguration.java
@@ -21,12 +21,14 @@ import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.module.resolver.AetherModuleResolver;
 import org.springframework.cloud.stream.module.resolver.ModuleResolver;
 import org.springframework.cloud.stream.module.resolver.ModuleResolverProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
 
 /**
  * Configuration class that has the beans required for module launcher.
@@ -61,4 +63,15 @@ public class ModuleLauncherConfiguration {
 		return new ModuleLauncher(moduleResolver);
 	}
 
+	@Bean
+	@ConfigurationPropertiesBinding
+	public Converter<String, ModuleOptionKey> stringToModuleOptionKeyConverter() {
+		return new Converter<String, ModuleOptionKey>() {
+			@Override
+			public ModuleOptionKey convert(String s) {
+				String[] keys = s.split(("[_\\-\\.]"));
+				return new ModuleOptionKey(Integer.valueOf(keys[0]), s.substring(keys[0].length() + 1));
+			}
+		};
+	}
 }

--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncherProperties.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncherProperties.java
@@ -61,7 +61,7 @@ public class ModuleLauncherProperties {
 	/**
 	 * Map of arguments, keyed by the 0-based index in the {@link #modules array}.
 	 */
-	private Map<Integer, Map<String, String>> args = new HashMap<>();
+	private Map<ModuleOptionKey, String> args = new HashMap<>();
 
 	public void setModules(String[] modules) {
 		this.modules = modules;
@@ -80,12 +80,11 @@ public class ModuleLauncherProperties {
 		return modules;
 	}
 
-	public void setArgs(Map<Integer, Map<String, String>> args) {
+	public void setArgs(Map<ModuleOptionKey, String> args) {
 		this.args = args;
 	}
 
-	public Map<Integer, Map<String, String>> getArgs() {
+	public Map<ModuleOptionKey, String> getArgs() {
 		return args;
 	}
-
 }

--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncherRunner.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncherRunner.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.stream.module.launcher;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -66,9 +67,17 @@ public class ModuleLauncherRunner implements CommandLineRunner {
 	private List<ModuleLaunchRequest> generateModuleLaunchRequests() {
 		List<ModuleLaunchRequest> requests = new ArrayList<>();
 		String[] modules = this.moduleLauncherProperties.getModules();
-		Map<Integer, Map<String, String>> arguments = this.moduleLauncherProperties.getArgs();
+		Map<ModuleOptionKey, String> arguments = this.moduleLauncherProperties.getArgs();
+		Map<Integer, Map<String,String>> properties = new HashMap<>();
 		for (int i = 0; i < modules.length; i++) {
-			ModuleLaunchRequest moduleLaunchRequest = new ModuleLaunchRequest(modules[i], arguments.get(i));
+			Map<String, String> options = new HashMap<>();
+			for (Map.Entry<ModuleOptionKey, String> value: arguments.entrySet()) {
+				if (value.getKey().getIndex() == i) {
+					options.put(value.getKey().getOption(), value.getValue());
+				}
+			}
+			properties.put(i, options);
+			ModuleLaunchRequest moduleLaunchRequest = new ModuleLaunchRequest(modules[i], properties.get(i));
 			requests.add(moduleLaunchRequest);
 		}
 		return requests;
@@ -83,5 +92,4 @@ public class ModuleLauncherRunner implements CommandLineRunner {
 		}
 		return filteredProperties.toArray(new String[filteredProperties.size()]);
 	}
-
 }

--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleOptionKey.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleOptionKey.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.module.launcher;
+
+/**
+ * Module option key that represents the module index (the index based on the program argument for the module launcher)
+ * and the option key.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+public class ModuleOptionKey {
+
+	private final int index;
+
+	private final String option;
+
+	public ModuleOptionKey(int index, String option) {
+		this.index = index;
+		this.option = option;
+	}
+
+	public int getIndex() {
+		return index;
+	}
+
+	public String getOption() {
+		return option;
+	}
+
+}


### PR DESCRIPTION
 - If the module argument key (--args.<index>.<option>) is delimited by underscore, then spring-boot doesn't resolve for the `ConfigurationProperties` of type `Map<?,Map<?,?>>`.
 - To overcome this issue on module launcher, this PR introduces `ModuleOptionKey` which is used as the key for module launcher args map property.
   - Add converters that converts the program arguments into appropriate `ModuleOptionKey`