### PR TITLE
Add support for Kafka in Cloud Foundry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	</scm>
 	<properties>
 		<java.version>1.7</java.version>
-		<rx-java.version>1.0.14</rx-java.version>
+		<rxjava.version>1.0.14</rxjava.version>
 		<spring-boot.version>1.3.0.BUILD-SNAPSHOT</spring-boot.version>
 		<spring-framework.version>4.2.1.BUILD-SNAPSHOT</spring-framework.version>
 		<spring-integration.version>4.2.0.BUILD-SNAPSHOT</spring-integration.version>
@@ -144,7 +144,7 @@
 			<dependency>
 				<groupId>io.reactivex</groupId>
 				<artifactId>rxjava</artifactId>
-				<version>${rx-java.version}</version>
+				<version>${rxjava.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.objenesis</groupId>

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/pom.xml
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/pom.xml
@@ -18,7 +18,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<kafka.version>0.8.2.1</kafka.version>
 		<spring-integration-kafka.version>1.2.0.RELEASE</spring-integration-kafka.version>
-		<rxjava.version>1.0.0</rxjava.version>
+		<rxjava-math.version>1.0.0</rxjava-math.version>
 	</properties>
 
 	<dependencies>
@@ -67,12 +67,12 @@
 		<dependency>
 			<groupId>io.reactivex</groupId>
 			<artifactId>rxjava</artifactId>
-			<version>${rxjava.version}</version>
+			<version>${rx-java.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.reactivex</groupId>
 			<artifactId>rxjava-math</artifactId>
-			<version>${rxjava.version}</version>
+			<version>${rxjava-math.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.xd</groupId>

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/pom.xml
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/pom.xml
@@ -67,7 +67,6 @@
 		<dependency>
 			<groupId>io.reactivex</groupId>
 			<artifactId>rxjava</artifactId>
-			<version>${rx-java.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.reactivex</groupId>

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaMessageChannelBinderConfiguration.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaMessageChannelBinderConfiguration.java
@@ -34,7 +34,7 @@ import org.springframework.util.StringUtils;
 @ConfigurationProperties(prefix = "spring.cloud.stream.binder.kafka")
 public class KafkaMessageChannelBinderConfiguration {
 
-	private String[] zkAddress;
+	private String[] zkNodes;
 
 	private String zkDefaultPort;
 
@@ -111,8 +111,8 @@ public class KafkaMessageChannelBinderConfiguration {
 		return kafkaMessageChannelBinder;
 	}
 
-	public void setZkAddress(String[] zkAddress) {
-		this.zkAddress = zkAddress;
+	public void setZkNodes(String[] zkNodes) {
+		this.zkNodes = zkNodes;
 	}
 
 	public void setZkDefaultPort(String zkDefaultPort) {
@@ -176,7 +176,7 @@ public class KafkaMessageChannelBinderConfiguration {
 	}
 
 	public String getZkConnectionString() {
-		return toConnectionString(this.zkAddress, this.zkDefaultPort);
+		return toConnectionString(this.zkNodes, this.zkDefaultPort);
 	}
 
 	public String getKafkaConnectionString() {

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaMessageChannelBinderConfiguration.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaMessageChannelBinderConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.codec.Codec;
 import org.springframework.integration.kafka.support.ZookeeperConnect;
+import org.springframework.util.StringUtils;
 
 /**
  * @author David Turanski
@@ -33,9 +34,13 @@ import org.springframework.integration.kafka.support.ZookeeperConnect;
 @ConfigurationProperties(prefix = "spring.cloud.stream.binder.kafka")
 public class KafkaMessageChannelBinderConfiguration {
 
-	private String zkAddress;
+	private String[] zkAddress;
 
-	private String brokers;
+	private String zkDefaultPort;
+
+	private String[] brokers;
+
+	private String brokersDefaultPort;
 
 	private KafkaMessageChannelBinder.Mode mode;
 
@@ -68,14 +73,14 @@ public class KafkaMessageChannelBinderConfiguration {
 	@Bean
 	ZookeeperConnect zookeeperConnect() {
 		ZookeeperConnect zookeeperConnect = new ZookeeperConnect();
-		zookeeperConnect.setZkConnect(zkAddress);
+		zookeeperConnect.setZkConnect(getZkConnectionString());
 		return zookeeperConnect;
 	}
 
 	@Bean
 	KafkaMessageChannelBinder kafkaMessageChannelBinder() {
 		KafkaMessageChannelBinder kafkaMessageChannelBinder = new KafkaMessageChannelBinder(zookeeperConnect(),
-				brokers, zkAddress, new String[0]);
+				getKafkaConnectionString(), getZkConnectionString());
 		kafkaMessageChannelBinder.setCodec(codec);
 		kafkaMessageChannelBinder.setMode(mode);
 		kafkaMessageChannelBinder.setOffsetStoreTopic(offsetStoreTopic);
@@ -106,12 +111,20 @@ public class KafkaMessageChannelBinderConfiguration {
 		return kafkaMessageChannelBinder;
 	}
 
-	public void setZkAddress(String zkAddress) {
+	public void setZkAddress(String[] zkAddress) {
 		this.zkAddress = zkAddress;
 	}
 
-	public void setBrokers(String brokers) {
+	public void setZkDefaultPort(String zkDefaultPort) {
+		this.zkDefaultPort = zkDefaultPort;
+	}
+
+	public void setBrokers(String[] brokers) {
 		this.brokers = brokers;
+	}
+
+	public void setBrokersDefaultPort(String brokersDefaultPort) {
+		this.brokersDefaultPort = brokersDefaultPort;
 	}
 
 	public void setMode(KafkaMessageChannelBinder.Mode mode) {
@@ -162,4 +175,29 @@ public class KafkaMessageChannelBinderConfiguration {
 		this.codec = codec;
 	}
 
+	public String getZkConnectionString() {
+		return toConnectionString(this.zkAddress, this.zkDefaultPort);
+	}
+
+	public String getKafkaConnectionString() {
+		return toConnectionString(this.brokers, this.brokersDefaultPort);
+	}
+
+	/**
+	 * Converts an array of host values to a comma-separated String.
+	 *
+	 * It will append the default port value, if not already specified.
+	 */
+	private String toConnectionString(String[] hosts, String defaultPort) {
+		String[] fullyFormattedHosts = new String[hosts.length];
+		for (int i = 0; i < hosts.length; i++) {
+			if (hosts[i].contains(":") || StringUtils.isEmpty(defaultPort)) {
+				fullyFormattedHosts[i] = hosts[i];
+			}
+			else {
+				fullyFormattedHosts[i] = hosts[i] + ":" + defaultPort;
+			}
+		}
+		return StringUtils.arrayToCommaDelimitedString(fullyFormattedHosts);
+	}
 }

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/resources/META-INF/spring-cloud-stream/kafka-binder.properties
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/resources/META-INF/spring-cloud-stream/kafka-binder.properties
@@ -1,5 +1,7 @@
-spring.cloud.stream.binder.kafka.brokers=localhost:9092
-spring.cloud.stream.binder.kafka.zkAddress=localhost:2181
+spring.cloud.stream.binder.kafka.brokers=${vcap.services.kafka.credentials.kafka.node_ips:localhost}
+spring.cloud.stream.binder.kafka.brokersDefaultPort=${vcap.services.kafka.credentials.kafka.port:9092}
+spring.cloud.stream.binder.kafka.zkAddress=${vcap.services.kafka.credentials.zookeeper.node_ips:localhost}
+spring.cloud.stream.binder.kafka.zkDefaultPort=${vcap.services.kafka.credentials.zookeeper.port:2181}
 spring.cloud.stream.binder.kafka.mode=embeddedHeaders
 spring.cloud.stream.binder.kafka.offsetStoreTopic=SpringXdOffsets
 spring.cloud.stream.binder.kafka.offsetStoreSegmentSize=25000000

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/resources/META-INF/spring-cloud-stream/kafka-binder.properties
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/resources/META-INF/spring-cloud-stream/kafka-binder.properties
@@ -1,6 +1,6 @@
 spring.cloud.stream.binder.kafka.brokers=${vcap.services.kafka.credentials.kafka.node_ips:localhost}
 spring.cloud.stream.binder.kafka.brokersDefaultPort=${vcap.services.kafka.credentials.kafka.port:9092}
-spring.cloud.stream.binder.kafka.zkAddress=${vcap.services.kafka.credentials.zookeeper.node_ips:localhost}
+spring.cloud.stream.binder.kafka.zkNodes=${vcap.services.kafka.credentials.zookeeper.node_ips:localhost}
 spring.cloud.stream.binder.kafka.zkDefaultPort=${vcap.services.kafka.credentials.zookeeper.port:2181}
 spring.cloud.stream.binder.kafka.mode=embeddedHeaders
 spring.cloud.stream.binder.kafka.offsetStoreTopic=SpringXdOffsets


### PR DESCRIPTION
- use the VCAP properties to find brokers and ports

How to test: run time log by pushing jars into CF after rebuilding SCSM with the Kafka binder. 