### PR TITLE
Add a default poller for Spring Integration

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingAutoConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingAutoConfiguration.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.stream.binding.ChannelBindingService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.scheduling.PollerMetadata;
+import org.springframework.messaging.MessageChannel;
+
+/**
+ * Configuration class with some useful beans for {@link MessageChannel} binding and
+ * general Spring Integration infrastructure.
+ *
+ * @author Dave Syer
+ */
+@Configuration
+@ConditionalOnBean(ChannelBindingService.class)
+@EnableConfigurationProperties(DefaultPollerProperties.class)
+public class ChannelBindingAutoConfiguration {
+
+	@Autowired
+	private DefaultPollerProperties poller;
+
+	@Bean(name = PollerMetadata.DEFAULT_POLLER)
+	@ConditionalOnMissingBean(PollerMetadata.class)
+	public PollerMetadata defaultPoller() {
+		PollerMetadata pollerMetadata = this.poller.getPollerMetadata();
+		return pollerMetadata;
+	}
+
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceConfiguration.java
@@ -22,11 +22,11 @@ import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cloud.stream.binding.ChannelBindingService;
 import org.springframework.cloud.stream.binder.Binder;
 import org.springframework.cloud.stream.binding.BinderAwareChannelResolver;
 import org.springframework.cloud.stream.binding.BinderAwareRouterBeanPostProcessor;
 import org.springframework.cloud.stream.binding.ChannelBindingLifecycle;
+import org.springframework.cloud.stream.binding.ChannelBindingService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
@@ -47,8 +47,13 @@ import org.springframework.messaging.core.DestinationResolver;
 public class ChannelBindingServiceConfiguration {
 
 	@Bean
+	// This conditional is intentionally not in an autoconfig (usually a bad idea) because
+	// it is used to detect a ChannelBindingService in the parent context (which we know
+	// already exists).
 	@ConditionalOnMissingBean(ChannelBindingService.class)
-	public ChannelBindingService bindingService(ChannelBindingProperties channelBindingProperties, Binder<MessageChannel> binder) {
+	public ChannelBindingService bindingService(
+			ChannelBindingProperties channelBindingProperties,
+			Binder<MessageChannel> binder) {
 		return new ChannelBindingService(channelBindingProperties, binder);
 	}
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/DefaultPollerProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/DefaultPollerProperties.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.integration.scheduling.PollerMetadata;
+import org.springframework.scheduling.support.PeriodicTrigger;
+
+/**
+ * @author Dave Syer
+ *
+ */
+@ConfigurationProperties("spring.integration.poller")
+public class DefaultPollerProperties {
+
+	/**
+	 * Fixed delay for default poller.
+	 */
+	private long fixedDelay = 1000L;
+	/**
+	 * Maximum messages per poll for the default poller.
+	 */
+	private long maxMessagesPerPoll = 1L;
+
+	public PollerMetadata getPollerMetadata() {
+		PollerMetadata pollerMetadata = new PollerMetadata();
+		pollerMetadata.setTrigger(new PeriodicTrigger(this.fixedDelay));
+		pollerMetadata.setMaxMessagesPerPoll(this.maxMessagesPerPoll);
+		return pollerMetadata;
+	}
+
+	public long getFixedDelay() {
+		return this.fixedDelay;
+	}
+
+	public void setFixedDelay(long fixedDelay) {
+		this.fixedDelay = fixedDelay;
+	}
+
+	public long getMaxMessagesPerPoll() {
+		return this.maxMessagesPerPoll;
+	}
+
+	public void setMaxMessagesPerPoll(long maxMessagesPerPoll) {
+		this.maxMessagesPerPoll = maxMessagesPerPoll;
+	}
+
+}

--- a/spring-cloud-stream/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-stream/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration:\
+org.springframework.cloud.stream.config.ChannelBindingAutoConfiguration


### PR DESCRIPTION
Useful for simple implementations of @EnableModule(Source) without
having to specify a poller explicitly