### PR TITLE
Add per-binding configuration for partitioning

### DIFF
--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -391,6 +391,7 @@ public class KafkaMessageChannelBinder extends MessageChannelBinderSupport {
 			retryTemplate.setBackOffPolicy(backOffPolicy);
 			retryOperations = retryTemplate;
 		}
+		super.afterPropertiesSet();
 	}
 
 	/**

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaTestBinder.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaTestBinder.java
@@ -56,10 +56,10 @@ public class KafkaTestBinder extends AbstractTestBinder<KafkaMessageChannelBinde
 			binder.setCodec(getCodec());
 			binder.setDefaultBatchingEnabled(false);
 			binder.setMode(mode);
-			binder.afterPropertiesSet();
 			GenericApplicationContext context = new GenericApplicationContext();
 			context.refresh();
 			binder.setApplicationContext(context);
+			binder.afterPropertiesSet();
 			this.setBinder(binder);
 		}
 		catch (Exception e) {

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-spi/src/main/java/org/springframework/cloud/stream/binder/MessageChannelBinderSupport.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-spi/src/main/java/org/springframework/cloud/stream/binder/MessageChannelBinderSupport.java
@@ -146,6 +146,7 @@ public abstract class MessageChannelBinderSupport
 					BinderProperties.PARTITION_KEY_EXTRACTOR_CLASS,
 					BinderProperties.PARTITION_SELECTOR_CLASS,
 					BinderProperties.PARTITION_SELECTOR_EXPRESSION,
+					BinderProperties.MIN_PARTITION_COUNT
 			}));
 
 	protected static final Set<Object> PRODUCER_BATCHING_BASIC_PROPERTIES = new HashSet<Object>(

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/ChannelBindingService.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/ChannelBindingService.java
@@ -16,14 +16,10 @@
 
 package org.springframework.cloud.stream.binding;
 
-import java.util.Properties;
-
 import org.springframework.cloud.stream.binder.Binder;
-import org.springframework.cloud.stream.binder.BinderProperties;
 import org.springframework.cloud.stream.config.ChannelBindingProperties;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.util.Assert;
-import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -48,7 +44,7 @@ public class ChannelBindingService {
 
 	public void bindConsumer(MessageChannel inputChannel, String inputChannelName) {
 		String channelBindingTarget = this.channelBindingProperties
-				.getBindingTarget(inputChannelName);
+				.getBindingDestination(inputChannelName);
 		if (isChannelPubSub(channelBindingTarget)) {
 			this.binder.bindPubSubConsumer(removePrefix(channelBindingTarget),
 					inputChannel, this.channelBindingProperties.getConsumerProperties(inputChannelName));
@@ -61,7 +57,7 @@ public class ChannelBindingService {
 
 	public void bindProducer(MessageChannel outputChannel, String outputChannelName) {
 		String channelBindingTarget = this.channelBindingProperties
-				.getBindingTarget(outputChannelName);
+				.getBindingDestination(outputChannelName);
 		if (isChannelPubSub(channelBindingTarget)) {
 			this.binder.bindPubSubProducer(removePrefix(channelBindingTarget),
 					outputChannel, this.channelBindingProperties.getProducerProperties(outputChannelName));

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/ChannelBindingService.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/ChannelBindingService.java
@@ -16,14 +16,19 @@
 
 package org.springframework.cloud.stream.binding;
 
+import java.util.Properties;
+
 import org.springframework.cloud.stream.binder.Binder;
+import org.springframework.cloud.stream.binder.BinderProperties;
 import org.springframework.cloud.stream.config.ChannelBindingProperties;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
 /**
- * Handles the binding of input/output channels by delegating to an underlying {@link Binder}.
+ * Handles the binding of input/output channels by delegating to an underlying
+ * {@link Binder}.
  *
  * @author Mark Fisher
  * @author Dave Syer
@@ -36,35 +41,34 @@ public class ChannelBindingService {
 	private ChannelBindingProperties channelBindingProperties;
 
 	public ChannelBindingService(ChannelBindingProperties channelBindingProperties,
-															 Binder<MessageChannel> binder) {
+			Binder<MessageChannel> binder) {
 		this.channelBindingProperties = channelBindingProperties;
 		this.binder = binder;
 	}
 
-
 	public void bindConsumer(MessageChannel inputChannel, String inputChannelName) {
 		String channelBindingTarget = this.channelBindingProperties
-				.getBindingPath(inputChannelName);
+				.getBindingTarget(inputChannelName);
 		if (isChannelPubSub(channelBindingTarget)) {
-			this.binder.bindPubSubConsumer(removePrefix(channelBindingTarget), inputChannel,
-					this.channelBindingProperties.getConsumerProperties());
+			this.binder.bindPubSubConsumer(removePrefix(channelBindingTarget),
+					inputChannel, this.channelBindingProperties.getConsumerProperties(inputChannelName));
 		}
 		else {
 			this.binder.bindConsumer(channelBindingTarget, inputChannel,
-					this.channelBindingProperties.getConsumerProperties());
+					this.channelBindingProperties.getConsumerProperties(inputChannelName));
 		}
 	}
 
 	public void bindProducer(MessageChannel outputChannel, String outputChannelName) {
 		String channelBindingTarget = this.channelBindingProperties
-				.getBindingPath(outputChannelName);
+				.getBindingTarget(outputChannelName);
 		if (isChannelPubSub(channelBindingTarget)) {
-			this.binder.bindPubSubProducer(removePrefix(channelBindingTarget), outputChannel,
-					this.channelBindingProperties.getProducerProperties());
+			this.binder.bindPubSubProducer(removePrefix(channelBindingTarget),
+					outputChannel, this.channelBindingProperties.getProducerProperties(outputChannelName));
 		}
 		else {
 			this.binder.bindProducer(channelBindingTarget, outputChannel,
-					this.channelBindingProperties.getProducerProperties());
+					this.channelBindingProperties.getProducerProperties(outputChannelName));
 		}
 	}
 
@@ -75,19 +79,15 @@ public class ChannelBindingService {
 	}
 
 	private String removePrefix(String bindingTarget) {
-		Assert.isTrue(StringUtils.hasText(bindingTarget),
-				"Binding target should not be empty/null.");
+		Assert.isTrue(StringUtils.hasText(bindingTarget), "Binding target should not be empty/null.");
 		return bindingTarget.substring(bindingTarget.indexOf(":") + 1);
 	}
 
 	public void unbindConsumers(String inputChannelName) {
-		this.binder.unbindConsumers
-				(inputChannelName);
+		this.binder.unbindConsumers(inputChannelName);
 	}
 
 	public void unbindProducers(String outputChannelName) {
 		this.binder.unbindProducers(outputChannelName);
 	}
-
-
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingProperties.java
@@ -44,8 +44,7 @@ public class ChannelBindingProperties {
 	@Value("${INSTANCE_INDEX:${CF_INSTANCE_INDEX:0}}")
 	private int instanceIndex;
 
-	@Value("${INSTANCE_COUNT:1}")
-	private int instanceCount;
+	private int instanceCount = 1;
 
 	private Properties consumerProperties = new Properties();
 
@@ -171,9 +170,7 @@ public class ChannelBindingProperties {
 	public Properties getConsumerProperties(String inputChannelName) {
 		if (isPartitionedConsumer(inputChannelName)) {
 			Properties channelConsumerProperties = new Properties();
-			if (consumerProperties != null) {
-				channelConsumerProperties.putAll(consumerProperties);
-			}
+			channelConsumerProperties.putAll(consumerProperties);
 			channelConsumerProperties.setProperty(BinderProperties.COUNT,
 					Integer.toString(getInstanceCount()));
 			channelConsumerProperties.setProperty(BinderProperties.PARTITION_INDEX,
@@ -195,11 +192,7 @@ public class ChannelBindingProperties {
 	public Properties getProducerProperties(String outputChannelName) {
 		if (isPartitionedProducer(outputChannelName)) {
 			Properties channelProducerProperties = new Properties();
-			if (this.producerProperties != null) {
-				channelProducerProperties.putAll(this.producerProperties);
-			}
-			channelProducerProperties.put(BinderProperties.MIN_PARTITION_COUNT,
-					Integer.toString(getPartitionCount(outputChannelName)));
+			channelProducerProperties.putAll(this.producerProperties);
 			channelProducerProperties.setProperty(BinderProperties.NEXT_MODULE_COUNT,
 					Integer.toString(getPartitionCount(outputChannelName)));
 			copyChannelBindingProperty(outputChannelName, channelProducerProperties,

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingProperties.java
@@ -35,7 +35,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 @JsonInclude(Include.NON_DEFAULT)
 public class ChannelBindingProperties {
 
-	public static final String TARGET = "target";
+	public static final String DESTINATION = "destination";
 
 	public static final String PARTITION_COUNT = "partitionCount";
 
@@ -94,7 +94,7 @@ public class ChannelBindingProperties {
 	}
 
 
-	public String getBindingTarget(String channelName) {
+	public String getBindingDestination(String channelName) {
 		Object binding = bindings.get(channelName);
 		// we may shortcut directly to the path
 		if (binding != null) {
@@ -103,7 +103,7 @@ public class ChannelBindingProperties {
 			}
 			else if (binding instanceof Map) {
 				Map<?, ?> bindingProperties = (Map<?, ?>) binding;
-				Object bindingPath = bindingProperties.get(TARGET);
+				Object bindingPath = bindingProperties.get(DESTINATION);
 				if (bindingPath != null) {
 					return bindingPath.toString();
 				}
@@ -226,7 +226,7 @@ public class ChannelBindingProperties {
 	}
 
 	public String getTapChannelName(String channelName) {
-		return "tap:" + getBindingTarget(channelName);
+		return "tap:" + getBindingDestination(channelName);
 	}
 
 }

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/partitioning/PartitionedConsumerTest.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/partitioning/PartitionedConsumerTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.partitioning;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.text.IsEqualIgnoringCase.equalToIgnoringCase;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.Properties;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.cloud.stream.annotation.Bindings;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.binder.Binder;
+import org.springframework.cloud.stream.binder.BinderProperties;
+import org.springframework.cloud.stream.messaging.Sink;
+import org.springframework.cloud.stream.messaging.Source;
+import org.springframework.cloud.stream.utils.MockBinderConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Marius Bogoevici
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(PartitionedConsumerTest.TestSink.class)
+
+public class PartitionedConsumerTest {
+
+	@SuppressWarnings("rawtypes")
+	@Autowired
+	private Binder binder;
+
+	@Autowired @Bindings(TestSink.class)
+	private Sink testSource;
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testBindingPartitionedConsumer() {
+		ArgumentCaptor<Properties> argumentCaptor = ArgumentCaptor.forClass(Properties.class);
+		verify(binder).bindConsumer(eq("partIn"), eq(testSource.input()), argumentCaptor.capture());
+		Assert.assertThat(argumentCaptor.getValue().getProperty(BinderProperties.PARTITION_INDEX), equalTo("0"));
+		Assert.assertThat(argumentCaptor.getValue().getProperty(BinderProperties.COUNT),
+				equalTo("2"));
+		verifyNoMoreInteractions(binder);
+	}
+
+
+	@EnableBinding(Sink.class)
+	@EnableAutoConfiguration
+	@Import(MockBinderConfiguration.class)
+	@PropertySource("classpath:/org/springframework/cloud/stream/binder/partitioned-consumer-test.properties")
+	public static class TestSink {
+
+	}
+
+	class PropertiesArgumentMatcher extends ArgumentMatcher<Properties> {
+		@Override
+		public boolean matches(Object argument) {
+			if (!(argument instanceof Properties)) {
+				return false;
+			}
+			return true;
+		}
+	}
+
+}

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/partitioning/PartitionedProducerTest.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/partitioning/PartitionedProducerTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.partitioning;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.Properties;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.cloud.stream.annotation.Bindings;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.binder.Binder;
+import org.springframework.cloud.stream.binder.BinderProperties;
+import org.springframework.cloud.stream.messaging.Source;
+import org.springframework.cloud.stream.utils.MockBinderConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Marius Bogoevici
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(PartitionedProducerTest.TestSource.class)
+
+public class PartitionedProducerTest {
+
+	@SuppressWarnings("rawtypes")
+	@Autowired
+	private Binder binder;
+
+	@Autowired @Bindings(TestSource.class)
+	private Source testSource;
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testBindingPartitionedProducer() {
+		ArgumentCaptor<Properties> argumentCaptor = ArgumentCaptor.forClass(Properties.class);
+		verify(binder).bindProducer(eq("partOut"), eq(testSource.output()), argumentCaptor.capture());
+		Assert.assertThat(argumentCaptor.getValue().getProperty(BinderProperties.MIN_PARTITION_COUNT), equalTo("3"));
+		Assert.assertThat(argumentCaptor.getValue().getProperty(BinderProperties.NEXT_MODULE_COUNT), equalTo("3"));
+		Assert.assertThat(argumentCaptor.getValue().getProperty(BinderProperties.PARTITION_KEY_EXPRESSION),
+				equalTo("payload"));
+		verifyNoMoreInteractions(binder);
+	}
+
+
+	@EnableBinding(Source.class)
+	@EnableAutoConfiguration
+	@Import(MockBinderConfiguration.class)
+	@PropertySource("classpath:/org/springframework/cloud/stream/binder/partitioned-producer-test.properties")
+	public static class TestSource {
+
+	}
+
+	class PropertiesArgumentMatcher extends ArgumentMatcher<Properties> {
+		@Override
+		public boolean matches(Object argument) {
+			if (!(argument instanceof Properties)) {
+				return false;
+			}
+			return true;
+		}
+	}
+
+}

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/partitioning/PartitionedProducerTest.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/partitioning/PartitionedProducerTest.java
@@ -62,7 +62,6 @@ public class PartitionedProducerTest {
 	public void testBindingPartitionedProducer() {
 		ArgumentCaptor<Properties> argumentCaptor = ArgumentCaptor.forClass(Properties.class);
 		verify(binder).bindProducer(eq("partOut"), eq(testSource.output()), argumentCaptor.capture());
-		Assert.assertThat(argumentCaptor.getValue().getProperty(BinderProperties.MIN_PARTITION_COUNT), equalTo("3"));
 		Assert.assertThat(argumentCaptor.getValue().getProperty(BinderProperties.NEXT_MODULE_COUNT), equalTo("3"));
 		Assert.assertThat(argumentCaptor.getValue().getProperty(BinderProperties.PARTITION_KEY_EXPRESSION),
 				equalTo("payload"));

--- a/spring-cloud-stream/src/test/resources/org/springframework/cloud/stream/binder/partitioned-consumer-test.properties
+++ b/spring-cloud-stream/src/test/resources/org/springframework/cloud/stream/binder/partitioned-consumer-test.properties
@@ -1,0 +1,5 @@
+spring.cloud.stream.bindings.input.target=partIn
+spring.cloud.stream.bindings.input.partitioned=true
+spring.cloud.stream.instanceCount=2
+spring.cloud.stream.instanceIndex=0
+

--- a/spring-cloud-stream/src/test/resources/org/springframework/cloud/stream/binder/partitioned-consumer-test.properties
+++ b/spring-cloud-stream/src/test/resources/org/springframework/cloud/stream/binder/partitioned-consumer-test.properties
@@ -1,4 +1,4 @@
-spring.cloud.stream.bindings.input.target=partIn
+spring.cloud.stream.bindings.input.destination=partIn
 spring.cloud.stream.bindings.input.partitioned=true
 spring.cloud.stream.instanceCount=2
 spring.cloud.stream.instanceIndex=0

--- a/spring-cloud-stream/src/test/resources/org/springframework/cloud/stream/binder/partitioned-producer-test.properties
+++ b/spring-cloud-stream/src/test/resources/org/springframework/cloud/stream/binder/partitioned-producer-test.properties
@@ -1,4 +1,4 @@
-spring.cloud.stream.bindings.output.target=partOut
+spring.cloud.stream.bindings.output.destination=partOut
 spring.cloud.stream.bindings.output.partitionKeyExpression=payload
 spring.cloud.stream.bindings.output.partitionCount=3
 

--- a/spring-cloud-stream/src/test/resources/org/springframework/cloud/stream/binder/partitioned-producer-test.properties
+++ b/spring-cloud-stream/src/test/resources/org/springframework/cloud/stream/binder/partitioned-producer-test.properties
@@ -1,0 +1,4 @@
+spring.cloud.stream.bindings.output.target=partOut
+spring.cloud.stream.bindings.output.partitionKeyExpression=payload
+spring.cloud.stream.bindings.output.partitionCount=3
+


### PR DESCRIPTION
- consumer and producer partitioning properties are defined per-binding;
- the binding configuration will use an expanded form (where `destination` indicates the binding target, missing in the short form `spring.cloud.stream.binding.input=tessttock`;
- `partitioned` indicates that an input is partitioned (must be used in conjunction with an `instanceIndex` setting - either via arguments or via environment. `instanceCount` must be defined for Kafka.)
- `partitionKeyExpression` or `partitionKeyExtractorClass` indicate that a producer is partitioned (must be used in conjunction with supplying a `partitionCount` property)
- unit tests
- Kafka binding fixes for partitioning
- the current Binder properties need to be renamed, but due to the use of hardcoded values I left them alone;

Usage example:

java -jar time-source/target/time-source-1.0.0.BUILD-SNAPSHOT-exec.jar --spring.cloud.stream.bindings.output.destination=parttock --spring.cloud.stream.bindings.output.partitionKeyExpression=payload --spring.cloud.stream.bindings.output.partitionCount=3

java -jar log-sink/target/log-sink-1.0.0.BUILD-SNAPSHOT-exec.jar --spring.cloud.stream.bindings.input.partitioned=true --spring.cloud.stream.bindings.input.destination=parttock --spring.cloud.stream.instanceCount=3 --spring.cloud.stream.instanceIndex=0 --server.port=0
