### PR TITLE
Add ChannelsEndpoint back for introspecting bindings

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/Bindable.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/Bindable.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.stream.binding;
 
+import java.util.Set;
+
 /**
  * Marker interface for instances that can bind/unbind groups of inputs and outputs.
  *
@@ -44,5 +46,15 @@ public interface Bindable {
 	 * Unbinds all the outputs associated with this instance.
 	 */
 	void unbindOutputs(ChannelBindingService adapter);
+
+	/**
+	 * Enumerates all the input binding names.
+	 */
+	Set<String> getInputs();
+
+	/**
+	 * Enumerates all the output binding names.
+	 */
+	Set<String> getOutputs();
 
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindingBeanDefinitionRegistryUtils.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindingBeanDefinitionRegistryUtils.java
@@ -18,8 +18,6 @@ package org.springframework.cloud.stream.binding;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 import org.springframework.beans.factory.support.AutowireCandidateQualifier;

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingProperties.java
@@ -16,12 +16,16 @@
 
 package org.springframework.cloud.stream.config;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
 /**
  * Contains the properties of a binding.
  *
  * @author Marius Bogoevici
  * @author Ilayaperumal Gopinathan
  */
+@JsonInclude(value = Include.NON_DEFAULT)
 public class BindingProperties {
 
 	private String destination;
@@ -41,7 +45,7 @@ public class BindingProperties {
 	private String contentType;
 
 	public String getDestination() {
-		return destination;
+		return this.destination;
 	}
 
 	public void setDestination(String destination) {
@@ -49,7 +53,7 @@ public class BindingProperties {
 	}
 
 	public boolean isPartitioned() {
-		return partitioned;
+		return this.partitioned;
 	}
 
 	public void setPartitioned(boolean partitioned) {
@@ -57,7 +61,7 @@ public class BindingProperties {
 	}
 
 	public int getPartitionCount() {
-		return partitionCount;
+		return this.partitionCount;
 	}
 
 	public void setPartitionCount(int partitionCount) {
@@ -65,7 +69,7 @@ public class BindingProperties {
 	}
 
 	public String getPartitionKeyExpression() {
-		return partitionKeyExpression;
+		return this.partitionKeyExpression;
 	}
 
 	public void setPartitionKeyExpression(String partitionKeyExpression) {
@@ -73,7 +77,7 @@ public class BindingProperties {
 	}
 
 	public String getPartitionKeyExtractorClass() {
-		return partitionKeyExtractorClass;
+		return this.partitionKeyExtractorClass;
 	}
 
 	public void setPartitionKeyExtractorClass(String partitionKeyExtractorClass) {
@@ -81,7 +85,7 @@ public class BindingProperties {
 	}
 
 	public String getPartitionSelectorClass() {
-		return partitionSelectorClass;
+		return this.partitionSelectorClass;
 	}
 
 	public void setPartitionSelectorClass(String partitionSelectorClass) {
@@ -89,7 +93,7 @@ public class BindingProperties {
 	}
 
 	public String getPartitionSelectorExpression() {
-		return partitionSelectorExpression;
+		return this.partitionSelectorExpression;
 	}
 
 	public void setPartitionSelectorExpression(String partitionSelectorExpression) {

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingAutoConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingAutoConfiguration.java
@@ -16,11 +16,15 @@
 
 package org.springframework.cloud.stream.config;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.stream.binding.Bindable;
 import org.springframework.cloud.stream.binding.ChannelBindingService;
+import org.springframework.cloud.stream.endpoint.ChannelsEndpoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.scheduling.PollerMetadata;
@@ -44,6 +48,12 @@ public class ChannelBindingAutoConfiguration {
 	@ConditionalOnMissingBean(PollerMetadata.class)
 	public PollerMetadata defaultPoller() {
 		return this.poller.getPollerMetadata();
+	}
+
+	@Bean
+	@Autowired(required=false)
+	public ChannelsEndpoint channelsEndpoint(List<Bindable> adapters, ChannelBindingServiceProperties properties) {
+		return new ChannelsEndpoint(adapters, properties);
 	}
 
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/endpoint/ChannelsEndpoint.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/endpoint/ChannelsEndpoint.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.endpoint;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.boot.actuate.endpoint.AbstractEndpoint;
+import org.springframework.cloud.stream.binding.Bindable;
+import org.springframework.cloud.stream.config.BindingProperties;
+import org.springframework.cloud.stream.config.ChannelBindingServiceProperties;
+import org.springframework.cloud.stream.endpoint.ChannelsEndpoint.ChannelsMetaData;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+/**
+ * @author Dave Syer
+ */
+@RestController
+public class ChannelsEndpoint extends AbstractEndpoint<ChannelsMetaData> {
+
+	private List<Bindable> adapters;
+
+	private ChannelBindingServiceProperties properties;
+
+	public ChannelsEndpoint(List<Bindable> adapters,
+			ChannelBindingServiceProperties properties) {
+		super("channels");
+		this.adapters = adapters;
+		this.properties = properties;
+	}
+
+	@Override
+	public ChannelsMetaData invoke() {
+		ChannelsMetaData map = new ChannelsMetaData();
+		Map<String, BindingProperties> inputs = map.getInputs();
+		Map<String, BindingProperties> outputs = map.getOutputs();
+		for (Bindable factory : this.adapters) {
+			Map<String, BindingProperties> bindings = this.properties.getBindings();
+			for (String name : factory.getInputs()) {
+				inputs.put(name, bindings.containsKey(name) ? bindings.get(name)
+						: new BindingProperties());
+			}
+			for (String name : factory.getOutputs()) {
+				outputs.put(name, bindings.containsKey(name) ? bindings.get(name)
+						: new BindingProperties());
+			}
+		}
+		return map;
+	}
+
+	@JsonInclude(value = Include.NON_DEFAULT)
+	public static class ChannelsMetaData {
+		private Map<String, BindingProperties> inputs = new LinkedHashMap<>();
+		private Map<String, BindingProperties> outputs = new LinkedHashMap<>();
+
+		public Map<String, BindingProperties> getInputs() {
+			return this.inputs;
+		}
+
+		public void setInputs(Map<String, BindingProperties> inputs) {
+			this.inputs = inputs;
+		}
+
+		public Map<String, BindingProperties> getOutputs() {
+			return this.outputs;
+		}
+
+		public void setOutputs(Map<String, BindingProperties> outputs) {
+			this.outputs = outputs;
+		}
+	}
+
+}


### PR DESCRIPTION
Bindable picks up 2 new methods to enumerate the binding names, and then
it's a simple matter to list all the inputs and outputs and their
properties.

Fixes gh-149