### PR TITLE
XD-3601 Add unique Id for ModuleLaunchRequest

### DIFF
--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLaunchRequest.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLaunchRequest.java
@@ -24,16 +24,28 @@ import java.util.Map;
  * Those arguments will be passed to the module by the launcher.
  *
  * @author Eric Bottard
+ * @author Ilayaperumal Gopinathan
  */
 public class ModuleLaunchRequest {
+
+	/**
+	 * String that uniquely identifies Module launch request. This is useful when there are multiple requests
+	 * with the same module that need to be uniquely identified.
+	 */
+	private final String requestId;
 
 	private final String module;
 
 	private final Map<String, String> arguments;
 
-	public ModuleLaunchRequest(String module, Map<String, String> arguments) {
+	public ModuleLaunchRequest(String requestId, String module, Map<String, String> arguments) {
+		this.requestId = requestId;
 		this.module = module;
 		this.arguments = arguments != null ? new HashMap<>(arguments) : new HashMap<String, String>();
+	}
+
+	public String getRequestId() {
+		return requestId;
 	}
 
 	public String getModule() {

--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLaunchRequest.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLaunchRequest.java
@@ -29,7 +29,7 @@ import java.util.Map;
 public class ModuleLaunchRequest {
 
 	/**
-	 * String that uniquely identifies Module launch request. This is useful when there are multiple requests
+	 * String that uniquely identifies each module launch request. This is useful when there are multiple requests
 	 * with the same module that need to be uniquely identified.
 	 */
 	private final String requestId;

--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncher.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncher.java
@@ -220,7 +220,13 @@ public class ModuleLauncher {
 		Collections.reverse(reversed);
 		for (ModuleLaunchRequest moduleLaunchRequest : reversed) {
 			String module = moduleLaunchRequest.getModule();
-			moduleLaunchRequest.addArgument("spring.jmx.default-domain", module.replace("/", ".").replace(":", "."));
+//			// TODO: this approach assumes server.port is always available for the module. This is currently true
+//			// as we always launch module with embedded servlet container
+//			String serverPort = moduleLaunchRequest.getArguments().get("server.port");
+//			moduleLaunchRequest.addArgument("spring.jmx.default-domain", module.replace("/", ".").replace(":", ".")
+//					.concat("." + serverPort));
+			moduleLaunchRequest.addArgument("spring.jmx.default-domain", moduleLaunchRequest.getRequestId());
+			moduleLaunchRequest.addArgument("endpoints.jmx.unique-names", "true");
 			Map<String, String> arguments = moduleLaunchRequest.getArguments();
 			if (arguments.containsKey(INCLUDE_DEPENDENCIES_ARG) || arguments.containsKey(EXCLUDE_DEPENDENCIES_ARG)) {
 				String includes = arguments.get(INCLUDE_DEPENDENCIES_ARG);

--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncherRunner.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncherRunner.java
@@ -17,7 +17,6 @@
 package org.springframework.cloud.stream.module.launcher;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -91,7 +90,7 @@ public class ModuleLauncherRunner implements CommandLineRunner {
 					moduleArguments.putAll(moduleSpecificArgs);
 				}
 			}
-			ModuleLaunchRequest moduleLaunchRequest = new ModuleLaunchRequest(modules[i], moduleArguments);
+			ModuleLaunchRequest moduleLaunchRequest = new ModuleLaunchRequest(modules[i], modules[i], moduleArguments);
 			requests.add(moduleLaunchRequest);
 		}
 		return requests;


### PR DESCRIPTION
 - Add `requestId` to ModuleLaunchRequest which uniquely identifies the ModuleLaunchRequest
   - This is useful when there are multiple module launch requests for the same module and avoid any naming clash with the module launch requests
 - One other possible solution is to append `server.port` to the ModuleLaunchRequest
   - Since s-c-s module always has an embedded servlet container this might be a simple fix. But having unique requestId would make it easy to understand (for instance we can have streamName + moduleLabel as the requestId)