### PR TITLE
Remove explicit setting of jmx domain name

### DIFF
--- a/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncher.java
+++ b/spring-cloud-stream-module-launcher/src/main/java/org/springframework/cloud/stream/module/launcher/ModuleLauncher.java
@@ -220,7 +220,6 @@ public class ModuleLauncher {
 		Collections.reverse(reversed);
 		for (ModuleLaunchRequest moduleLaunchRequest : reversed) {
 			String module = moduleLaunchRequest.getModule();
-			moduleLaunchRequest.addArgument("spring.jmx.default-domain", module.replace("/", ".").replace(":", "."));
 			Map<String, String> arguments = moduleLaunchRequest.getArguments();
 			if (arguments.containsKey(INCLUDE_DEPENDENCIES_ARG) || arguments.containsKey(EXCLUDE_DEPENDENCIES_ARG)) {
 				String includes = arguments.get(INCLUDE_DEPENDENCIES_ARG);


### PR DESCRIPTION
 - It is assumed to be the responsibility of the user to specify the appropriate jmx domain name for the modules (either via s-c-dataflow or via module launcher)