### PR TITLE
XD-3651 Fix handling of numeric, boolean and null values

### DIFF
--- a/spring-cloud-stream-tuple/src/main/java/org/springframework/cloud/stream/tuple/JsonNodeToTupleConverter.java
+++ b/spring-cloud-stream-tuple/src/main/java/org/springframework/cloud/stream/tuple/JsonNodeToTupleConverter.java
@@ -45,6 +45,15 @@ public class JsonNodeToTupleConverter implements Converter<JsonNode, Tuple> {
 				else if (node.isArray()) {
 					builder.addEntry(name, nodeToList(node));
 				}
+				else if (node.isNull()) {
+					builder.addEntry(name, null);
+				}
+				else if (node.isBoolean()) {
+					builder.addEntry(name, node.booleanValue());
+				}
+				else if (node.isNumber()) {
+					builder.addEntry(name, node.numberValue());
+				}
 				else {
 					builder.addEntry(name, node.asText());
 				}
@@ -65,6 +74,15 @@ public class JsonNodeToTupleConverter implements Converter<JsonNode, Tuple> {
 			}
 			else if (item.isArray()) {
 				list.add(nodeToList(item));
+			}
+			else if (node.isNull()) {
+				list.add(null);
+			}
+			else if (node.isBoolean()) {
+				list.add(item.booleanValue());
+			}
+			else if (node.isNumber()) {
+				list.add(item.numberValue());
 			}
 			else {
 				list.add(item.asText());

--- a/spring-cloud-stream-tuple/src/main/java/org/springframework/cloud/stream/tuple/JsonStringToTupleConverter.java
+++ b/spring-cloud-stream-tuple/src/main/java/org/springframework/cloud/stream/tuple/JsonStringToTupleConverter.java
@@ -52,6 +52,15 @@ public class JsonStringToTupleConverter implements Converter<String, Tuple> {
 				else if (node.isArray()) {
 					builder.addEntry(name, nodeToList(node));
 				}
+				else if (node.isNull()) {
+					builder.addEntry(name, null);
+				}
+				else if (node.isBoolean()) {
+					builder.addEntry(name, node.booleanValue());
+				}
+				else if (node.isNumber()) {
+					builder.addEntry(name, node.numberValue());
+				}
 				else {
 					builder.addEntry(name, node.asText());
 				}
@@ -72,6 +81,15 @@ public class JsonStringToTupleConverter implements Converter<String, Tuple> {
 			}
 			else if (item.isArray()) {
 				list.add(nodeToList(item));
+			}
+			else if (node.isNull()) {
+				list.add(null);
+			}
+			else if (node.isBoolean()) {
+				list.add(item.booleanValue());
+			}
+			else if (node.isNumber()) {
+				list.add(item.numberValue());
 			}
 			else {
 				list.add(item.asText());

--- a/spring-cloud-stream-tuple/src/main/java/org/springframework/cloud/stream/tuple/TupleToJsonStringConverter.java
+++ b/spring-cloud-stream-tuple/src/main/java/org/springframework/cloud/stream/tuple/TupleToJsonStringConverter.java
@@ -49,7 +49,10 @@ public class TupleToJsonStringConverter implements Converter<Tuple, String> {
 		for (int i = 0; i < source.size(); i++) {
 			Object value = source.getValues().get(i);
 			String name = source.getFieldNames().get(i);
-			if (value != null) {
+			if (value == null) {
+				root.putNull(name);
+			}
+			else {
 				if (value instanceof Tuple) {
 					root.putPOJO(name, toObjectNode((Tuple) value));
 				}


### PR DESCRIPTION
- this applies to the Json-Tuple conversions

- we need to be able to support docs like this: {"id": 19, "name": "Anna", "age": null} without loosing the null or the numeric type of the id