### PR TITLE
GH-196 Add message history tracking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
 		<module>spring-cloud-stream-module-launcher</module>
 		<module>spring-cloud-stream-test-support</module>
 		<module>spring-cloud-stream-test-support-internal</module>
+		<module>spring-cloud-stream-integration-tests</module>
 		<module>spring-cloud-stream-configuration-metadata</module>
 		<module>spring-cloud-stream-docs</module>
 	</modules>

--- a/spring-cloud-stream-integration-tests/pom.xml
+++ b/spring-cloud-stream-integration-tests/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>spring-cloud-stream-integration-tests</artifactId>
+	<packaging>jar</packaging>
+	<name>spring-cloud-stream-integration-tests</name>
+	<description>Integration tests for Spring Cloud Stream</description>
+
+	<parent>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-stream-parent</artifactId>
+		<version>1.0.0.BUILD-SNAPSHOT</version>
+	</parent>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-stream</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-stream-redis</artifactId>
+			<version>1.0.0.BUILD-SNAPSHOT</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-stream-test-support-internal</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/MessageChannelConfigurerTests.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/MessageChannelConfigurerTests.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.config;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.cloud.stream.annotation.Bindings;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.binder.redis.config.RedisMessageChannelBinderConfiguration;
+import org.springframework.cloud.stream.messaging.Sink;
+import org.springframework.cloud.stream.messaging.Source;
+import org.springframework.cloud.stream.test.junit.redis.RedisTestSupport;
+import org.springframework.cloud.stream.tuple.Tuple;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.MessagingException;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.util.Assert;
+
+/**
+ * @author Ilayaperumal Gopinathan
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration({MessageChannelConfigurerTests.TestSource.class,
+		MessageChannelConfigurerTests.TestSink.class})
+public class MessageChannelConfigurerTests {
+
+	@Rule
+	public RedisTestSupport redisTestSupport = new RedisTestSupport();
+
+	@Autowired @Bindings(TestSink.class)
+	private Sink testSink;
+
+	@Autowired
+	@Bindings(TestSource.class)
+	private Source testSource;
+
+	@Test
+	public void testContentTypeConfigurer() throws Exception {
+		final CountDownLatch latch = new CountDownLatch(1);
+		testSink.input().subscribe(new MessageHandler() {
+			@Override
+			public void handleMessage(Message<?> message) throws MessagingException {
+				Assert.isTrue(message.getPayload() instanceof Tuple);
+				Assert.isTrue(((Tuple)message.getPayload()).getFieldNames().get(0).equals("message"));
+				Assert.isTrue(((Tuple) message.getPayload()).getValue(0).equals("Hi"));
+				latch.countDown();
+			}
+		});
+		testSource.output().send(MessageBuilder.withPayload("{\"message\":\"Hi\"}").build());
+		latch.await(10, TimeUnit.SECONDS);
+	}
+
+	@Test
+	public void testHistoryTrackerConfigurer() throws Exception {
+		final CountDownLatch latch = new CountDownLatch(1);
+		testSink.input().subscribe(new MessageHandler() {
+			@Override
+			public void handleMessage(Message<?> message) throws MessagingException {
+				Assert.isTrue(message.getHeaders().containsKey("SPRING_CLOUD_STREAM_HISTORY"),
+						"Message header should have tracking history info");
+				BindingProperties inputBindingProps = (BindingProperties) ((Map)((List) message.getHeaders()
+						.get("SPRING_CLOUD_STREAM_HISTORY")).get(0)).get("input");
+				Assert.isTrue(inputBindingProps.getDestination().equals("configure"));
+				Assert.isTrue(inputBindingProps.getTrackHistory());
+				BindingProperties outputBindingProps = (BindingProperties) ((Map)((List) message.getHeaders()
+						.get("SPRING_CLOUD_STREAM_HISTORY")).get(0)).get("output");;
+				Assert.isTrue(outputBindingProps.getDestination().equals("configure"));
+				Assert.isTrue(!outputBindingProps.getTrackHistory());
+				latch.countDown();
+			}
+		});
+		testSource.output().send(MessageBuilder.withPayload("{\"test\":\"value\"}").build());
+		latch.await(10, TimeUnit.SECONDS);
+	}
+
+	@EnableBinding(Source.class)
+	@EnableAutoConfiguration
+	@Import(RedisMessageChannelBinderConfiguration.class)
+	@PropertySource("classpath:/org/springframework/cloud/stream/config/source-channel-configurers.properties")
+	public static class TestSource {
+
+	}
+
+	@EnableBinding(Sink.class)
+	@EnableAutoConfiguration
+	@Import(RedisMessageChannelBinderConfiguration.class)
+	@PropertySource("classpath:/org/springframework/cloud/stream/config/sink-channel-configurers.properties")
+	public static class TestSink {
+
+	}
+}
+

--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/MessageChannelConfigurerTests.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/MessageChannelConfigurerTests.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.cloud.stream.config;
 
+import static org.junit.Assert.assertTrue;
+
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -30,6 +32,7 @@ import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.cloud.stream.annotation.Bindings;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.binder.redis.config.RedisMessageChannelBinderConfiguration;
+import org.springframework.cloud.stream.messaging.Processor;
 import org.springframework.cloud.stream.messaging.Sink;
 import org.springframework.cloud.stream.messaging.Source;
 import org.springframework.cloud.stream.test.junit.redis.RedisTestSupport;
@@ -41,13 +44,13 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessagingException;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.util.Assert;
 
 /**
  * @author Ilayaperumal Gopinathan
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration({MessageChannelConfigurerTests.TestSource.class,
+		MessageChannelConfigurerTests.TestProcessor.class,
 		MessageChannelConfigurerTests.TestSink.class})
 public class MessageChannelConfigurerTests {
 
@@ -61,43 +64,87 @@ public class MessageChannelConfigurerTests {
 	@Bindings(TestSource.class)
 	private Source testSource;
 
+	@Autowired
+	@Bindings(TestProcessor.class)
+	private Processor testProcessor;
+
 	@Test
 	public void testContentTypeConfigurer() throws Exception {
 		final CountDownLatch latch = new CountDownLatch(1);
-		testSink.input().subscribe(new MessageHandler() {
+		MessageHandler messageHandler = new MessageHandler() {
 			@Override
 			public void handleMessage(Message<?> message) throws MessagingException {
-				Assert.isTrue(message.getPayload() instanceof Tuple);
-				Assert.isTrue(((Tuple)message.getPayload()).getFieldNames().get(0).equals("message"));
-				Assert.isTrue(((Tuple) message.getPayload()).getValue(0).equals("Hi"));
+				assertTrue(message.getPayload() instanceof Tuple);
+				assertTrue(((Tuple) message.getPayload()).getFieldNames().get(0).equals("message"));
+				assertTrue(((Tuple) message.getPayload()).getValue(0).equals("Hi"));
 				latch.countDown();
 			}
-		});
+		};
+		testSink.input().subscribe(messageHandler);
 		testSource.output().send(MessageBuilder.withPayload("{\"message\":\"Hi\"}").build());
 		latch.await(10, TimeUnit.SECONDS);
+		assertTrue(latch.getCount() == 0);
+		testSink.input().unsubscribe(messageHandler);
 	}
 
 	@Test
 	public void testHistoryTrackerConfigurer() throws Exception {
-		final CountDownLatch latch = new CountDownLatch(1);
-		testSink.input().subscribe(new MessageHandler() {
+		final CountDownLatch latch1 = new CountDownLatch(1);
+		MessageHandler messageHandler1 = new MessageHandler() {
 			@Override
 			public void handleMessage(Message<?> message) throws MessagingException {
-				Assert.isTrue(message.getHeaders().containsKey("SPRING_CLOUD_STREAM_HISTORY"),
-						"Message header should have tracking history info");
-				BindingProperties inputBindingProps = (BindingProperties) ((Map)((List) message.getHeaders()
-						.get("SPRING_CLOUD_STREAM_HISTORY")).get(0)).get("input");
-				Assert.isTrue(inputBindingProps.getDestination().equals("configure"));
-				Assert.isTrue(inputBindingProps.getTrackHistory());
-				BindingProperties outputBindingProps = (BindingProperties) ((Map)((List) message.getHeaders()
-						.get("SPRING_CLOUD_STREAM_HISTORY")).get(0)).get("output");;
-				Assert.isTrue(outputBindingProps.getDestination().equals("configure"));
-				Assert.isTrue(!outputBindingProps.getTrackHistory());
-				latch.countDown();
+				assertTrue("Message header should have tracking history info",
+						message.getHeaders().containsKey("SPRING_CLOUD_STREAM_HISTORY"));
+				Map<String, String> headerValue = ((Map) ((List) message.getHeaders()
+						.get("SPRING_CLOUD_STREAM_HISTORY")).get(0));
+				String inputBindingProps = (String) headerValue.get("input");
+				assertTrue(inputBindingProps.contains("destination=configure"));
+				assertTrue(inputBindingProps.contains("trackHistory=true"));
+				assertTrue(headerValue.get("instanceIndex").equals("0"));
+				assertTrue(headerValue.get("instanceCount").equals("1"));
+				assertTrue(headerValue.get("producer.nextModuleCount").equals("1"));
+				assertTrue(headerValue.get("consumer.concurrency").equals("1"));
+				String outputBindingProps = (String) ((Map) ((List) message.getHeaders()
+						.get("SPRING_CLOUD_STREAM_HISTORY")).get(0)).get("output");
+				;
+				assertTrue(outputBindingProps.contains("destination=configure"));
+				assertTrue(outputBindingProps.contains("trackHistory=true"));
+				latch1.countDown();
 			}
-		});
+		};
+		testProcessor.input().subscribe(messageHandler1);
+		final CountDownLatch latch2 = new CountDownLatch(1);
+		MessageHandler messageHandler2 = new MessageHandler() {
+			@Override
+			public void handleMessage(Message<?> message) throws MessagingException {
+				assertTrue("Message header should have tracking history info",
+						message.getHeaders().containsKey("SPRING_CLOUD_STREAM_HISTORY"));
+				Map<String, String> headerValue = ((Map) ((List) message.getHeaders()
+						.get("SPRING_CLOUD_STREAM_HISTORY")).get(0));
+				String inputBindingProps = (String) headerValue.get("input");
+				assertTrue(inputBindingProps.contains("destination=configure"));
+				assertTrue(inputBindingProps.contains("trackHistory=true"));
+				assertTrue(headerValue.get("instanceIndex").equals("0"));
+				assertTrue(headerValue.get("instanceCount").equals("1"));
+				assertTrue(headerValue.get("producer.nextModuleCount").equals("1"));
+				assertTrue(headerValue.get("consumer.concurrency").equals("1"));
+				String outputBindingProps = (String) ((Map) ((List) message.getHeaders()
+						.get("SPRING_CLOUD_STREAM_HISTORY")).get(0)).get("output");
+				;
+				assertTrue(outputBindingProps.contains("destination=configure"));
+				assertTrue(outputBindingProps.contains("trackHistory=true"));
+				latch2.countDown();
+			}
+		};
+		testSink.input().subscribe(messageHandler2);
 		testSource.output().send(MessageBuilder.withPayload("{\"test\":\"value\"}").build());
-		latch.await(10, TimeUnit.SECONDS);
+		testProcessor.output().send(MessageBuilder.withPayload("{\"test\":\"value2\"}").build());
+		latch1.await(10, TimeUnit.SECONDS);
+		assertTrue(latch1.getCount() == 0);
+		latch2.await(10, TimeUnit.SECONDS);
+		assertTrue(latch2.getCount() == 0);
+		testProcessor.input().unsubscribe(messageHandler1);
+		testSink.input().unsubscribe(messageHandler2);
 	}
 
 	@EnableBinding(Source.class)
@@ -113,6 +160,14 @@ public class MessageChannelConfigurerTests {
 	@Import(RedisMessageChannelBinderConfiguration.class)
 	@PropertySource("classpath:/org/springframework/cloud/stream/config/sink-channel-configurers.properties")
 	public static class TestSink {
+
+	}
+
+	@EnableBinding(Processor.class)
+	@EnableAutoConfiguration
+	@Import(RedisMessageChannelBinderConfiguration.class)
+	@PropertySource("classpath:/org/springframework/cloud/stream/config/processor-channel-configurers.properties")
+	public static class TestProcessor {
 
 	}
 }

--- a/spring-cloud-stream-integration-tests/src/test/resources/org/springframework/cloud/stream/config/processor-channel-configurers.properties
+++ b/spring-cloud-stream-integration-tests/src/test/resources/org/springframework/cloud/stream/config/processor-channel-configurers.properties
@@ -1,0 +1,8 @@
+spring.cloud.stream.bindings.input.destination=configure
+spring.cloud.stream.bindings.input.contentType=text/plain
+spring.cloud.stream.bindings.input.trackHistory=true
+spring.cloud.stream.consumerProperties.concurrency=1
+spring.cloud.stream.bindings.output.destination=configure
+spring.cloud.stream.bindings.output.contentType=application/json
+spring.cloud.stream.bindings.output.trackHistory=true
+spring.cloud.stream.producerProperties.nextModuleCount=1

--- a/spring-cloud-stream-integration-tests/src/test/resources/org/springframework/cloud/stream/config/processor-channel-configurers.properties
+++ b/spring-cloud-stream-integration-tests/src/test/resources/org/springframework/cloud/stream/config/processor-channel-configurers.properties
@@ -1,8 +1,0 @@
-spring.cloud.stream.bindings.input.destination=configure
-spring.cloud.stream.bindings.input.contentType=text/plain
-spring.cloud.stream.bindings.input.trackHistory=true
-spring.cloud.stream.consumerProperties.concurrency=1
-spring.cloud.stream.bindings.output.destination=configure
-spring.cloud.stream.bindings.output.contentType=application/json
-spring.cloud.stream.bindings.output.trackHistory=true
-spring.cloud.stream.producerProperties.nextModuleCount=1

--- a/spring-cloud-stream-integration-tests/src/test/resources/org/springframework/cloud/stream/config/sink-channel-configurers.properties
+++ b/spring-cloud-stream-integration-tests/src/test/resources/org/springframework/cloud/stream/config/sink-channel-configurers.properties
@@ -1,0 +1,3 @@
+spring.cloud.stream.bindings.input.destination=configure
+spring.cloud.stream.bindings.input.contentType=application/x-spring-tuple
+spring.cloud.stream.bindings.input.trackHistory=true

--- a/spring-cloud-stream-integration-tests/src/test/resources/org/springframework/cloud/stream/config/sink-channel-configurers.properties
+++ b/spring-cloud-stream-integration-tests/src/test/resources/org/springframework/cloud/stream/config/sink-channel-configurers.properties
@@ -1,3 +1,4 @@
-spring.cloud.stream.bindings.input.destination=configure
+spring.cloud.stream.bindings.input.destination=configure1
 spring.cloud.stream.bindings.input.contentType=application/x-spring-tuple
 spring.cloud.stream.bindings.input.trackHistory=true
+spring.cloud.stream.consumerProperties.concurrency=1

--- a/spring-cloud-stream-integration-tests/src/test/resources/org/springframework/cloud/stream/config/source-channel-configurers.properties
+++ b/spring-cloud-stream-integration-tests/src/test/resources/org/springframework/cloud/stream/config/source-channel-configurers.properties
@@ -1,0 +1,2 @@
+spring.cloud.stream.bindings.output.destination=configure
+spring.cloud.stream.bindings.output.contentType=application/json

--- a/spring-cloud-stream-integration-tests/src/test/resources/org/springframework/cloud/stream/config/source-channel-configurers.properties
+++ b/spring-cloud-stream-integration-tests/src/test/resources/org/springframework/cloud/stream/config/source-channel-configurers.properties
@@ -1,2 +1,3 @@
-spring.cloud.stream.bindings.output.destination=configure
+spring.cloud.stream.bindings.output.destination=configure1
+spring.cloud.stream.producerProperties.nextModuleCount=1
 spring.cloud.stream.bindings.output.contentType=application/json

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/CompositeMessageChannelConfigurer.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/CompositeMessageChannelConfigurer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.binding;
+
+import java.util.List;
+
+import org.springframework.messaging.MessageChannel;
+
+/**
+ * {@link MessageChannelConfigurer} that composes all the message channel configurers.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+public class CompositeMessageChannelConfigurer implements MessageChannelConfigurer {
+
+	private final List<MessageChannelConfigurer> messageChannelConfigurers;
+
+	public CompositeMessageChannelConfigurer(List<MessageChannelConfigurer> messageChannelConfigurers) {
+		this.messageChannelConfigurers = messageChannelConfigurers;
+	}
+
+	@Override
+	public void configureMessageChannel(MessageChannel messageChannel, String channelName) {
+		for (MessageChannelConfigurer messageChannelConfigurer : messageChannelConfigurers) {
+			messageChannelConfigurer.configureMessageChannel(messageChannel, channelName);
+		}
+	}
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/DefaultBindableChannelFactory.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/DefaultBindableChannelFactory.java
@@ -29,23 +29,23 @@ import org.springframework.messaging.SubscribableChannel;
  */
 public class DefaultBindableChannelFactory implements BindableChannelFactory {
 
-	private final MessageConverterConfigurer messageConverterConfigurer;
+	private final MessageChannelConfigurer messageChannelConfigurer;
 
-	public DefaultBindableChannelFactory(MessageConverterConfigurer messageConverterConfigurer) {
-		this.messageConverterConfigurer = messageConverterConfigurer;
+	public DefaultBindableChannelFactory(MessageChannelConfigurer messageChannelConfigurer) {
+		this.messageChannelConfigurer = messageChannelConfigurer;
 	}
 
 	@Override
 	public PollableChannel createPollableChannel(String name) {
 		PollableChannel pollableChannel = new QueueChannel();
-		messageConverterConfigurer.configureMessageConverters(pollableChannel, name);
+		messageChannelConfigurer.configureMessageChannel(pollableChannel, name);
 		return pollableChannel;
 	}
 
 	@Override
 	public SubscribableChannel createSubscribableChannel(String name) {
 		SubscribableChannel subscribableChannel = new DirectChannel();
-		messageConverterConfigurer.configureMessageConverters(subscribableChannel, name);
+		messageChannelConfigurer.configureMessageChannel(subscribableChannel, name);
 		return subscribableChannel;
 	}
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/MessageChannelConfigurer.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/MessageChannelConfigurer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.binding;
+
+import org.springframework.messaging.MessageChannel;
+
+/**
+ * Interface to be implemented by the classes that configure the {@link Bindable} message channels.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+public interface MessageChannelConfigurer {
+
+	/**
+	 * Configure the given message channel.
+	 *
+	 * @param messageChannel the message channel
+	 * @param channelName name of the message channel
+	 */
+	void configureMessageChannel(MessageChannel messageChannel, String channelName);
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/MessageConverterConfigurer.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/MessageConverterConfigurer.java
@@ -48,7 +48,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Ilayaperumal Gopinathan
  */
-public class MessageConverterConfigurer implements BeanFactoryAware, InitializingBean {
+public class MessageConverterConfigurer implements MessageChannelConfigurer, BeanFactoryAware, InitializingBean {
 
 	private ConfigurableListableBeanFactory beanFactory;
 
@@ -87,7 +87,8 @@ public class MessageConverterConfigurer implements BeanFactoryAware, Initializin
 	 * @param channel message channel to set the data-type and message converters
 	 * @param channelName the channel name
 	 */
-	 void configureMessageConverters(MessageChannel channel, String channelName) {
+	@Override
+	public void configureMessageChannel(MessageChannel channel, String channelName) {
 		Assert.isAssignable(AbstractMessageChannel.class, channel.getClass());
 		AbstractMessageChannel messageChannel = (AbstractMessageChannel) channel;
 		BindingProperties bindingProperties = this.channelBindingServiceProperties.getBindings().get(channelName);

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/MessageHistoryTrackerConfigurer.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/MessageHistoryTrackerConfigurer.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.binding;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.stream.config.BindingProperties;
+import org.springframework.cloud.stream.config.ChannelBindingServiceProperties;
+import org.springframework.integration.channel.ChannelInterceptorAware;
+import org.springframework.integration.support.MessageBuilderFactory;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.support.ChannelInterceptorAdapter;
+
+/**
+ * Class that is responsible for configuring the message channel to enable message track history.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+public class MessageHistoryTrackerConfigurer implements MessageChannelConfigurer {
+
+	public static final String HISTORY_TRACKING_HEADER = "SPRING_CLOUD_STREAM_HISTORY";
+
+	private final ChannelBindingServiceProperties channelBindingServiceProperties;
+
+	@Autowired
+	MessageBuilderFactory messageBuilderFactory;
+
+	public MessageHistoryTrackerConfigurer(ChannelBindingServiceProperties channelBindingServiceProperties) {
+		this.channelBindingServiceProperties = channelBindingServiceProperties;
+	}
+
+	@Override
+	public void configureMessageChannel(MessageChannel messageChannel, String channelName) {
+		BindingProperties bindingProperties = channelBindingServiceProperties.getBindings().get(channelName);
+		if (bindingProperties != null && Boolean.TRUE.equals(bindingProperties.getTrackHistory())) {
+			if (messageChannel instanceof ChannelInterceptorAware) {
+				((ChannelInterceptorAware) messageChannel).addInterceptor(new ChannelInterceptorAdapter() {
+
+					@Override
+					public Message<?> preSend(Message<?> message, MessageChannel channel) {
+						@SuppressWarnings("unchecked")
+						Collection<Map<String, Object>> history =
+								(Collection<Map<String, Object>>) message.getHeaders().get(HISTORY_TRACKING_HEADER);
+						if (history == null) {
+							history = new ArrayList<>(1);
+						}
+						else {
+							history = new ArrayList<>(history);
+						}
+						Map<String, Object> map = new LinkedHashMap<String, Object>();
+						map.put("thread", Thread.currentThread().getName());
+						history.add(channelBindingServiceProperties.asMapProperties());
+						Message<?> out = messageBuilderFactory
+								.fromMessage(message)
+								.setHeader(HISTORY_TRACKING_HEADER, history)
+								.build();
+						map.put("timestamp", out.getHeaders().getTimestamp());
+						return out;
+					}
+				});
+			}
+		}
+	}
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingProperties.java
@@ -51,6 +51,8 @@ public class BindingProperties {
 
 	private String binder;
 
+	private boolean trackHistory;
+
 	public String getDestination() {
 		return this.destination;
 	}
@@ -123,6 +125,7 @@ public class BindingProperties {
 		this.contentType = contentType;
 	}
 
+
 	public String getBinder() {
 		return binder;
 	}
@@ -130,4 +133,13 @@ public class BindingProperties {
 	public void setBinder(String binder) {
 		this.binder = binder;
 	}
+
+	public Boolean getTrackHistory() {
+		return this.trackHistory;
+	}
+
+	public void setTrackHistory(boolean trackHistory) {
+		this.trackHistory = trackHistory;
+	}
+
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingProperties.java
@@ -31,6 +31,8 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 @JsonInclude(value = Include.NON_DEFAULT)
 public class BindingProperties {
 
+	private static final String COMMA = ",";
+
 	private String destination;
 
 	private boolean partitioned = false;
@@ -140,6 +142,39 @@ public class BindingProperties {
 
 	public void setTrackHistory(boolean trackHistory) {
 		this.trackHistory = trackHistory;
+	}
+
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append("destination=" + destination);
+		sb.append(COMMA);
+		sb.append("group=" + group);
+		sb.append(COMMA);
+		sb.append("contentType="+ contentType);
+		sb.append(COMMA);
+		sb.append("binder="+ binder);
+		sb.append(COMMA);
+		sb.append("trackHistory=" + trackHistory);
+		sb.append(COMMA);
+		sb.append("partitioned=" + partitioned);
+		sb.append(COMMA);
+		if (this.partitionKeyExpression != null && !this.partitionKeyExpression.isEmpty()) {
+			sb.append("partitionKeyExpression=" + partitionKeyExpression);
+			sb.append(COMMA);
+		}
+		if (this.partitionKeyExtractorClass != null && !this.partitionKeyExtractorClass.isEmpty()) {
+			sb.append("partitionKeyExtractorClass=" + partitionKeyExtractorClass);
+			sb.append(COMMA);
+		}
+		if (this.partitionSelectorClass != null && !this.partitionSelectorClass.isEmpty()) {
+			sb.append("partitionSelectorClass=" + partitionSelectorClass);
+			sb.append(COMMA);
+		}
+		if (this.partitionSelectorClass != null && !this.partitionSelectorClass.isEmpty()) {
+			sb.append("partitionSelectorExpression=" + partitionSelectorExpression);
+		}
+		sb.deleteCharAt(sb.lastIndexOf(COMMA));
+		return "BinderProperties{" + sb.toString() + "}";
 	}
 
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceConfiguration.java
@@ -79,7 +79,7 @@ public class ChannelBindingServiceConfiguration {
 	}
 
 	@Bean
-	MessageConverterConfigurer messageConverterConfigurer
+	public MessageConverterConfigurer messageConverterConfigurer
 			(ChannelBindingServiceProperties channelBindingServiceProperties) {
 		return new MessageConverterConfigurer(channelBindingServiceProperties);
 	}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceProperties.java
@@ -21,12 +21,12 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.TreeMap;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.util.StringUtils;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 /**
  * @author Dave Syer
@@ -208,14 +208,16 @@ public class ChannelBindingServiceProperties {
 		Map<String, Object> properties = new HashMap<>();
 		properties.put("instanceIndex", String.valueOf(getInstanceIndex()));
 		properties.put("instanceCount", String.valueOf(getInstanceCount()));
-		for (String name : getConsumerProperties().stringPropertyNames()) {
-			properties.put(name, getConsumerProperties());
+		Properties consumerProperties = getConsumerProperties();
+		for (String name : consumerProperties.stringPropertyNames()) {
+			properties.put("consumer." + name, consumerProperties.getProperty(name));
 		}
-		for (String name : getProducerProperties().stringPropertyNames()) {
-			properties.put(name, getProducerProperties());
+		Properties producerProperties = getProducerProperties();
+		for (String name : producerProperties.stringPropertyNames()) {
+			properties.put("producer." + name, producerProperties.getProperty(name));
 		}
 		for (Map.Entry<String, BindingProperties> entry : getBindings().entrySet()) {
-			properties.put(entry.getKey(), entry.getValue());
+			properties.put(entry.getKey(), entry.getValue().toString());
 		}
 		return properties;
 	}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceProperties.java
@@ -127,8 +127,8 @@ public class ChannelBindingServiceProperties {
 	public boolean isPartitionedProducer(String channelName) {
 		BindingProperties bindingProperties = bindings.get(channelName);
 		return bindingProperties != null &&
-					(StringUtils.hasText(bindingProperties.getPartitionKeyExpression())
-					|| StringUtils.hasText(bindingProperties.getPartitionKeyExtractorClass()));
+				(StringUtils.hasText(bindingProperties.getPartitionKeyExpression())
+						|| StringUtils.hasText(bindingProperties.getPartitionKeyExtractorClass()));
 
 	}
 
@@ -198,6 +198,26 @@ public class ChannelBindingServiceProperties {
 			return null;
 		}
 		return bindings.get(channelName).getBinder();
+	}
+
+	/**
+	 * Return configuration properties as Map.
+	 * @return map of channel binding configuration properties.
+	 */
+	public Map<String, Object> asMapProperties() {
+		Map<String, Object> properties = new HashMap<>();
+		properties.put("instanceIndex", String.valueOf(getInstanceIndex()));
+		properties.put("instanceCount", String.valueOf(getInstanceCount()));
+		for (String name : getConsumerProperties().stringPropertyNames()) {
+			properties.put(name, getConsumerProperties());
+		}
+		for (String name : getProducerProperties().stringPropertyNames()) {
+			properties.put(name, getProducerProperties());
+		}
+		for (Map.Entry<String, BindingProperties> entry : getBindings().entrySet()) {
+			properties.put(entry.getKey(), entry.getValue());
+		}
+		return properties;
 	}
 
 }


### PR DESCRIPTION
  - Add `MessageChannelConfigurer` that any class that configures the message channel would implement
   - Have `message-converter` and `message-history-tracking` configurer implement this interface
  - Autowire all available configurers and use them to configure the message channel
  - For the message history tracking
    - add `channel-binding` properties as part of message header along with `timestamp`

This resolves spring-cloud/spring-cloud-stream#196