### PR TITLE
Remove autoconfiguration for binders

### DIFF
--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaMessageChannelBinderConfiguration.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaMessageChannelBinderConfiguration.java
@@ -17,11 +17,14 @@
 package org.springframework.cloud.stream.binder.kafka.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.binder.kafka.KafkaMessageChannelBinder;
+import org.springframework.cloud.stream.config.codec.kryo.KryoCodecAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.integration.codec.Codec;
 import org.springframework.integration.kafka.support.ZookeeperConnect;
 import org.springframework.util.ObjectUtils;
@@ -34,6 +37,7 @@ import org.springframework.util.StringUtils;
  */
 @Configuration
 @EnableConfigurationProperties(KafkaBinderConfigurationProperties.class)
+@Import({KryoCodecAutoConfiguration.class, PropertyPlaceholderAutoConfiguration.class})
 @ConfigurationProperties(prefix = "spring.cloud.stream.binder.kafka")
 public class KafkaMessageChannelBinderConfiguration {
 

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitMessageChannelBinderConfiguration.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitMessageChannelBinderConfiguration.java
@@ -26,7 +26,6 @@ import org.springframework.amqp.support.postprocessor.DelegatingDecompressingPos
 import org.springframework.amqp.support.postprocessor.GZipPostProcessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
-import org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.binder.rabbit.ConnectionFactorySettings;
 import org.springframework.cloud.stream.binder.rabbit.RabbitMessageChannelBinder;
@@ -37,7 +36,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.integration.codec.Codec;
 
 @Configuration
-@Import({RabbitAutoConfiguration.class, PropertyPlaceholderAutoConfiguration.class, KryoCodecAutoConfiguration.class})
+@Import({PropertyPlaceholderAutoConfiguration.class, KryoCodecAutoConfiguration.class})
 @EnableConfigurationProperties({RabbitBinderConfigurationProperties.class})
 public class RabbitMessageChannelBinderConfiguration {
 

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitMessageChannelBinderConfiguration.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitMessageChannelBinderConfiguration.java
@@ -25,14 +25,19 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.support.postprocessor.DelegatingDecompressingPostProcessor;
 import org.springframework.amqp.support.postprocessor.GZipPostProcessor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.binder.rabbit.ConnectionFactorySettings;
 import org.springframework.cloud.stream.binder.rabbit.RabbitMessageChannelBinder;
+import org.springframework.cloud.stream.config.codec.kryo.KryoCodecAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.integration.codec.Codec;
 
 @Configuration
+@Import({RabbitAutoConfiguration.class, PropertyPlaceholderAutoConfiguration.class, KryoCodecAutoConfiguration.class})
 @EnableConfigurationProperties({RabbitBinderConfigurationProperties.class})
 public class RabbitMessageChannelBinderConfiguration {
 

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitServiceAutoConfiguration.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitServiceAutoConfiguration.java
@@ -61,4 +61,11 @@ public class RabbitServiceAutoConfiguration {
 			return cloud.getSingletonServiceConnector(ConnectionFactory.class, null);
 		}
 	}
+
+	@Configuration
+	@Profile("!cloud")
+	@Import(RabbitAutoConfiguration.class)
+	protected static class NoCloudConfig {
+
+	}
 }

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/src/main/java/org/springframework/cloud/stream/binder/redis/config/RedisMessageChannelBinderConfiguration.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/src/main/java/org/springframework/cloud/stream/binder/redis/config/RedisMessageChannelBinderConfiguration.java
@@ -34,7 +34,7 @@ import org.springframework.integration.codec.Codec;
  */
 @Configuration
 @EnableConfigurationProperties(RedisBinderConfigurationProperties.class)
-@Import({RedisAutoConfiguration.class, PropertyPlaceholderAutoConfiguration.class, KryoCodecAutoConfiguration.class})
+@Import({PropertyPlaceholderAutoConfiguration.class, KryoCodecAutoConfiguration.class})
 @ConfigurationProperties(prefix = "spring.cloud.stream.binder.redis")
 public class RedisMessageChannelBinderConfiguration {
 

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/src/main/java/org/springframework/cloud/stream/binder/redis/config/RedisMessageChannelBinderConfiguration.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/src/main/java/org/springframework/cloud/stream/binder/redis/config/RedisMessageChannelBinderConfiguration.java
@@ -17,11 +17,15 @@
 package org.springframework.cloud.stream.binder.redis.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.binder.redis.RedisMessageChannelBinder;
+import org.springframework.cloud.stream.config.codec.kryo.KryoCodecAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.integration.codec.Codec;
 
@@ -30,6 +34,7 @@ import org.springframework.integration.codec.Codec;
  */
 @Configuration
 @EnableConfigurationProperties(RedisBinderConfigurationProperties.class)
+@Import({RedisAutoConfiguration.class, PropertyPlaceholderAutoConfiguration.class, KryoCodecAutoConfiguration.class})
 @ConfigurationProperties(prefix = "spring.cloud.stream.binder.redis")
 public class RedisMessageChannelBinderConfiguration {
 

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/src/main/java/org/springframework/cloud/stream/binder/redis/config/RedisServiceAutoConfiguration.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/src/main/java/org/springframework/cloud/stream/binder/redis/config/RedisServiceAutoConfiguration.java
@@ -61,4 +61,9 @@ public class RedisServiceAutoConfiguration {
 		}
 	}
 
+	@Profile("!cloud")
+	@Import(RedisAutoConfiguration.class)
+	protected static class NoCloudConfig {
+	}
+
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
@@ -155,8 +155,6 @@ public class DefaultBinderFactory<T> implements BinderFactory<T>, DisposableBean
 	/**
 	 * Configuration class that enables autoconfiguration for the binders
 	 */
-	// TODO: Reconsider the use of autoconfiguration as part of binder configuration refactoring
-	@EnableAutoConfiguration
 	public static class SeedConfiguration {
 	}
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
@@ -23,7 +23,6 @@ import java.util.Properties;
 
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.boot.Banner.Mode;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.EnvironmentAware;
@@ -115,7 +114,6 @@ public class DefaultBinderFactory<T> implements BinderFactory<T>, DisposableBean
 			SpringApplicationBuilder springApplicationBuilder =
 					new SpringApplicationBuilder()
 							.sources(binderConfiguration.getBinderType().getConfigurationClasses())
-							.sources(SeedConfiguration.class)
 							.bannerMode(Mode.OFF)
 							.web(false);
 			ConfigurableApplicationContext binderProducingContext =
@@ -150,11 +148,5 @@ public class DefaultBinderFactory<T> implements BinderFactory<T>, DisposableBean
 		public ConfigurableApplicationContext getBinderContext() {
 			return binderContext;
 		}
-	}
-
-	/**
-	 * Configuration class that enables autoconfiguration for the binders
-	 */
-	public static class SeedConfiguration {
 	}
 }


### PR DESCRIPTION
Remove reliance on autoconfiguration for binders, preventing them to act on the main application's  dependencies.