### PR TITLE
Binders with default settings inherit from module's configuration

### DIFF
--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitServiceAutoConfiguration.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitServiceAutoConfiguration.java
@@ -66,6 +66,5 @@ public class RabbitServiceAutoConfiguration {
 	@Profile("!cloud")
 	@Import(RabbitAutoConfiguration.class)
 	protected static class NoCloudConfig {
-
 	}
 }

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/integration/RabbitBinderModuleTests.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/integration/RabbitBinderModuleTests.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.rabbit.integration;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.binder.Binder;
+import org.springframework.cloud.stream.binder.BinderFactory;
+import org.springframework.cloud.stream.binder.rabbit.RabbitMessageChannelBinder;
+import org.springframework.cloud.stream.messaging.Processor;
+import org.springframework.cloud.stream.test.junit.rabbit.RabbitTestSupport;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class RabbitBinderModuleTests {
+
+	@ClassRule
+	public static RabbitTestSupport rabbitTestSupport = new RabbitTestSupport();
+
+	private ConfigurableApplicationContext context = null;
+
+	public static final ConnectionFactory MOCK_CONNECTION_FACTORY = Mockito.mock(ConnectionFactory.class, Mockito.RETURNS_MOCKS);
+
+	@After
+	public void tearDown() {
+		if (context != null) {
+			context.close();
+			context = null;
+		}
+	}
+
+	@Test
+	public void testParentConnectionFactoryInheritedByDefault() {
+		context = SpringApplication.run(SimpleProcessor.class);
+		BinderFactory binderFactory = context.getBean(BinderFactory.class);
+		Binder binder = binderFactory.getBinder(null);
+		assertThat(binder, instanceOf(RabbitMessageChannelBinder.class));
+		DirectFieldAccessor binderFieldAccessor = new DirectFieldAccessor(binder);
+		ConnectionFactory binderConnectionFactory =
+				(ConnectionFactory) binderFieldAccessor.getPropertyValue("connectionFactory");
+		assertThat(binderConnectionFactory, instanceOf(CachingConnectionFactory.class));
+		ConnectionFactory connectionFactory = context.getBean(ConnectionFactory.class);
+		assertThat(binderConnectionFactory, is(connectionFactory));
+	}
+
+	@Test
+	public void testParentConnectionFactoryInheritedIfOverridden() {
+		context = new SpringApplication(SimpleProcessor.class, ConnectionFactoryConfiguration.class).run();
+		BinderFactory binderFactory = context.getBean(BinderFactory.class);
+		Binder binder = binderFactory.getBinder(null);
+		assertThat(binder, instanceOf(RabbitMessageChannelBinder.class));
+		DirectFieldAccessor binderFieldAccessor = new DirectFieldAccessor(binder);
+		ConnectionFactory binderConnectionFactory =
+				(ConnectionFactory) binderFieldAccessor.getPropertyValue("connectionFactory");
+		assertThat(binderConnectionFactory, is(MOCK_CONNECTION_FACTORY));
+		ConnectionFactory connectionFactory = context.getBean(ConnectionFactory.class);
+		assertThat(binderConnectionFactory, is(connectionFactory));
+	}
+
+	@Test
+	public void testParentConnectionFactoryNotInheritedByCustomizedBinders() {
+		List<String> params = new ArrayList<>();
+		params.add("--spring.cloud.stream.input.binder=custom");
+		params.add("--spring.cloud.stream.output.binder=custom");
+		params.add("--spring.cloud.stream.binders.custom.type=rabbit");
+		params.add("--spring.cloud.stream.binders.custom.environment.foo=bar");
+		context = SpringApplication.run(SimpleProcessor.class, params.toArray(new String[]{}));
+		BinderFactory binderFactory = context.getBean(BinderFactory.class);
+		Binder binder = binderFactory.getBinder(null);
+		assertThat(binder, instanceOf(RabbitMessageChannelBinder.class));
+		DirectFieldAccessor binderFieldAccessor = new DirectFieldAccessor(binder);
+		ConnectionFactory binderConnectionFactory =
+				(ConnectionFactory) binderFieldAccessor.getPropertyValue("connectionFactory");
+		ConnectionFactory connectionFactory = context.getBean(ConnectionFactory.class);
+		assertThat(binderConnectionFactory, not(is(connectionFactory)));
+	}
+
+	@EnableBinding(Processor.class)
+	@SpringBootApplication
+	public static class SimpleProcessor {
+
+	}
+
+	public static class ConnectionFactoryConfiguration {
+
+		@Bean
+		public ConnectionFactory connectionFactory() {
+			return MOCK_CONNECTION_FACTORY;
+		}
+	}
+}

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/src/test/java/org/springframework/cloud/stream/binder/redis/integration/RedisBinderModuleTests.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/src/test/java/org/springframework/cloud/stream/binder/redis/integration/RedisBinderModuleTests.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.redis.integration;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.binder.Binder;
+import org.springframework.cloud.stream.binder.BinderFactory;
+import org.springframework.cloud.stream.binder.redis.RedisMessageChannelBinder;
+import org.springframework.cloud.stream.messaging.Processor;
+import org.springframework.cloud.stream.test.junit.redis.RedisTestSupport;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class RedisBinderModuleTests {
+
+	@ClassRule
+	public static RedisTestSupport rabbitTestSupport = new RedisTestSupport();
+
+	private ConfigurableApplicationContext context = null;
+
+	public static final RedisConnectionFactory MOCK_CONNECTION_FACTORY = Mockito.mock(RedisConnectionFactory.class,
+			Mockito.RETURNS_MOCKS);
+
+	@After
+	public void tearDown() {
+		if (context != null) {
+			context.close();
+			context = null;
+		}
+	}
+
+	@Test
+	public void testParentConnectionFactoryInheritedByDefault() {
+		context = SpringApplication.run(SimpleProcessor.class);
+		BinderFactory binderFactory = context.getBean(BinderFactory.class);
+		Binder binder = binderFactory.getBinder(null);
+		assertThat(binder, instanceOf(RedisMessageChannelBinder.class));
+		DirectFieldAccessor binderFieldAccessor = new DirectFieldAccessor(binder);
+		RedisConnectionFactory binderConnectionFactory =
+				(RedisConnectionFactory) binderFieldAccessor.getPropertyValue("connectionFactory");
+		assertThat(binderConnectionFactory, instanceOf(RedisConnectionFactory.class));
+		RedisConnectionFactory connectionFactory = context.getBean(RedisConnectionFactory.class);
+		assertThat(binderConnectionFactory, is(connectionFactory));
+	}
+
+	@Test
+	public void testParentConnectionFactoryInheritedIfOverridden() {
+		context = new SpringApplication(SimpleProcessor.class, ConnectionFactoryConfiguration.class).run();
+		BinderFactory binderFactory = context.getBean(BinderFactory.class);
+		Binder binder = binderFactory.getBinder(null);
+		assertThat(binder, instanceOf(RedisMessageChannelBinder.class));
+		DirectFieldAccessor binderFieldAccessor = new DirectFieldAccessor(binder);
+		RedisConnectionFactory binderConnectionFactory =
+				(RedisConnectionFactory) binderFieldAccessor.getPropertyValue("connectionFactory");
+		assertThat(binderConnectionFactory, is(MOCK_CONNECTION_FACTORY));
+		RedisConnectionFactory connectionFactory = context.getBean(RedisConnectionFactory.class);
+		assertThat(binderConnectionFactory, is(connectionFactory));
+	}
+
+	@Test
+	public void testParentConnectionFactoryNotInheritedByCustomizedBinders() {
+		List<String> params = new ArrayList<>();
+		params.add("--spring.cloud.stream.input.binder=custom");
+		params.add("--spring.cloud.stream.output.binder=custom");
+		params.add("--spring.cloud.stream.binders.custom.type=redis");
+		params.add("--spring.cloud.stream.binders.custom.environment.foo=bar");
+		context = SpringApplication.run(SimpleProcessor.class, params.toArray(new String[]{}));
+		BinderFactory binderFactory = context.getBean(BinderFactory.class);
+		Binder binder = binderFactory.getBinder(null);
+		assertThat(binder, instanceOf(RedisMessageChannelBinder.class));
+		DirectFieldAccessor binderFieldAccessor = new DirectFieldAccessor(binder);
+		RedisConnectionFactory binderConnectionFactory =
+				(RedisConnectionFactory) binderFieldAccessor.getPropertyValue("connectionFactory");
+		RedisConnectionFactory connectionFactory = context.getBean(RedisConnectionFactory.class);
+		assertThat(binderConnectionFactory, not(is(connectionFactory)));
+	}
+
+	@EnableBinding(Processor.class)
+	@SpringBootApplication
+	public static class SimpleProcessor {
+
+	}
+
+	public static class ConnectionFactoryConfiguration {
+
+		@Bean
+		public RedisConnectionFactory connectionFactory() {
+			return MOCK_CONNECTION_FACTORY;
+		}
+	}
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderConfiguration.java
@@ -32,13 +32,17 @@ public class BinderConfiguration {
 
 	private final Properties properties;
 
+	private final boolean inheritEnvironment;
+
 	/**
 	 * @param binderType the binder type used by this configuration
 	 * @param properties the properties for setting up the binder
+	 * @param inheritEnvironment whether the binder should inherit the environment of the module
 	 */
-	public BinderConfiguration(BinderType binderType, Properties properties) {
+	public BinderConfiguration(BinderType binderType, Properties properties, boolean inheritEnvironment) {
 		this.binderType = binderType;
 		this.properties = properties;
+		this.inheritEnvironment = inheritEnvironment;
 	}
 
 	public BinderType getBinderType() {
@@ -47,5 +51,9 @@ public class BinderConfiguration {
 
 	public Properties getProperties() {
 		return properties;
+	}
+
+	public boolean isInheritEnvironment() {
+		return inheritEnvironment;
 	}
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BinderFactoryConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BinderFactoryConfiguration.java
@@ -62,21 +62,23 @@ public class BinderFactoryConfiguration {
 				if (binderTypeRegistry.get(binderEntry.getKey()) != null) {
 					binderConfigurations.put(binderEntry.getKey(),
 							new BinderConfiguration(binderTypeRegistry.get(binderEntry.getKey()),
-									binderProperties.getEnvironment()));
+									binderProperties.getEnvironment(), binderProperties.isInheritEnvironment()));
 				}
 				else {
 					Assert.hasText(binderProperties.getType(), "No 'type' property present for custom " +
 							"binder " + binderEntry.getKey());
+					BinderType binderType = binderTypeRegistry.get(binderProperties.getType());
+					Assert.notNull(binderType, "Binder type " + binderProperties.getType() + " is not defined");
 					binderConfigurations.put(binderEntry.getKey(),
-							new BinderConfiguration(binderTypeRegistry.get(binderProperties.getType()),
-									binderProperties.getEnvironment()));
+							new BinderConfiguration(binderType, binderProperties.getEnvironment(),
+									binderProperties.isInheritEnvironment()));
 				}
 			}
 		}
 		else {
 			for (Map.Entry<String, BinderType> entry : binderTypeRegistry.getAll().entrySet()) {
 				binderConfigurations.put(entry.getKey(),
-						new BinderConfiguration(entry.getValue(), new Properties()));
+						new BinderConfiguration(entry.getValue(), new Properties(), true));
 			}
 		}
 		DefaultBinderFactory binderFactory = new DefaultBinderFactory<>(binderConfigurations);

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BinderProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BinderProperties.java
@@ -28,6 +28,8 @@ public class BinderProperties {
 
 	private Properties environment = new Properties();
 
+	private boolean inheritEnvironment = true;
+
 	public String getType() {
 		return type;
 	}
@@ -44,4 +46,11 @@ public class BinderProperties {
 		this.environment = environment;
 	}
 
+	public boolean isInheritEnvironment() {
+		return inheritEnvironment;
+	}
+
+	public void setInheritEnvironment(boolean inheritEnvironment) {
+		this.inheritEnvironment = inheritEnvironment;
+	}
 }

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/BinderFactoryConfigurationTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/BinderFactoryConfigurationTests.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -97,6 +98,33 @@ public class BinderFactoryConfigurationTests {
 
 		Binder binder1 = binderFactory.getBinder("binder1");
 		assertThat(((StubBinder1)binder1).getName(), is(equalTo("foo")));
+	}
+
+	@Test
+	public void loadBinderTypeRegistryWithOneCustomBinderAndSharedEnvironment() throws Exception {
+		ConfigurableApplicationContext context = createBinderTestContext(
+				new String[] {"binder1"}, "binder1.name=foo",
+						"spring.cloud.stream.binders.custom.properties.foo=bar",
+						"spring.cloud.stream.binders.custom.type=binder1");
+
+		BinderFactory binderFactory = context.getBean(BinderFactory.class);
+
+		Binder binder1 = binderFactory.getBinder("custom");
+		assertThat(((StubBinder1)binder1).getName(), is(equalTo("foo")));
+	}
+
+	@Test
+	public void loadBinderTypeRegistryWithOneCustomBinderAndIsolatedEnvironment() throws Exception {
+		ConfigurableApplicationContext context = createBinderTestContext(
+				new String[] {"binder1"}, "binder1.name=foo",
+				"spring.cloud.stream.binders.custom.type=binder1",
+				"spring.cloud.stream.binders.custom.environment.foo=bar",
+				"spring.cloud.stream.binders.custom.inheritEnvironment=false");
+
+		BinderFactory binderFactory = context.getBean(BinderFactory.class);
+
+		Binder binder1 = binderFactory.getBinder("custom");
+		assertThat(((StubBinder1)binder1).getName(),isEmptyOrNullString());
 	}
 
 	@Test

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binding/ChannelBindingServiceTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binding/ChannelBindingServiceTests.java
@@ -51,7 +51,9 @@ public class ChannelBindingServiceTests {
 		properties.setBindings(bindings);
 		@SuppressWarnings("unchecked")
 		DefaultBinderFactory<MessageChannel> binderFactory =
-				new DefaultBinderFactory<>(Collections.singletonMap("mock", new BinderConfiguration(new BinderType("mock", new Class[]{MockBinderConfiguration.class}), new Properties())));
+				new DefaultBinderFactory<>(Collections.singletonMap("mock",
+						new BinderConfiguration(new BinderType("mock", new Class[]{MockBinderConfiguration.class}),
+								new Properties(), true)));
 		Binder<MessageChannel> binder = binderFactory.getBinder("mock");
 		ChannelBindingService service = new ChannelBindingService(properties, binderFactory);
 		MessageChannel inputChannel = new DirectChannel();
@@ -73,7 +75,9 @@ public class ChannelBindingServiceTests {
 		properties.setBindings(bindings);
 		@SuppressWarnings("unchecked")
 		DefaultBinderFactory<MessageChannel> binderFactory =
-				new DefaultBinderFactory<>(Collections.singletonMap("mock", new BinderConfiguration(new BinderType("mock", new Class[]{MockBinderConfiguration.class}), new Properties())));
+				new DefaultBinderFactory<>(Collections.singletonMap("mock",
+						new BinderConfiguration(new BinderType("mock", new Class[]{MockBinderConfiguration.class}),
+								new Properties(), true)));
 		Binder<MessageChannel> binder = binderFactory.getBinder("mock");
 		ChannelBindingService service = new ChannelBindingService(properties, binderFactory);
 		MessageChannel inputChannel = new DirectChannel();


### PR DESCRIPTION
Resolves #229
Optimizes connection factory creation for binders that can use Boot's autoconfiguration