### PR TITLE
Inherit Environment from main context when creating a Binder

### DIFF
--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/BinderFactoryConfigurationTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/BinderFactoryConfigurationTests.java
@@ -33,7 +33,6 @@ import java.net.URL;
 import java.net.URLClassLoader;
 
 import org.junit.Test;
-
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -87,6 +86,17 @@ public class BinderFactoryConfigurationTests {
 
 		Binder defaultBinder = binderFactory.getBinder(null);
 		assertThat(defaultBinder, is(binder1));
+	}
+
+	@Test
+	public void loadBinderTypeRegistryWithOneBinderAndSharedEnvironment() throws Exception {
+		ConfigurableApplicationContext context = createBinderTestContext(
+				new String[] {"binder1"}, "binder1.name=foo");
+
+		BinderFactory binderFactory = context.getBean(BinderFactory.class);
+
+		Binder binder1 = binderFactory.getBinder("binder1");
+		assertThat(((StubBinder1)binder1).getName(), is(equalTo("foo")));
 	}
 
 	@Test

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/stub1/StubBinder1.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/stub1/StubBinder1.java
@@ -25,6 +25,16 @@ import org.springframework.cloud.stream.binder.Binder;
  */
 public class StubBinder1 implements Binder {
 
+	private String name;
+
+	public String getName() {
+		return this.name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
 	@Override
 	public void bindConsumer(String name, Object inboundBindTarget, Properties properties) {
 

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/stub1/StubBinder1Configuration.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/stub1/StubBinder1Configuration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.stream.binder.stub1;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.binder.Binder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -24,9 +26,11 @@ import org.springframework.context.annotation.Configuration;
  * @author Marius Bogoevici
  */
 @Configuration
+@EnableConfigurationProperties
 public class StubBinder1Configuration {
 
 	@Bean
+	@ConfigurationProperties("binder1")
 	public Binder binder() {
 		return new StubBinder1();
 	}


### PR DESCRIPTION
The DefaultBinderFactory makes use of SpringApplicationBuilder to
build a context containing a binder. It has access to the Environment
of the surrounding context, but doesn't use it, and doesn't use it
(before this change). Users will be surprised if (for instance) they
change the default rabbitmq hostname and the change doesn't propagate
to the binder.