### PR TITLE
GH-236: EmbeddedHeadersMessageConverter Multibyte

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/EmbeddedHeadersMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/EmbeddedHeadersMessageConverter.java
@@ -63,9 +63,9 @@ public class EmbeddedHeadersMessageConverter {
 					: original.get(header);
 			if (value != null) {
 				String json = this.objectMapper.toJson(value);
-				headerValues[n++] = json.getBytes("UTF-8");
+				headerValues[n] = json.getBytes("UTF-8");
 				headerCount++;
-				headersLength += header.length() + json.length();
+				headersLength += header.length() + headerValues[n++].length;
 			}
 			else {
 				headerValues[n++] = null;


### PR DESCRIPTION
Fixes spring-cloud/spring-cloud-stream#236

Buffer overflow when converting multi-byte characters from
Unicode to UTF-8.