### PR TITLE
scsm-88 Support Dynamic Binding Channel Limits

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BinderAwareChannelResolver.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BinderAwareChannelResolver.java
@@ -93,15 +93,16 @@ public class BinderAwareChannelResolver extends BeanFactoryMessageChannelDestina
 								" [<transport>:]<name>");
 					}
 				}
-				String[] outboundChannelNames = null;
+				String[] dynamicDestinations = null;
 				Properties producerProperties = null;
 				if (this.channelBindingServiceProperties != null) {
-					outboundChannelNames = this.channelBindingServiceProperties.getOutboundChannelNames();
+					dynamicDestinations = this.channelBindingServiceProperties.getDynamicDestinations();
 					// TODO: need the props to return some defaults if not found
 					producerProperties = this.channelBindingServiceProperties.getProducerProperties(name);
 				}
-				boolean dynamicAllowed = outboundChannelNames == null || outboundChannelNames.length == 0
-						|| Arrays.asList(outboundChannelNames).contains(name);
+				boolean dynamicAllowed = dynamicDestinations == null
+						|| dynamicDestinations.length == 0
+						|| Arrays.asList(dynamicDestinations).contains(name);
 				if (dynamicAllowed) {
 					Binder<MessageChannel> binder = binderFactory.getBinder(transport);
 					binder.bindProducer(name, channel, producerProperties);

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BinderAwareChannelResolver.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BinderAwareChannelResolver.java
@@ -16,17 +16,19 @@
 
 package org.springframework.cloud.stream.binding;
 
+import java.util.Arrays;
 import java.util.Properties;
 
 import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
-import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.cloud.stream.binder.Binder;
 import org.springframework.cloud.stream.binder.BinderFactory;
+import org.springframework.cloud.stream.config.ChannelBindingServiceProperties;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.core.BeanFactoryMessageChannelDestinationResolver;
 import org.springframework.messaging.core.DestinationResolutionException;
+import org.springframework.util.Assert;
 
 /**
  * A {@link org.springframework.messaging.core.DestinationResolver} implementation that
@@ -40,36 +42,41 @@ public class BinderAwareChannelResolver extends BeanFactoryMessageChannelDestina
 
 	private final BinderFactory<MessageChannel> binderFactory;
 
-	private final Properties producerProperties;
+	private final ChannelBindingServiceProperties channelBindingServiceProperties;
 
-	private DefaultListableBeanFactory beanFactory;
+	private ConfigurableListableBeanFactory beanFactory;
 
-	public BinderAwareChannelResolver(BinderFactory<MessageChannel> binderFactory, Properties producerProperties) {
+	public BinderAwareChannelResolver(BinderFactory<MessageChannel> binderFactory,
+			ChannelBindingServiceProperties channelBindingServiceProperties) {
+		Assert.notNull(binderFactory, "'binderFactory' cannot be null");
 		this.binderFactory = binderFactory;
-		this.producerProperties = producerProperties;
+		this.channelBindingServiceProperties = channelBindingServiceProperties;
 	}
 
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) {
 		super.setBeanFactory(beanFactory);
-		if (beanFactory instanceof ConfigurableBeanFactory) {
-			this.beanFactory = (DefaultListableBeanFactory) beanFactory;
+		if (beanFactory instanceof ConfigurableListableBeanFactory) {
+			this.beanFactory = (ConfigurableListableBeanFactory) beanFactory;
 		}
 	}
 
 	@Override
 	public MessageChannel resolveDestination(String name) {
 		MessageChannel channel = null;
+		DestinationResolutionException destinationResolutionException;
 		try {
 			return super.resolveDestination(name);
 		}
 		catch (DestinationResolutionException e) {
+			destinationResolutionException = e;
 		}
 		synchronized (this) {
 			try {
 				return super.resolveDestination(name);
 			}
 			catch (DestinationResolutionException e) {
+				destinationResolutionException = e;
 			}
 			if (this.beanFactory != null && this.binderFactory != null) {
 				channel = new DirectChannel();
@@ -86,8 +93,22 @@ public class BinderAwareChannelResolver extends BeanFactoryMessageChannelDestina
 								" [<transport>:]<name>");
 					}
 				}
-				Binder<MessageChannel> binder = binderFactory.getBinder(transport);
-				binder.bindProducer(name, channel, this.producerProperties);
+				String[] outboundChannelNames = null;
+				Properties producerProperties = null;
+				if (this.channelBindingServiceProperties != null) {
+					outboundChannelNames = this.channelBindingServiceProperties.getOutboundChannelNames();
+					// TODO: need the props to return some defaults if not found
+					producerProperties = this.channelBindingServiceProperties.getProducerProperties(name);
+				}
+				boolean dynamicAllowed = outboundChannelNames == null || outboundChannelNames.length == 0
+						|| Arrays.asList(outboundChannelNames).contains(name);
+				if (dynamicAllowed) {
+					Binder<MessageChannel> binder = binderFactory.getBinder(transport);
+					binder.bindProducer(name, channel, producerProperties);
+				}
+				else {
+					throw destinationResolutionException;
+				}
 			}
 			return channel;
 		}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactoryUtils;
@@ -31,7 +30,6 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesBindin
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.binder.BinderFactory;
 import org.springframework.cloud.stream.binding.BindableChannelFactory;
-import org.springframework.cloud.stream.binding.MessageChannelConfigurer;
 import org.springframework.cloud.stream.binding.BinderAwareChannelResolver;
 import org.springframework.cloud.stream.binding.BinderAwareRouterBeanPostProcessor;
 import org.springframework.cloud.stream.binding.ChannelBindingService;
@@ -39,6 +37,7 @@ import org.springframework.cloud.stream.binding.CompositeMessageChannelConfigure
 import org.springframework.cloud.stream.binding.ContextStartAfterRefreshListener;
 import org.springframework.cloud.stream.binding.DefaultBindableChannelFactory;
 import org.springframework.cloud.stream.binding.InputBindingLifecycle;
+import org.springframework.cloud.stream.binding.MessageChannelConfigurer;
 import org.springframework.cloud.stream.binding.MessageConverterConfigurer;
 import org.springframework.cloud.stream.binding.MessageHistoryTrackerConfigurer;
 import org.springframework.cloud.stream.binding.OutputBindingLifecycle;
@@ -62,6 +61,7 @@ import org.springframework.messaging.core.DestinationResolver;
  * @author David Turanski
  * @author Marius Bogoevici
  * @author Ilayaperumal Gopinathan
+ * @author Gary Russell
  */
 @Configuration
 @EnableConfigurationProperties(ChannelBindingServiceProperties.class)
@@ -124,8 +124,9 @@ public class ChannelBindingServiceConfiguration {
 
 	@Bean
 	public BinderAwareChannelResolver binderAwareChannelResolver(
-			BinderFactory<MessageChannel> binderFactory) {
-		return new BinderAwareChannelResolver(binderFactory, new Properties());
+			BinderFactory<MessageChannel> binderFactory,
+			ChannelBindingServiceProperties channelBindingServiceProperties) {
+		return new BinderAwareChannelResolver(binderFactory, channelBindingServiceProperties);
 	}
 
 	@Bean

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceProperties.java
@@ -50,6 +50,8 @@ public class ChannelBindingServiceProperties {
 
 	private String defaultBinder;
 
+	private String[] outboundChannelNames = new String[0];
+
 	public Map<String, BindingProperties> getBindings() {
 		return bindings;
 	}
@@ -209,6 +211,14 @@ public class ChannelBindingServiceProperties {
 						Integer.toString(getInstanceIndex()));
 			}
 		}
+	}
+
+	public String[] getOutboundChannelNames() {
+		return outboundChannelNames;
+	}
+
+	public void setOutboundChannelNames(String[] outboundChannelNames) {
+		this.outboundChannelNames = outboundChannelNames;
 	}
 
 	public String getBinder(String channelName) {

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceProperties.java
@@ -50,7 +50,7 @@ public class ChannelBindingServiceProperties {
 
 	private String defaultBinder;
 
-	private String[] outboundChannelNames = new String[0];
+	private String[] dynamicDestinations = new String[0];
 
 	public Map<String, BindingProperties> getBindings() {
 		return bindings;
@@ -90,6 +90,14 @@ public class ChannelBindingServiceProperties {
 
 	public void setInstanceCount(int instanceCount) {
 		this.instanceCount = instanceCount;
+	}
+
+	public String[] getDynamicDestinations() {
+		return dynamicDestinations;
+	}
+
+	public void setDynamicDestinations(String[] dynamicDestinations) {
+		this.dynamicDestinations = dynamicDestinations;
 	}
 
 	public String getBindingDestination(String channelName) {
@@ -211,14 +219,6 @@ public class ChannelBindingServiceProperties {
 						Integer.toString(getInstanceIndex()));
 			}
 		}
-	}
-
-	public String[] getOutboundChannelNames() {
-		return outboundChannelNames;
-	}
-
-	public void setOutboundChannelNames(String[] outboundChannelNames) {
-		this.outboundChannelNames = outboundChannelNames;
 	}
 
 	public String getBinder(String channelName) {

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binding/ChannelBindingServiceTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binding/ChannelBindingServiceTests.java
@@ -143,10 +143,10 @@ public class ChannelBindingServiceTests {
 		MessageChannel resolved = resolver.resolveDestination("mock:bar");
 		assertThat(resolved, sameInstance(dynamic.get()));
 		verify(binder).bindProducer(eq("mock:bar"), eq(dynamic.get()), any(Properties.class));
-		properties.setOutboundChannelNames(new String[] { "mock:bar" });
+		properties.setDynamicDestinations(new String[] { "mock:bar" });
 		resolved = resolver.resolveDestination("mock:bar");
 		assertThat(resolved, sameInstance(dynamic.get()));
-		properties.setOutboundChannelNames(new String[] { "foo:bar" });
+		properties.setDynamicDestinations(new String[] { "foo:bar" });
 		try {
 			resolved = resolver.resolveDestination("mock:bar");
 			fail();

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binding/ChannelBindingServiceTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binding/ChannelBindingServiceTests.java
@@ -16,18 +16,33 @@
 
 package org.springframework.cloud.stream.binding;
 
+
 import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.matches;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.cloud.stream.binder.Binder;
 import org.springframework.cloud.stream.binder.BinderConfiguration;
 import org.springframework.cloud.stream.binder.BinderType;
@@ -39,6 +54,7 @@ import org.springframework.cloud.stream.utils.MockBinderConfiguration;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.endpoint.AbstractEndpoint;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.core.DestinationResolutionException;
 
 /**
  * @author Gary Russell
@@ -94,10 +110,51 @@ public class ChannelBindingServiceTests {
 		MessageChannel inputChannel = new DirectChannel();
 		Binding<MessageChannel> mockBinding = Binding.forConsumer("foo", "fooGroup", Mockito.mock(AbstractEndpoint.class),
 				inputChannel, null);
-		Mockito.when(binder.bindConsumer("foo", "fooGroup", inputChannel, new Properties()))
+		when(binder.bindConsumer("foo", "fooGroup", inputChannel, new Properties()))
 				.thenReturn(mockBinding);
 		Binding<MessageChannel> binding = service.bindConsumer(inputChannel, name);
-		Assert.assertThat(binding, sameInstance(mockBinding));
+		assertThat(binding, sameInstance(mockBinding));
+
+		final AtomicReference<MessageChannel> dynamic = new AtomicReference<>();
+		when(binder.bindProducer(
+				matches("mock:bar"), any(DirectChannel.class), any(Properties.class))).thenReturn(mockBinding);
+		BinderAwareChannelResolver resolver = new BinderAwareChannelResolver(binderFactory, properties);
+		ConfigurableListableBeanFactory beanFactory = mock(ConfigurableListableBeanFactory.class);
+		when(beanFactory.getBean("mock:bar", MessageChannel.class))
+			.thenThrow(new NoSuchBeanDefinitionException(MessageChannel.class));
+		doAnswer(new Answer<Void>(){
+
+			@Override
+			public Void answer(InvocationOnMock invocation) throws Throwable {
+				dynamic.set(invocation.getArgumentAt(1, MessageChannel.class));
+				return null;
+			}
+
+		}).when(beanFactory).registerSingleton(eq("mock:bar"), any(MessageChannel.class));
+		doAnswer(new Answer<Object>() {
+
+			@Override
+			public Object answer(InvocationOnMock invocation) throws Throwable {
+				return dynamic.get();
+			}
+
+		}).when(beanFactory).initializeBean(any(MessageChannel.class), eq("mock:bar"));
+		resolver.setBeanFactory(beanFactory);
+		MessageChannel resolved = resolver.resolveDestination("mock:bar");
+		assertThat(resolved, sameInstance(dynamic.get()));
+		verify(binder).bindProducer(eq("mock:bar"), eq(dynamic.get()), any(Properties.class));
+		properties.setOutboundChannelNames(new String[] { "mock:bar" });
+		resolved = resolver.resolveDestination("mock:bar");
+		assertThat(resolved, sameInstance(dynamic.get()));
+		properties.setOutboundChannelNames(new String[] { "foo:bar" });
+		try {
+			resolved = resolver.resolveDestination("mock:bar");
+			fail();
+		}
+		catch (DestinationResolutionException e) {
+			assertThat(e.getMessage(), containsString("Failed to find MessageChannel bean with name 'mock:bar'"));
+		}
+
 		service.unbindConsumers(name);
 		verify(binder).bindConsumer(name, props.getGroup(), inputChannel, properties.getConsumerProperties(name));
 		verify(binder).unbind(binding);


### PR DESCRIPTION
Required by scsm-88.

If `outputChannelNames` is not zero length, only dynamically bind if the channel is is in the list.
