### PR TITLE
Handle binder config properties in BindingProperties

### DIFF
--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/MessageChannelConfigurerTests.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/MessageChannelConfigurerTests.java
@@ -96,15 +96,15 @@ public class MessageChannelConfigurerTests {
 				String inputBindingProps = headerValue.get("input");
 				assertTrue(inputBindingProps.contains("destination=configure"));
 				assertTrue(inputBindingProps.contains("trackHistory=true"));
+				assertTrue(inputBindingProps.contains("concurrency=1"));
 				assertTrue(headerValue.get("instanceIndex").equals("0"));
 				assertTrue(headerValue.get("instanceCount").equals("1"));
-				assertTrue(headerValue.get("producer.nextModuleCount").equals("1"));
-				assertTrue(headerValue.get("consumer.concurrency").equals("1"));
 				String outputBindingProps = (String) ((Map<?, ?>) ((List<?>) message.getHeaders()
 						.get("SPRING_CLOUD_STREAM_HISTORY")).get(0)).get("output");
 				;
 				assertTrue(outputBindingProps.contains("destination=configure"));
-				assertTrue(outputBindingProps.contains("trackHistory=false"));
+				assertTrue(!outputBindingProps.contains("trackHistory"));
+				assertTrue(outputBindingProps.contains("nextModuleCount=1"));
 				latch1.countDown();
 			}
 		};

--- a/spring-cloud-stream-integration-tests/src/test/resources/org/springframework/cloud/stream/config/sink-channel-configurers.properties
+++ b/spring-cloud-stream-integration-tests/src/test/resources/org/springframework/cloud/stream/config/sink-channel-configurers.properties
@@ -1,4 +1,4 @@
 spring.cloud.stream.bindings.input.destination=configure1
 spring.cloud.stream.bindings.input.contentType=application/x-spring-tuple
-spring.cloud.stream.bindings.input.trackHistory=true
-spring.cloud.stream.consumerProperties.concurrency=1
+spring.cloud.stream.bindings.input.config.trackHistory=true
+spring.cloud.stream.bindings.input.config.concurrency=1

--- a/spring-cloud-stream-integration-tests/src/test/resources/org/springframework/cloud/stream/config/source-channel-configurers.properties
+++ b/spring-cloud-stream-integration-tests/src/test/resources/org/springframework/cloud/stream/config/source-channel-configurers.properties
@@ -1,3 +1,3 @@
 spring.cloud.stream.bindings.output.destination=configure1
-spring.cloud.stream.producerProperties.nextModuleCount=1
+spring.cloud.stream.bindings.output.config.nextModuleCount=1
 spring.cloud.stream.bindings.output.contentType=application/json

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderProperties.java
@@ -21,6 +21,7 @@ package org.springframework.cloud.stream.binder;
  * Common binder properties.
  *
  * @author Gary Russell
+ * @author Ilayaperumal Gopinathan
  */
 public interface BinderProperties {
 
@@ -70,6 +71,16 @@ public interface BinderProperties {
 	 * The consumer's partition index.
 	 */
 	public static final String PARTITION_INDEX = "partitionIndex";
+
+	/**
+	 * Property to use for Message Tracking History.
+	 */
+	public static final String TRACK_HISTORY = "trackHistory";
+
+	/**
+	 * Property to indicate the consumer that the upstream module is partitioned.
+	 */
+	public static final String PARTITIONED = "partitioned";
 
 	/**
 	 * The partition key expression.

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/MessageChannelBinderSupport.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/MessageChannelBinderSupport.java
@@ -125,6 +125,8 @@ public abstract class MessageChannelBinderSupport
 	protected static final Set<Object> CONSUMER_STANDARD_PROPERTIES = new SetBuilder()
 			.add(BinderProperties.COUNT)
 			.add(BinderProperties.SEQUENCE)
+			.add(BinderProperties.TRACK_HISTORY)
+			.add(BinderProperties.PARTITIONED)
 			.build();
 
 	protected static final Set<Object> PRODUCER_STANDARD_PROPERTIES = new HashSet<Object>(Arrays.asList(

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/MessageHistoryTrackerConfigurer.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/MessageHistoryTrackerConfigurer.java
@@ -50,7 +50,8 @@ public class MessageHistoryTrackerConfigurer implements MessageChannelConfigurer
 	@Override
 	public void configureMessageChannel(MessageChannel messageChannel, String channelName) {
 		BindingProperties bindingProperties = channelBindingServiceProperties.getBindings().get(channelName);
-		if (bindingProperties != null && Boolean.TRUE.equals(bindingProperties.getTrackHistory())) {
+		if (bindingProperties != null && bindingProperties.getConfig() != null &&
+				"true".equalsIgnoreCase((bindingProperties.getConfig().get("trackHistory")))) {
 			if (messageChannel instanceof ChannelInterceptorAware) {
 				((ChannelInterceptorAware) messageChannel).addInterceptor(new ChannelInterceptorAdapter() {
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingProperties.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.stream.config;
 
+import java.util.Map;
 import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -35,25 +36,16 @@ public class BindingProperties {
 
 	private String destination;
 
-	private boolean partitioned = false;
-
-	private int partitionCount = 1;
-
-	private String partitionKeyExpression;
-
-	private String partitionKeyExtractorClass;
-
-	private String partitionSelectorClass;
-
-	private String partitionSelectorExpression;
-
 	private String group = UUID.randomUUID().toString();
 
 	private String contentType;
 
 	private String binder;
 
-	private boolean trackHistory;
+	/**
+	 *  Config properties thar are set per-binding level (like producer/consumer properties per-binding).
+	 */
+	private Map<String, String> config;
 
 	public String getDestination() {
 		return this.destination;
@@ -61,54 +53,6 @@ public class BindingProperties {
 
 	public void setDestination(String destination) {
 		this.destination = destination;
-	}
-
-	public boolean isPartitioned() {
-		return this.partitioned;
-	}
-
-	public void setPartitioned(boolean partitioned) {
-		this.partitioned = partitioned;
-	}
-
-	public int getPartitionCount() {
-		return this.partitionCount;
-	}
-
-	public void setPartitionCount(int partitionCount) {
-		this.partitionCount = partitionCount;
-	}
-
-	public String getPartitionKeyExpression() {
-		return this.partitionKeyExpression;
-	}
-
-	public void setPartitionKeyExpression(String partitionKeyExpression) {
-		this.partitionKeyExpression = partitionKeyExpression;
-	}
-
-	public String getPartitionKeyExtractorClass() {
-		return this.partitionKeyExtractorClass;
-	}
-
-	public void setPartitionKeyExtractorClass(String partitionKeyExtractorClass) {
-		this.partitionKeyExtractorClass = partitionKeyExtractorClass;
-	}
-
-	public String getPartitionSelectorClass() {
-		return this.partitionSelectorClass;
-	}
-
-	public void setPartitionSelectorClass(String partitionSelectorClass) {
-		this.partitionSelectorClass = partitionSelectorClass;
-	}
-
-	public String getPartitionSelectorExpression() {
-		return this.partitionSelectorExpression;
-	}
-
-	public void setPartitionSelectorExpression(String partitionSelectorExpression) {
-		this.partitionSelectorExpression = partitionSelectorExpression;
 	}
 
 	public String getGroup() {
@@ -127,7 +71,6 @@ public class BindingProperties {
 		this.contentType = contentType;
 	}
 
-
 	public String getBinder() {
 		return binder;
 	}
@@ -136,12 +79,12 @@ public class BindingProperties {
 		this.binder = binder;
 	}
 
-	public Boolean getTrackHistory() {
-		return this.trackHistory;
+	public Map<String, String> getConfig() {
+		return this.config;
 	}
 
-	public void setTrackHistory(boolean trackHistory) {
-		this.trackHistory = trackHistory;
+	public void setConfig(Map<String, String> properties) {
+		this.config = properties;
 	}
 
 	public String toString() {
@@ -150,28 +93,24 @@ public class BindingProperties {
 		sb.append(COMMA);
 		sb.append("group=" + group);
 		sb.append(COMMA);
-		sb.append("contentType="+ contentType);
+		sb.append("contentType=" + contentType);
 		sb.append(COMMA);
-		sb.append("binder="+ binder);
+		sb.append("binder=" + binder);
 		sb.append(COMMA);
-		sb.append("trackHistory=" + trackHistory);
-		sb.append(COMMA);
-		sb.append("partitioned=" + partitioned);
-		sb.append(COMMA);
-		if (this.partitionKeyExpression != null && !this.partitionKeyExpression.isEmpty()) {
-			sb.append("partitionKeyExpression=" + partitionKeyExpression);
-			sb.append(COMMA);
+		if (config != null) {
+			StringBuilder props = new StringBuilder();
+			props.append("Properties{");
+			for (Map.Entry<String, String> entry : config.entrySet()) {
+				props.append(String.format("%s=%s,", entry.getKey(), entry.getValue()));
+			}
+			if (props.lastIndexOf(COMMA) > 0) {
+				props.deleteCharAt(props.lastIndexOf(COMMA));
+			}
+			props.append("}");
+			sb.append(props);
 		}
-		if (this.partitionKeyExtractorClass != null && !this.partitionKeyExtractorClass.isEmpty()) {
-			sb.append("partitionKeyExtractorClass=" + partitionKeyExtractorClass);
-			sb.append(COMMA);
-		}
-		if (this.partitionSelectorClass != null && !this.partitionSelectorClass.isEmpty()) {
-			sb.append("partitionSelectorClass=" + partitionSelectorClass);
-			sb.append(COMMA);
-		}
-		if (this.partitionSelectorClass != null && !this.partitionSelectorClass.isEmpty()) {
-			sb.append("partitionSelectorExpression=" + partitionSelectorExpression);
+		else {
+			sb.deleteCharAt(sb.lastIndexOf(COMMA));
 		}
 		sb.deleteCharAt(sb.lastIndexOf(COMMA));
 		return "BindingProperties{" + sb.toString() + "}";

--- a/spring-cloud-stream/src/test/resources/org/springframework/cloud/stream/binder/partitioned-consumer-test.properties
+++ b/spring-cloud-stream/src/test/resources/org/springframework/cloud/stream/binder/partitioned-consumer-test.properties
@@ -1,5 +1,5 @@
 spring.cloud.stream.bindings.input.destination=partIn
-spring.cloud.stream.bindings.input.partitioned=true
+spring.cloud.stream.bindings.input.config.partitioned=true
 spring.cloud.stream.instanceCount=2
 spring.cloud.stream.instanceIndex=0
 

--- a/spring-cloud-stream/src/test/resources/org/springframework/cloud/stream/binder/partitioned-producer-test.properties
+++ b/spring-cloud-stream/src/test/resources/org/springframework/cloud/stream/binder/partitioned-producer-test.properties
@@ -1,4 +1,4 @@
 spring.cloud.stream.bindings.output.destination=partOut
-spring.cloud.stream.bindings.output.partitionKeyExpression=payload
-spring.cloud.stream.bindings.output.partitionCount=3
+spring.cloud.stream.bindings.output.config.partitionKeyExpression=payload
+spring.cloud.stream.bindings.output.config.partitionCount=3
 


### PR DESCRIPTION
 - Per-binding properties defined in `BindingProperties` need to hold the binder specific configurations needed when binding producer/consumers.
Currently, these are added in `ChannelBindingServiceProperties` as producer/consumer properties. Since, these configuration properties are for
per-binding based on the input/output (consumer/producer) channel being bound it would be better to move these properties into `BindingProperties`.
- Add `config` key in `BindingProperties` which can hold all the properties that can be passed as `per-binding` properties (including the producer/consumer properties)
- Remove `partition`, `trackHistory` related properties with the assumption they are handled in BindingProperties' config

- This fixes #256