### PR TITLE
GH-274 Fixes for AggregatedApplication

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplication.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplication.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplication.java
@@ -111,6 +111,7 @@ public class AggregateApplication {
 		return new SpringApplicationBuilder(module)
 				.web(false)
 				.bannerMode(Mode.OFF)
+				.properties("spring.jmx.default-domain=" + module)
 				.properties(CHANNEL_NAMESPACE_PROPERTY_NAME + "=" + namespace)
 				.registerShutdownHook(false)
 				.parent(applicationContext);

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindableProxyFactory.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindableProxyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindableProxyFactory.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindableProxyFactory.java
@@ -131,6 +131,7 @@ public class BindableProxyFactory implements MethodInterceptor, FactoryBean<Obje
 						inputHolders.put(name, new ChannelHolder(createBindableChannel(name, channelType), true));
 					}
 					else {
+						inputHolders.put(name, new ChannelHolder(sharedChannel, false));
 						if (!channelType.isAssignableFrom(sharedChannel.getClass())) {
 							bridgeSharedChannel(channelType, sharedChannel);
 						}
@@ -150,6 +151,7 @@ public class BindableProxyFactory implements MethodInterceptor, FactoryBean<Obje
 						outputHolders.put(name, new ChannelHolder(createBindableChannel(name, channelType), true));
 					}
 					else {
+						outputHolders.put(name, new ChannelHolder(sharedChannel, false));
 						if (!channelType.isAssignableFrom(sharedChannel.getClass())) {
 							bridgeSharedChannel(channelType, sharedChannel);
 						}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingAutoConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.messaging.MessageChannel;
  * general Spring Integration infrastructure.
  *
  * @author Dave Syer
+ * @author Marius Bogoevici
  */
 @Configuration
 @ConditionalOnBean(ChannelBindingService.class)
@@ -45,7 +46,7 @@ public class ChannelBindingAutoConfiguration {
 	private DefaultPollerProperties poller;
 
 	@Autowired(required = false)
-	List<Bindable> adapters;
+	private List<Bindable> adapters;
 
 	@Bean(name = PollerMetadata.DEFAULT_POLLER)
 	@ConditionalOnMissingBean(PollerMetadata.class)

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingAutoConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingAutoConfiguration.java
@@ -44,6 +44,9 @@ public class ChannelBindingAutoConfiguration {
 	@Autowired
 	private DefaultPollerProperties poller;
 
+	@Autowired(required = false)
+	List<Bindable> adapters;
+
 	@Bean(name = PollerMetadata.DEFAULT_POLLER)
 	@ConditionalOnMissingBean(PollerMetadata.class)
 	public PollerMetadata defaultPoller() {
@@ -51,8 +54,7 @@ public class ChannelBindingAutoConfiguration {
 	}
 
 	@Bean
-	@Autowired(required=false)
-	public ChannelsEndpoint channelsEndpoint(List<Bindable> adapters, ChannelBindingServiceProperties properties) {
+	public ChannelsEndpoint channelsEndpoint(ChannelBindingServiceProperties properties) {
 		return new ChannelsEndpoint(adapters, properties);
 	}
 


### PR DESCRIPTION
Resolves #274.

* Handle @Autowired(required=false) correctly when no `Bindable` beans are present (i.e. aggregated root context)
* Ensure separate domains per subcontext
* Register shared channels internally with the proxy