### PR TITLE
Add health indicators infrastructure

### DIFF
--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitServiceAutoConfiguration.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitServiceAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitServiceAutoConfiguration.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitServiceAutoConfiguration.java
@@ -17,6 +17,9 @@
 package org.springframework.cloud.stream.binder.rabbit.config;
 
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.health.RabbitHealthIndicator;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration;
 import org.springframework.boot.autoconfigure.cloud.CloudAutoConfiguration;
@@ -66,5 +69,11 @@ public class RabbitServiceAutoConfiguration {
 	@Profile("!cloud")
 	@Import(RabbitAutoConfiguration.class)
 	protected static class NoCloudConfig {
+
+	}
+
+	@Bean
+	public HealthIndicator binderHealthIndicator(RabbitTemplate rabbitTemplate) {
+		return new RabbitHealthIndicator(rabbitTemplate);
 	}
 }

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/src/main/java/org/springframework/cloud/stream/binder/redis/config/RedisMessageChannelBinderConfiguration.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/src/main/java/org/springframework/cloud/stream/binder/redis/config/RedisMessageChannelBinderConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/src/main/java/org/springframework/cloud/stream/binder/redis/config/RedisMessageChannelBinderConfiguration.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/src/main/java/org/springframework/cloud/stream/binder/redis/config/RedisMessageChannelBinderConfiguration.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.stream.binder.redis.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
-import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.binder.redis.RedisMessageChannelBinder;

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/src/main/java/org/springframework/cloud/stream/binder/redis/config/RedisServiceAutoConfiguration.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/src/main/java/org/springframework/cloud/stream/binder/redis/config/RedisServiceAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/src/main/java/org/springframework/cloud/stream/binder/redis/config/RedisServiceAutoConfiguration.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/src/main/java/org/springframework/cloud/stream/binder/redis/config/RedisServiceAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.stream.binder.redis.config;
 
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.health.RedisHealthIndicator;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.cloud.CloudAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -66,4 +68,8 @@ public class RedisServiceAutoConfiguration {
 	protected static class NoCloudConfig {
 	}
 
+	@Bean
+	public HealthIndicator binderHealthIndicator(RedisConnectionFactory redisConnectionFactory) {
+		return new RedisHealthIndicator(redisConnectionFactory);
+	}
 }

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/src/test/java/org/springframework/cloud/stream/binder/redis/integration/RedisBinderModuleTests.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/src/test/java/org/springframework/cloud/stream/binder/redis/integration/RedisBinderModuleTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/src/test/java/org/springframework/cloud/stream/binder/redis/integration/RedisBinderModuleTests.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/src/test/java/org/springframework/cloud/stream/binder/redis/integration/RedisBinderModuleTests.java
@@ -16,13 +16,17 @@
 
 package org.springframework.cloud.stream.binder.redis.integration;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.collection.IsMapContaining.hasKey;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.ClassRule;
@@ -31,6 +35,9 @@ import org.mockito.Mockito;
 
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.health.CompositeHealthIndicator;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.health.Status;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.binder.Binder;
@@ -65,7 +72,7 @@ public class RedisBinderModuleTests {
 
 	@Test
 	public void testParentConnectionFactoryInheritedByDefault() {
-		context = SpringApplication.run(SimpleProcessor.class);
+		context = SpringApplication.run(SimpleProcessor.class, "--server.port=0");
 		BinderFactory<?> binderFactory = context.getBean(BinderFactory.class);
 		Binder<?> binder = binderFactory.getBinder(null);
 		assertThat(binder, instanceOf(RedisMessageChannelBinder.class));
@@ -75,6 +82,15 @@ public class RedisBinderModuleTests {
 		assertThat(binderConnectionFactory, instanceOf(RedisConnectionFactory.class));
 		RedisConnectionFactory connectionFactory = context.getBean(RedisConnectionFactory.class);
 		assertThat(binderConnectionFactory, is(connectionFactory));
+		CompositeHealthIndicator bindersHealthIndicator =
+				context.getBean("bindersHealthIndicator", CompositeHealthIndicator.class);
+		assertNotNull(bindersHealthIndicator);
+		DirectFieldAccessor directFieldAccessor = new DirectFieldAccessor(bindersHealthIndicator);
+		@SuppressWarnings("unchecked")
+		Map<String,HealthIndicator> healthIndicators =
+				(Map<String, HealthIndicator>) directFieldAccessor.getPropertyValue("indicators");
+		assertThat(healthIndicators, hasKey("redis"));
+		assertThat(healthIndicators.get("redis").health().getStatus(), equalTo(Status.UP));
 	}
 
 	@Test
@@ -89,6 +105,15 @@ public class RedisBinderModuleTests {
 		assertThat(binderConnectionFactory, is(MOCK_CONNECTION_FACTORY));
 		RedisConnectionFactory connectionFactory = context.getBean(RedisConnectionFactory.class);
 		assertThat(binderConnectionFactory, is(connectionFactory));
+		CompositeHealthIndicator bindersHealthIndicator =
+				context.getBean("bindersHealthIndicator", CompositeHealthIndicator.class);
+		assertNotNull(bindersHealthIndicator);
+		DirectFieldAccessor directFieldAccessor = new DirectFieldAccessor(bindersHealthIndicator);
+		@SuppressWarnings("unchecked")
+		Map<String,HealthIndicator> healthIndicators =
+				(Map<String, HealthIndicator>) directFieldAccessor.getPropertyValue("indicators");
+		assertThat(healthIndicators, hasKey("redis"));
+		assertThat(healthIndicators.get("redis").health().getStatus(), equalTo(Status.UP));
 	}
 
 	@Test
@@ -107,6 +132,15 @@ public class RedisBinderModuleTests {
 				(RedisConnectionFactory) binderFieldAccessor.getPropertyValue("connectionFactory");
 		RedisConnectionFactory connectionFactory = context.getBean(RedisConnectionFactory.class);
 		assertThat(binderConnectionFactory, not(is(connectionFactory)));
+		CompositeHealthIndicator bindersHealthIndicator =
+				context.getBean("bindersHealthIndicator", CompositeHealthIndicator.class);
+		assertNotNull(bindersHealthIndicator);
+		DirectFieldAccessor directFieldAccessor = new DirectFieldAccessor(bindersHealthIndicator);
+		@SuppressWarnings("unchecked")
+		Map<String,HealthIndicator> healthIndicators =
+				(Map<String, HealthIndicator>) directFieldAccessor.getPropertyValue("indicators");
+		assertThat(healthIndicators, hasKey("custom"));
+		assertThat(healthIndicators.get("custom").health().getStatus(), equalTo(Status.UP));
 	}
 
 	@EnableBinding(Processor.class)

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BinderFactoryConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BinderFactoryConfiguration.java
@@ -26,6 +26,9 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.boot.actuate.autoconfigure.ConditionalOnEnabledHealthIndicator;
+import org.springframework.boot.actuate.health.CompositeHealthIndicator;
+import org.springframework.boot.actuate.health.OrderedHealthAggregator;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cloud.stream.binder.BinderConfiguration;
 import org.springframework.cloud.stream.binder.BinderFactory;
@@ -112,6 +115,13 @@ public class BinderFactoryConfiguration {
 			throw new BeanCreationException("Cannot create binder factory:", e);
 		}
 		return new DefaultBinderTypeRegistry(binderTypes);
+	}
+
+	@Bean
+	@ConditionalOnEnabledHealthIndicator("binders")
+	@ConditionalOnMissingBean(name = "bindersHealthIndicator")
+	public CompositeHealthIndicator bindersHealthIndicator() {
+		return new CompositeHealthIndicator(new OrderedHealthAggregator());
 	}
 
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BinderFactoryConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BinderFactoryConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,9 +26,6 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.springframework.beans.factory.BeanCreationException;
-import org.springframework.boot.actuate.autoconfigure.ConditionalOnEnabledHealthIndicator;
-import org.springframework.boot.actuate.health.CompositeHealthIndicator;
-import org.springframework.boot.actuate.health.OrderedHealthAggregator;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cloud.stream.binder.BinderConfiguration;
 import org.springframework.cloud.stream.binder.BinderFactory;
@@ -116,14 +113,6 @@ public class BinderFactoryConfiguration {
 		}
 		return new DefaultBinderTypeRegistry(binderTypes);
 	}
-
-	@Bean
-	@ConditionalOnEnabledHealthIndicator("binders")
-	@ConditionalOnMissingBean(name = "bindersHealthIndicator")
-	public CompositeHealthIndicator bindersHealthIndicator() {
-		return new CompositeHealthIndicator(new OrderedHealthAggregator());
-	}
-
 
 	static Collection<BinderType> parseBinderConfigurations(ClassLoader classLoader, Resource resource)
 			throws IOException, ClassNotFoundException {

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingAutoConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingAutoConfiguration.java
@@ -65,4 +65,10 @@ public class ChannelBindingAutoConfiguration {
 		return new ChannelsEndpoint(adapters, properties);
 	}
 
+	@Bean
+	@ConditionalOnEnabledHealthIndicator("binders")
+	@ConditionalOnMissingBean(name = "bindersHealthIndicator")
+	public CompositeHealthIndicator bindersHealthIndicator() {
+		return new CompositeHealthIndicator(new OrderedHealthAggregator());
+	}
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingAutoConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingAutoConfiguration.java
@@ -19,6 +19,11 @@ package org.springframework.cloud.stream.config;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.ConditionalOnEnabledHealthIndicator;
+import org.springframework.boot.actuate.autoconfigure.EndpointAutoConfiguration;
+import org.springframework.boot.actuate.health.CompositeHealthIndicator;
+import org.springframework.boot.actuate.health.OrderedHealthAggregator;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -40,6 +45,7 @@ import org.springframework.messaging.MessageChannel;
 @Configuration
 @ConditionalOnBean(ChannelBindingService.class)
 @EnableConfigurationProperties(DefaultPollerProperties.class)
+@AutoConfigureBefore(EndpointAutoConfiguration.class)
 public class ChannelBindingAutoConfiguration {
 
 	@Autowired

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceConfiguration.java
@@ -31,7 +31,6 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesBindin
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.binder.BinderFactory;
 import org.springframework.cloud.stream.binding.BindableChannelFactory;
-import org.springframework.cloud.stream.binding.MessageChannelConfigurer;
 import org.springframework.cloud.stream.binding.BinderAwareChannelResolver;
 import org.springframework.cloud.stream.binding.BinderAwareRouterBeanPostProcessor;
 import org.springframework.cloud.stream.binding.ChannelBindingService;
@@ -39,6 +38,7 @@ import org.springframework.cloud.stream.binding.CompositeMessageChannelConfigure
 import org.springframework.cloud.stream.binding.ContextStartAfterRefreshListener;
 import org.springframework.cloud.stream.binding.DefaultBindableChannelFactory;
 import org.springframework.cloud.stream.binding.InputBindingLifecycle;
+import org.springframework.cloud.stream.binding.MessageChannelConfigurer;
 import org.springframework.cloud.stream.binding.MessageConverterConfigurer;
 import org.springframework.cloud.stream.binding.MessageHistoryTrackerConfigurer;
 import org.springframework.cloud.stream.binding.OutputBindingLifecycle;

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/BinderFactoryConfigurationTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/BinderFactoryConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,25 +26,16 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.Map;
 
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.collection.IsMapContaining;
 import org.junit.Test;
 
-import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.BeanCreationException;
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.boot.actuate.health.CompositeHealthIndicator;
-import org.springframework.boot.actuate.health.HealthIndicator;
-import org.springframework.boot.actuate.health.Status;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -196,32 +187,8 @@ public class BinderFactoryConfigurationTests {
 		Binder defaultBinder = binderFactory.getBinder(null);
 		assertThat(defaultBinder, is(binder2));
 	}
-
-	@Test
-	public void healthIndicatorsCheck() throws Exception {
-		ConfigurableApplicationContext context =
-				createBinderTestContext(
-						new String[]{"binder1", "binder2"}, "spring.cloud.stream.defaultBinder:binder2");
-
-		Binder binder1 = context.getBean(BinderFactory.class).getBinder("binder1");
-		assertThat(binder1, instanceOf(StubBinder1.class));
-		Binder binder2 = context.getBean(BinderFactory.class).getBinder("binder2");
-		assertThat(binder2, instanceOf(StubBinder2.class));
-
-		CompositeHealthIndicator bindersHealthIndicator =
-				context.getBean("bindersHealthIndicator", CompositeHealthIndicator.class);
-		DirectFieldAccessor directFieldAccessor = new DirectFieldAccessor(bindersHealthIndicator);
-		assertNotNull(bindersHealthIndicator);
-		@SuppressWarnings("unchecked")
-		Map<String,HealthIndicator> healthIndicators =
-				(Map<String, HealthIndicator>) directFieldAccessor.getPropertyValue("indicators");
-		assertThat(healthIndicators, IsMapContaining.hasKey("binder1"));
-		assertThat(healthIndicators.get("binder1").health().getStatus(), CoreMatchers.equalTo(Status.UP));
-		assertThat(healthIndicators, IsMapContaining.hasKey("binder2"));
-		assertThat(healthIndicators.get("binder2").health().getStatus(), CoreMatchers.equalTo(Status.UNKNOWN));
-	}
-
-	private static ConfigurableApplicationContext createBinderTestContext(String[] additionalClasspathDirectories,
+	
+	public static ConfigurableApplicationContext createBinderTestContext(String[] additionalClasspathDirectories,
 																		  String... properties)
 			throws IOException {
 		URL[] urls = ObjectUtils.isEmpty(additionalClasspathDirectories) ?

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/HealthIndicatorsConfigurationTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/HealthIndicatorsConfigurationTests.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Map;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.collection.IsMapContaining;
+import org.junit.Test;
+
+import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.boot.actuate.health.CompositeHealthIndicator;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.binder.stub1.StubBinder1;
+import org.springframework.cloud.stream.binder.stub2.StubBinder2;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.util.ObjectUtils;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class HealthIndicatorsConfigurationTests {
+
+
+	@Test
+	public void healthIndicatorsCheck() throws Exception {
+		ConfigurableApplicationContext context =
+				createBinderTestContext(
+						new String[]{"binder1", "binder2"}, "spring.cloud.stream.defaultBinder:binder2");
+
+		Binder binder1 = context.getBean(BinderFactory.class).getBinder("binder1");
+		assertThat(binder1, instanceOf(StubBinder1.class));
+		Binder binder2 = context.getBean(BinderFactory.class).getBinder("binder2");
+		assertThat(binder2, instanceOf(StubBinder2.class));
+
+		CompositeHealthIndicator bindersHealthIndicator =
+				context.getBean("bindersHealthIndicator", CompositeHealthIndicator.class);
+		DirectFieldAccessor directFieldAccessor = new DirectFieldAccessor(bindersHealthIndicator);
+		assertNotNull(bindersHealthIndicator);
+		@SuppressWarnings("unchecked")
+		Map<String,HealthIndicator> healthIndicators =
+				(Map<String, HealthIndicator>) directFieldAccessor.getPropertyValue("indicators");
+		assertThat(healthIndicators, IsMapContaining.hasKey("binder1"));
+		assertThat(healthIndicators.get("binder1").health().getStatus(), CoreMatchers.equalTo(Status.UP));
+		assertThat(healthIndicators, IsMapContaining.hasKey("binder2"));
+		assertThat(healthIndicators.get("binder2").health().getStatus(), CoreMatchers.equalTo(Status.UNKNOWN));
+	}
+
+	public static ConfigurableApplicationContext createBinderTestContext(String[] additionalClasspathDirectories,
+																		 String... properties)
+			throws IOException {
+		URL[] urls = ObjectUtils.isEmpty(additionalClasspathDirectories) ?
+				new URL[0] : new URL[additionalClasspathDirectories.length];
+		if (!ObjectUtils.isEmpty(additionalClasspathDirectories)) {
+			for (int i = 0; i < additionalClasspathDirectories.length; i++) {
+				urls[i] = new URL(new ClassPathResource(additionalClasspathDirectories[i]).getURL().toString() + "/");
+			}
+		}
+		ClassLoader classLoader = new URLClassLoader(urls, BinderFactoryConfigurationTests.class.getClassLoader());
+		return new SpringApplicationBuilder(SimpleSource.class)
+				.resourceLoader(new DefaultResourceLoader(classLoader))
+				.properties(properties)
+				.web(false)
+				.run();
+	}
+
+	@EnableAutoConfiguration
+	@EnableBinding
+	public static class SimpleSource {
+	}
+}

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/stub1/StubBinder1Configuration.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/stub1/StubBinder1Configuration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.stream.binder.stub1;
 
+import org.springframework.boot.actuate.health.ApplicationHealthIndicator;
+import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.binder.Binder;
@@ -33,5 +35,10 @@ public class StubBinder1Configuration {
 	@ConfigurationProperties("binder1")
 	public Binder<?> binder() {
 		return new StubBinder1();
+	}
+
+	@Bean
+	public HealthIndicator binderHealthIndicator() {
+		return new ApplicationHealthIndicator();
 	}
 }


### PR DESCRIPTION
Resolves #233

- Adds a generic 'bindersHealthIndicator' bean controlled by `management.health.binders.enabled` that tallies results from binders
- Binders are expected to expose one or more health indicators based on the status of the middleware connection. If no health indicators are exposed, the status is deemed to be 'UNKNOWN'
- Add support for Redis and Rabbit based on existing health indicators

Note: Kafka will require a separate health indicator - see https://github.com/spring-cloud/spring-cloud-stream/issues/297