### PR TITLE
Add spring-rabbit explicitly to the dependencies BOM

### DIFF
--- a/spring-cloud-stream-binders/pom.xml
+++ b/spring-cloud-stream-binders/pom.xml
@@ -17,7 +17,7 @@
 	<properties>
 		<kafka.version>0.8.2.1</kafka.version>
 		<curator.version>2.6.0</curator.version>
-        <spring-amqp.version>1.5.4.BUILD-SNAPSHOT</spring-amqp.version>
+		<spring-amqp.version>1.5.4.BUILD-SNAPSHOT</spring-amqp.version>
 	</properties>
 	<modules>
 		<module>spring-cloud-stream-binder-test</module>

--- a/spring-cloud-stream-dependencies/pom.xml
+++ b/spring-cloud-stream-dependencies/pom.xml
@@ -6,7 +6,7 @@
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
 		<version>1.1.0.BUILD-SNAPSHOT</version>
-        <relativePath/>
+		<relativePath/>
 	</parent>
 	<artifactId>spring-cloud-stream-dependencies</artifactId>
 	<version>1.0.0.BUILD-SNAPSHOT</version>
@@ -16,18 +16,19 @@
 	<properties>
 		<rxjava.version>1.0.14</rxjava.version>
 		<spring-integration.version>4.2.4.RELEASE</spring-integration.version>
+		<spring-amqp.version>1.5.4.BUILD-SNAPSHOT</spring-amqp.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-stream</artifactId>
-				<version>1.0.0.BUILD-SNAPSHOT</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-stream-codec</artifactId>
-				<version>1.0.0.BUILD-SNAPSHOT</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
@@ -37,7 +38,7 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-stream-binder-kafka</artifactId>
-				<version>1.0.0.BUILD-SNAPSHOT</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
@@ -47,17 +48,17 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-stream-binder-redis</artifactId>
-				<version>1.0.0.BUILD-SNAPSHOT</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-stream-binder-rabbit</artifactId>
-				<version>1.0.0.BUILD-SNAPSHOT</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-starter-stream-kafka</artifactId>
-				<version>1.0.0.BUILD-SNAPSHOT</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
@@ -67,32 +68,32 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-starter-stream-redis</artifactId>
-				<version>1.0.0.BUILD-SNAPSHOT</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-starter-stream-rabbit</artifactId>
-				<version>1.0.0.BUILD-SNAPSHOT</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-stream-binder-test</artifactId>
-				<version>1.0.0.BUILD-SNAPSHOT</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-stream-module-launcher</artifactId>
-				<version>1.0.0.BUILD-SNAPSHOT</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-stream-test-support</artifactId>
-				<version>1.0.0.BUILD-SNAPSHOT</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-stream-test-support-internal</artifactId>
-				<version>1.0.0.BUILD-SNAPSHOT</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
@@ -118,6 +119,11 @@
 				<groupId>org.objenesis</groupId>
 				<artifactId>objenesis</artifactId>
 				<version>2.1</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.amqp</groupId>
+				<artifactId>spring-rabbit</artifactId>
+				<version>${spring-amqp.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.integration</groupId>

--- a/spring-cloud-stream-samples/pom.xml
+++ b/spring-cloud-stream-samples/pom.xml
@@ -10,9 +10,9 @@
 		<url>http://www.spring.io</url>
 	</organization>
 	<parent>
-	  <groupId>org.springframework.cloud</groupId>
-	  <artifactId>spring-cloud-stream-parent</artifactId>
-	  <version>1.0.0.BUILD-SNAPSHOT</version>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-stream-parent</artifactId>
+		<version>1.0.0.BUILD-SNAPSHOT</version>
 	</parent>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -48,16 +48,16 @@
 		</dependencies>
 	</dependencyManagement>
 	<build>
-      <pluginManagement>
-		<plugins>
-			<plugin>
-				<!--skip deploy (this is just a test module) -->
-				<artifactId>maven-deploy-plugin</artifactId>
-				<configuration>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<!--skip deploy (this is just a test module) -->
+					<artifactId>maven-deploy-plugin</artifactId>
+					<configuration>
 					<skip>true</skip>
-				</configuration>
-			</plugin>
-        </plugins>
-      </pluginManagement>
-    </build>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
 </project>

--- a/spring-cloud-stream-starters/pom.xml
+++ b/spring-cloud-stream-starters/pom.xml
@@ -9,9 +9,9 @@
 		<url>http://www.spring.io</url>
 	</organization>
 	<parent>
-	  <groupId>org.springframework.cloud</groupId>
-	  <artifactId>spring-cloud-stream-parent</artifactId>
-	  <version>1.0.0.BUILD-SNAPSHOT</version>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-stream-parent</artifactId>
+		<version>1.0.0.BUILD-SNAPSHOT</version>
 	</parent>
 	<modules>
 		<module>spring-cloud-starter-stream-rabbit</module>

--- a/spring-cloud-stream-starters/spring-cloud-starter-stream-rabbit/pom.xml
+++ b/spring-cloud-stream-starters/spring-cloud-starter-stream-rabbit/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
@@ -16,6 +17,7 @@
 	</organization>
 	<properties>
 		<main.basedir>${basedir}/../..</main.basedir>
+		<spring-amqp.version>1.5.4.BUILD-SNAPSHOT</spring-amqp.version>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
It actually still has to be managed using a property in
spring-cloud-stream-binders-parent, but this change is for users.
Any user that wants an app using stream and rabbit needs to use the
spring-cloud-dependencies BOM. A gradle user has to do nothing else
with this change. A maven user still has to add an explicit
<spring-aqmp.version/> to the application POM.