### PR TITLE
Add support for resetting offsets in the Kafka bus

### DIFF
--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -155,7 +155,7 @@ public class KafkaMessageChannelBinder extends MessageChannelBinderSupport {
 
 	private static final boolean DEFAULT_RESET_ON_START = false;
 
-	private static final StartingOffset DEFAULT_START = StartingOffset.latest;
+	private static final StartOffset DEFAULT_START = StartOffset.latest;
 
 	private RetryOperations retryOperations;
 
@@ -278,9 +278,9 @@ public class KafkaMessageChannelBinder extends MessageChannelBinderSupport {
 
 	private Mode mode = Mode.embeddedHeaders;
 
-	private boolean resetOnStart = false;
+	private boolean resetOffsets = false;
 
-	private StartingOffset startingOffset = StartingOffset.latest;
+	private StartOffset startOffset = StartOffset.latest;
 
 	public KafkaMessageChannelBinder(ZookeeperConnect zookeeperConnect, String brokers, String zkAddress,
 			 String... headersToMap) {
@@ -442,20 +442,20 @@ public class KafkaMessageChannelBinder extends MessageChannelBinderSupport {
 		this.mode = mode;
 	}
 
-	public boolean isResetOnStart() {
-		return resetOnStart;
+	public boolean isResetOffsets() {
+		return resetOffsets;
 	}
 
-	public void setResetOnStart(boolean resetOnStart) {
-		this.resetOnStart = resetOnStart;
+	public void setResetOffsets(boolean resetOffsets) {
+		this.resetOffsets = resetOffsets;
 	}
 
-	public StartingOffset getStartingOffset() {
-		return startingOffset;
+	public StartOffset getStartOffset() {
+		return startOffset;
 	}
 
-	public void setStartingOffset(StartingOffset startingOffset) {
-		this.startingOffset = startingOffset;
+	public void setStartOffset(StartOffset startOffset) {
+		this.startOffset = startOffset;
 	}
 
 	@Override
@@ -463,11 +463,11 @@ public class KafkaMessageChannelBinder extends MessageChannelBinderSupport {
 		// If the caller provides a group, use it; otherwise
 		// usage of a different consumer group each time achieves pub-sub
 		// but multiple instances of this binding will each get all messages
-		// PubSub consumers reset at the latest time, which allows them to receive only messages sent after
+		// PubSub consumers resetOffsets at the latest time, which allows them to receive only messages sent after
 		// they've been bound
 		String consumerGroup = group == null ? "anonymous." + UUID.randomUUID().toString() : group;
-		long referencePoint = this.startingOffset != null ?
-				startingOffset.getReferencePoint() : OffsetRequest.LatestTime();
+		long referencePoint = this.startOffset != null ?
+				startOffset.getReferencePoint() : OffsetRequest.LatestTime();
 		return createKafkaConsumer(name, inputChannel, properties, consumerGroup, referencePoint);
 	}
 
@@ -704,7 +704,7 @@ public class KafkaMessageChannelBinder extends MessageChannelBinderSupport {
 		// if we have less target partitions than target concurrency, adjust accordingly
 		messageListenerContainer.setConcurrency(Math.min(maxConcurrency, listenedPartitions.size()));
 		OffsetManager offsetManager = createOffsetManager(group, referencePoint);
-		if (resetOnStart) {
+		if (resetOffsets) {
 			offsetManager.resetOffsets(listenedPartitions);
 		}
 		messageListenerContainer.setOffsetManager(offsetManager);
@@ -912,13 +912,13 @@ public class KafkaMessageChannelBinder extends MessageChannelBinderSupport {
 		embeddedHeaders
 	}
 
-	public enum StartingOffset {
+	public enum StartOffset {
 		earliest(OffsetRequest.EarliestTime()),
 		latest(OffsetRequest.LatestTime());
 
 		private final long referencePoint;
 
-		StartingOffset(long referencePoint) {
+		StartOffset(long referencePoint) {
 			this.referencePoint = referencePoint;
 		}
 

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaMessageChannelBinderConfiguration.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaMessageChannelBinderConfiguration.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.stream.binder.kafka.config;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.binder.kafka.KafkaMessageChannelBinder;
 import org.springframework.cloud.stream.config.codec.kryo.KryoCodecAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -72,9 +71,9 @@ public class KafkaMessageChannelBinderConfiguration {
 
 	private int offsetUpdateShutdownTimeout;
 
-	private boolean resetOnStart = false;
+	private boolean resetOffsets = false;
 
-	private KafkaMessageChannelBinder.StartingOffset startingOffset;
+	private KafkaMessageChannelBinder.StartOffset startOffset;
 
 	@Autowired
 	private Codec codec;
@@ -122,8 +121,8 @@ public class KafkaMessageChannelBinderConfiguration {
 				.getReplicationFactor());
 		kafkaMessageChannelBinder.setDefaultRequiredAcks(kafkaBinderConfigurationProperties.getRequiredAcks());
 
-		kafkaMessageChannelBinder.setResetOnStart(resetOnStart);
-		kafkaMessageChannelBinder.setStartingOffset(startingOffset);
+		kafkaMessageChannelBinder.setResetOffsets(resetOffsets);
+		kafkaMessageChannelBinder.setStartOffset(startOffset);
 
 		return kafkaMessageChannelBinder;
 	}
@@ -208,20 +207,20 @@ public class KafkaMessageChannelBinderConfiguration {
 		return toConnectionString(this.brokers, this.defaultBrokerPort);
 	}
 
-	public KafkaMessageChannelBinder.StartingOffset getStartingOffset() {
-		return startingOffset;
+	public KafkaMessageChannelBinder.StartOffset getStartOffset() {
+		return startOffset;
 	}
 
-	public void setStartingOffset(KafkaMessageChannelBinder.StartingOffset startingOffset) {
-		this.startingOffset = startingOffset;
+	public void setStartOffset(KafkaMessageChannelBinder.StartOffset startOffset) {
+		this.startOffset = startOffset;
 	}
 
-	public boolean isResetOnStart() {
-		return resetOnStart;
+	public boolean isResetOffsets() {
+		return resetOffsets;
 	}
 
-	public void setResetOnStart(boolean resetOnStart) {
-		this.resetOnStart = resetOnStart;
+	public void setResetOffsets(boolean resetOffsets) {
+		this.resetOffsets = resetOffsets;
 	}
 
 	/**

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaMessageChannelBinderConfiguration.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaMessageChannelBinderConfiguration.java
@@ -36,7 +36,6 @@ import org.springframework.util.StringUtils;
  * @author Mark Fisher
  */
 @Configuration
-@EnableConfigurationProperties(KafkaBinderConfigurationProperties.class)
 @Import({KryoCodecAutoConfiguration.class, PropertyPlaceholderAutoConfiguration.class})
 @ConfigurationProperties(prefix = "spring.cloud.stream.binder.kafka")
 public class KafkaMessageChannelBinderConfiguration {

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaMessageChannelBinderConfiguration.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaMessageChannelBinderConfiguration.java
@@ -73,6 +73,10 @@ public class KafkaMessageChannelBinderConfiguration {
 
 	private int offsetUpdateShutdownTimeout;
 
+	private boolean resetOnStart = false;
+
+	private KafkaMessageChannelBinder.StartingOffset startingOffset;
+
 	@Autowired
 	private Codec codec;
 
@@ -118,6 +122,9 @@ public class KafkaMessageChannelBinderConfiguration {
 		kafkaMessageChannelBinder.setDefaultReplicationFactor(kafkaBinderConfigurationProperties
 				.getReplicationFactor());
 		kafkaMessageChannelBinder.setDefaultRequiredAcks(kafkaBinderConfigurationProperties.getRequiredAcks());
+
+		kafkaMessageChannelBinder.setResetOnStart(resetOnStart);
+		kafkaMessageChannelBinder.setStartingOffset(startingOffset);
 
 		return kafkaMessageChannelBinder;
 	}
@@ -200,6 +207,22 @@ public class KafkaMessageChannelBinderConfiguration {
 
 	public String getKafkaConnectionString() {
 		return toConnectionString(this.brokers, this.defaultBrokerPort);
+	}
+
+	public KafkaMessageChannelBinder.StartingOffset getStartingOffset() {
+		return startingOffset;
+	}
+
+	public void setStartingOffset(KafkaMessageChannelBinder.StartingOffset startingOffset) {
+		this.startingOffset = startingOffset;
+	}
+
+	public boolean isResetOnStart() {
+		return resetOnStart;
+	}
+
+	public void setResetOnStart(boolean resetOnStart) {
+		this.resetOnStart = resetOnStart;
 	}
 
 	/**

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaServiceAutoConfiguration.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaServiceAutoConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.stream.binder.kafka.config;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.test.ImportAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.binder.Binder;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -30,6 +31,7 @@ import org.springframework.context.annotation.PropertySource;
  */
 @Configuration
 @ConditionalOnMissingBean(Binder.class)
+@EnableConfigurationProperties({KafkaBinderConfigurationProperties.class,KafkaMessageChannelBinderConfiguration.class})
 @ImportAutoConfiguration(KafkaMessageChannelBinderConfiguration.class)
 public class KafkaServiceAutoConfiguration {
 

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
@@ -362,7 +362,7 @@ public class KafkaBinderTests extends PartitionCapableBinderTests {
 		context.refresh();
 		binder.setApplicationContext(context);
 		binder.afterPropertiesSet();
-		binder.setStartingOffset(KafkaMessageChannelBinder.StartingOffset.earliest);
+		binder.setStartOffset(KafkaMessageChannelBinder.StartOffset.earliest);
 		DirectChannel output = new DirectChannel();
 		Properties properties = new Properties();
 		QueueChannel input1 = new QueueChannel();
@@ -389,8 +389,8 @@ public class KafkaBinderTests extends PartitionCapableBinderTests {
 		GenericApplicationContext context = new GenericApplicationContext();
 		context.refresh();
 		binder.setApplicationContext(context);
-		binder.setStartingOffset(KafkaMessageChannelBinder.StartingOffset.earliest);
-		binder.setResetOnStart(true);
+		binder.setStartOffset(KafkaMessageChannelBinder.StartOffset.earliest);
+		binder.setResetOffsets(true);
 		binder.afterPropertiesSet();
 		DirectChannel output = new DirectChannel();
 		Properties properties = new Properties();
@@ -443,7 +443,7 @@ public class KafkaBinderTests extends PartitionCapableBinderTests {
 		context.refresh();
 		binder.setApplicationContext(context);
 		binder.afterPropertiesSet();
-		binder.setStartingOffset(KafkaMessageChannelBinder.StartingOffset.earliest);
+		binder.setStartOffset(KafkaMessageChannelBinder.StartOffset.earliest);
 		DirectChannel output = new DirectChannel();
 		Properties properties = new Properties();
 		QueueChannel input1 = new QueueChannel();

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-test/src/main/java/org/springframework/cloud/stream/binder/PartitionCapableBinderTests.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-test/src/main/java/org/springframework/cloud/stream/binder/PartitionCapableBinderTests.java
@@ -51,6 +51,7 @@ import org.springframework.messaging.support.GenericMessage;
  *
  * @author Gary Russell
  * @author Mark Fisher
+ * @author Marius Bogoevici
  */
 abstract public class PartitionCapableBinderTests extends BrokerBinderTests {
 

--- a/spring-cloud-stream-samples/source/pom.xml
+++ b/spring-cloud-stream-samples/source/pom.xml
@@ -24,7 +24,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-binder-redis</artifactId>
+			<artifactId>spring-cloud-stream-binder-kafka</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
@@ -145,7 +145,7 @@ public class DefaultBinderFactory<T> implements BinderFactory<T>, DisposableBean
 			if (useApplicationContextAsParent) {
 				springApplicationBuilder.parent(context);
 			}
-			else if (environment != null && binderConfiguration.isInheritEnvironment()) {
+			if (useApplicationContextAsParent || (environment != null && binderConfiguration.isInheritEnvironment())) {
 				StandardEnvironment binderEnvironment = new StandardEnvironment();
 				binderEnvironment.merge(environment);
 				springApplicationBuilder.environment(binderEnvironment);


### PR DESCRIPTION
- add two additional binder properties `startOffset` (with supported values `earliest` and `latest`) and `resetOffsets` that allow the binder to reset consumers to the earliest and latest offsets in the bus. 
- ensure that environment is merged correctly
- tests 

TBD: provide configuration options per-binding (separate issue)

In summary, allows users to start a Kafka-bound app with the following options:

````
java -jar log-sink/target/log-sink-1.0.0.BUILD-SNAPSHOT-exec.jar --spring.cloud.stream.bindings.input.destination=mydestination --spring.cloud.stream.bindings.input.group=group1 --server.port=9003 --spring.cloud.stream.binder.kafka.resetOffsets=true --spring.cloud.stream.binder.kafka.startOffset=earliest
````
(`latest` is also supported for `startOffset`)