### PR TITLE
Use kafka on the travis infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jdk:
 services:
   - redis-server
 env:
-  - REDIS_TIMEOUT_MULTIPLIER=3 KAFKA_TIMEOUT_MULTIPLIER=10
+  - REDIS_TIMEOUT_MULTIPLIER=3 KAFKA_TIMEOUT_MULTIPLIER=30
 before_install:
   - wget http://www.us.apache.org/dist/kafka/0.8.2.1/kafka_2.10-0.8.2.1.tgz -O kafka.tgz
   - mkdir -p kafka && tar xzf kafka.tgz -C kafka --strip-components 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,19 @@ jdk:
   - oraclejdk8
 services:
   - redis-server
+env:
+  - REDIS_TIMEOUT_MULTIPLIER=3 KAFKA_TIMEOUT_MULTIPLIER=10
+before_install:
+  - wget http://www.us.apache.org/dist/kafka/0.8.2.1/kafka_2.10-0.8.2.1.tgz -O kafka.tgz
+  - mkdir -p kafka && tar xzf kafka.tgz -C kafka --strip-components 1
+  - nohup bash -c "cd kafka && bin/zookeeper-server-start.sh config/zookeeper.properties &"
+  - nohup bash -c "cd kafka && bin/kafka-server-start.sh config/server.properties &"
+  - sleep 5
 install: true
 # The environment variable ${TRAVIS_PULL_REQUEST} is set to "false" when the build 
 # is for a normal branch commit. When the build is for a pull request, it will 
 # contain the pull request’s number.
 script:
   - '[ "${TRAVIS_PULL_REQUEST}" != "false" ] || ./mvnw -s .settings.xml package -Pfull -U -Dmaven.test.redirectTestOutputToFile=false'
-  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] || ./mvnw -s .settings.xml package -DskipTests -U -Dmaven.test.redirectTestOutputToFile=false'
+  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] || ./mvnw -s .settings.xml package -U -Dmaven.test.redirectTestOutputToFile=false'
 

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import kafka.api.OffsetRequest;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -53,8 +54,6 @@ import org.springframework.integration.kafka.support.ZookeeperConnect;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
-
-import kafka.api.OffsetRequest;
 
 
 /**
@@ -186,7 +185,7 @@ public class KafkaBinderTests extends PartitionCapableBinderTests {
 		// Let the consumer actually bind to the producer before sending a msg
 		binderBindUnbindLatency();
 		moduleOutputChannel.send(message);
-		Message<?> inbound = moduleInputChannel.receive(2000);
+		Message<?> inbound = moduleInputChannel.receive((int)(2000 * timeoutMultiplier));
 		assertNotNull(inbound);
 		assertArrayEquals(ratherBigPayload, (byte[]) inbound.getPayload());
 		Collection<Partition> partitions = binder.getCoreBinder().getConnectionFactory().getPartitions(
@@ -219,7 +218,7 @@ public class KafkaBinderTests extends PartitionCapableBinderTests {
 		// Let the consumer actually bind to the producer before sending a msg
 		binderBindUnbindLatency();
 		moduleOutputChannel.send(message);
-		Message<?> inbound = moduleInputChannel.receive(2000);
+		Message<?> inbound = moduleInputChannel.receive((int)(2000 * timeoutMultiplier));
 		assertNotNull(inbound);
 		assertArrayEquals(ratherBigPayload, (byte[]) inbound.getPayload());
 		Collection<Partition> partitions = binder.getCoreBinder().getConnectionFactory().getPartitions(
@@ -251,7 +250,7 @@ public class KafkaBinderTests extends PartitionCapableBinderTests {
 		// Let the consumer actually bind to the producer before sending a msg
 		binderBindUnbindLatency();
 		moduleOutputChannel.send(message);
-		Message<?> inbound = moduleInputChannel.receive(2000);
+		Message<?> inbound = moduleInputChannel.receive((int)(2000 * timeoutMultiplier));
 		assertNotNull(inbound);
 		assertArrayEquals(ratherBigPayload, (byte[]) inbound.getPayload());
 		Collection<Partition> partitions = binder.getCoreBinder().getConnectionFactory().getPartitions(
@@ -283,7 +282,7 @@ public class KafkaBinderTests extends PartitionCapableBinderTests {
 		// Let the consumer actually bind to the producer before sending a msg
 		binderBindUnbindLatency();
 		moduleOutputChannel.send(message);
-		Message<?> inbound = moduleInputChannel.receive(2000);
+		Message<?> inbound = moduleInputChannel.receive((int)(2000 * timeoutMultiplier));
 		assertNotNull(inbound);
 		assertArrayEquals(ratherBigPayload, (byte[]) inbound.getPayload());
 		Collection<Partition> partitions = binder.getCoreBinder().getConnectionFactory().getPartitions(
@@ -315,7 +314,7 @@ public class KafkaBinderTests extends PartitionCapableBinderTests {
 		// Let the consumer actually bind to the producer before sending a msg
 		binderBindUnbindLatency();
 		moduleOutputChannel.send(message);
-		Message<?> inbound = moduleInputChannel.receive(2000);
+		Message<?> inbound = moduleInputChannel.receive((int)(2000 * timeoutMultiplier));
 		assertNotNull(inbound);
 		assertArrayEquals(ratherBigPayload, (byte[]) inbound.getPayload());
 		Collection<Partition> partitions = binder.getCoreBinder().getConnectionFactory().getPartitions(
@@ -343,11 +342,11 @@ public class KafkaBinderTests extends PartitionCapableBinderTests {
 		String testPayload1 = "foo-" + UUID.randomUUID().toString();
 		output.send(new GenericMessage<>(testPayload1.getBytes()));
 		binder.bindConsumer(testTopicName, "startOffsets", input1, properties);
-		Message<byte[]> receivedMessage1 = (Message<byte[]>) input1.receive(1000);
+		Message<byte[]> receivedMessage1 = (Message<byte[]>) input1.receive((int)(1000 * timeoutMultiplier));
 		assertThat(receivedMessage1, is(nullValue()));
 		String testPayload2 = "foo-" + UUID.randomUUID().toString();
 		output.send(new GenericMessage<>(testPayload2.getBytes()));
-		Message<byte[]> receivedMessage2 = (Message<byte[]>) input1.receive(1000);
+		Message<byte[]> receivedMessage2 = (Message<byte[]>) input1.receive((int)(1000 * timeoutMultiplier));
 		assertThat(receivedMessage2, not(nullValue()));
 		assertThat(new String(receivedMessage2.getPayload()), equalTo(testPayload2));
 	}
@@ -371,11 +370,11 @@ public class KafkaBinderTests extends PartitionCapableBinderTests {
 		String testPayload1 = "foo-" + UUID.randomUUID().toString();
 		output.send(new GenericMessage<>(testPayload1.getBytes()));
 		binder.bindConsumer(testTopicName, "startOffsets", input1, properties);
-		Message<byte[]> receivedMessage1 = (Message<byte[]>) input1.receive(1000);
+		Message<byte[]> receivedMessage1 = (Message<byte[]>) input1.receive((int)(1000 * timeoutMultiplier));
 		assertThat(receivedMessage1, not(nullValue()));
 		String testPayload2 = "foo-" + UUID.randomUUID().toString();
 		output.send(new GenericMessage<>(testPayload2.getBytes()));
-		Message<byte[]> receivedMessage2 = (Message<byte[]>) input1.receive(1000);
+		Message<byte[]> receivedMessage2 = (Message<byte[]>) input1.receive((int)(1000 * timeoutMultiplier));
 		assertThat(receivedMessage2, not(nullValue()));
 		assertThat(new String(receivedMessage2.getPayload()), equalTo(testPayload2));
 	}
@@ -402,11 +401,11 @@ public class KafkaBinderTests extends PartitionCapableBinderTests {
 		output.send(new GenericMessage<>(testPayload1.getBytes()));
 		Binding<MessageChannel> consumerBinding =
 				binder.bindConsumer(testTopicName, "startOffsets", input1, properties);
-		Message<byte[]> receivedMessage1 = (Message<byte[]>) input1.receive(1000);
+		Message<byte[]> receivedMessage1 = (Message<byte[]>) input1.receive((int)(1000 * timeoutMultiplier));
 		assertThat(receivedMessage1, not(nullValue()));
 		String testPayload2 = "foo-" + UUID.randomUUID().toString();
 		output.send(new GenericMessage<>(testPayload2.getBytes()));
-		Message<byte[]> receivedMessage2 = (Message<byte[]>) input1.receive(1000);
+		Message<byte[]> receivedMessage2 = (Message<byte[]>) input1.receive((int)(1000 * timeoutMultiplier));
 		assertThat(receivedMessage2, not(nullValue()));
 		assertThat(new String(receivedMessage2.getPayload()), equalTo(testPayload2));
 		binder.unbind(consumerBinding);
@@ -416,13 +415,13 @@ public class KafkaBinderTests extends PartitionCapableBinderTests {
 
 		consumerBinding =
 				binder.bindConsumer(testTopicName, "startOffsets", input1, properties);
-		Message<byte[]> receivedMessage4 = (Message<byte[]>) input1.receive(1000);
+		Message<byte[]> receivedMessage4 = (Message<byte[]>) input1.receive((int)(1000 * timeoutMultiplier));
 		assertThat(receivedMessage4, not(nullValue()));
 		assertThat(new String(receivedMessage4.getPayload()), equalTo(testPayload1));
-		Message<byte[]> receivedMessage5 = (Message<byte[]>) input1.receive(1000);
+		Message<byte[]> receivedMessage5 = (Message<byte[]>) input1.receive((int)(1000 * timeoutMultiplier));
 		assertThat(receivedMessage5, not(nullValue()));
 		assertThat(new String(receivedMessage5.getPayload()), equalTo(testPayload2));
-		Message<byte[]> receivedMessage6 = (Message<byte[]>) input1.receive(1000);
+		Message<byte[]> receivedMessage6 = (Message<byte[]>) input1.receive((int)(1000 * timeoutMultiplier));
 		assertThat(receivedMessage6, not(nullValue()));
 		assertThat(new String(receivedMessage6.getPayload()), equalTo(testPayload3));
 		binder.unbind(consumerBinding);
@@ -448,11 +447,11 @@ public class KafkaBinderTests extends PartitionCapableBinderTests {
 		String testPayload1 = "foo-" + UUID.randomUUID().toString();
 		output.send(new GenericMessage<>(testPayload1.getBytes()));
 		Binding<MessageChannel> consumerBinding = binder.bindConsumer(testTopicName, "startOffsets", input1, properties);
-		Message<byte[]> receivedMessage1 = (Message<byte[]>) input1.receive(1000);
+		Message<byte[]> receivedMessage1 = (Message<byte[]>) input1.receive((int)(1000 * timeoutMultiplier));
 		assertThat(receivedMessage1, not(nullValue()));
 		String testPayload2 = "foo-" + UUID.randomUUID().toString();
 		output.send(new GenericMessage<>(testPayload2.getBytes()));
-		Message<byte[]> receivedMessage2 = (Message<byte[]>) input1.receive(1000);
+		Message<byte[]> receivedMessage2 = (Message<byte[]>) input1.receive((int)(1000 * timeoutMultiplier));
 		assertThat(receivedMessage2, not(nullValue()));
 		assertThat(new String(receivedMessage2.getPayload()), equalTo(testPayload2));
 		binder.unbind(consumerBinding);
@@ -462,7 +461,7 @@ public class KafkaBinderTests extends PartitionCapableBinderTests {
 
 		consumerBinding =
 				binder.bindConsumer(testTopicName, "startOffsets", input1, properties);
-		Message<byte[]> receivedMessage3 = (Message<byte[]>) input1.receive(1000);
+		Message<byte[]> receivedMessage3 = (Message<byte[]>) input1.receive((int)(1000 * timeoutMultiplier));
 		assertThat(receivedMessage3, not(nullValue()));
 		assertThat(new String(receivedMessage3.getPayload()), equalTo(testPayload3));
 		binder.unbind(consumerBinding);

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
@@ -157,7 +157,7 @@ public class KafkaBinderTests extends PartitionCapableBinderTests {
 			// Let the consumer actually bind to the producer before sending a msg
 			binderBindUnbindLatency();
 			moduleOutputChannel.send(message);
-			Message<?> inbound = moduleInputChannel.receive(2000);
+			Message<?> inbound = receive(moduleInputChannel);
 			assertNotNull(inbound);
 			assertArrayEquals(ratherBigPayload, (byte[]) inbound.getPayload());
 			binder.unbind(producerBinding);
@@ -185,7 +185,7 @@ public class KafkaBinderTests extends PartitionCapableBinderTests {
 		// Let the consumer actually bind to the producer before sending a msg
 		binderBindUnbindLatency();
 		moduleOutputChannel.send(message);
-		Message<?> inbound = moduleInputChannel.receive((int)(2000 * timeoutMultiplier));
+		Message<?> inbound = receive(moduleInputChannel);
 		assertNotNull(inbound);
 		assertArrayEquals(ratherBigPayload, (byte[]) inbound.getPayload());
 		Collection<Partition> partitions = binder.getCoreBinder().getConnectionFactory().getPartitions(
@@ -218,7 +218,7 @@ public class KafkaBinderTests extends PartitionCapableBinderTests {
 		// Let the consumer actually bind to the producer before sending a msg
 		binderBindUnbindLatency();
 		moduleOutputChannel.send(message);
-		Message<?> inbound = moduleInputChannel.receive((int)(2000 * timeoutMultiplier));
+		Message<?> inbound = receive(moduleInputChannel);
 		assertNotNull(inbound);
 		assertArrayEquals(ratherBigPayload, (byte[]) inbound.getPayload());
 		Collection<Partition> partitions = binder.getCoreBinder().getConnectionFactory().getPartitions(
@@ -250,7 +250,7 @@ public class KafkaBinderTests extends PartitionCapableBinderTests {
 		// Let the consumer actually bind to the producer before sending a msg
 		binderBindUnbindLatency();
 		moduleOutputChannel.send(message);
-		Message<?> inbound = moduleInputChannel.receive((int)(2000 * timeoutMultiplier));
+		Message<?> inbound = receive(moduleInputChannel);
 		assertNotNull(inbound);
 		assertArrayEquals(ratherBigPayload, (byte[]) inbound.getPayload());
 		Collection<Partition> partitions = binder.getCoreBinder().getConnectionFactory().getPartitions(
@@ -282,7 +282,7 @@ public class KafkaBinderTests extends PartitionCapableBinderTests {
 		// Let the consumer actually bind to the producer before sending a msg
 		binderBindUnbindLatency();
 		moduleOutputChannel.send(message);
-		Message<?> inbound = moduleInputChannel.receive((int)(2000 * timeoutMultiplier));
+		Message<?> inbound = receive(moduleInputChannel);
 		assertNotNull(inbound);
 		assertArrayEquals(ratherBigPayload, (byte[]) inbound.getPayload());
 		Collection<Partition> partitions = binder.getCoreBinder().getConnectionFactory().getPartitions(
@@ -314,7 +314,7 @@ public class KafkaBinderTests extends PartitionCapableBinderTests {
 		// Let the consumer actually bind to the producer before sending a msg
 		binderBindUnbindLatency();
 		moduleOutputChannel.send(message);
-		Message<?> inbound = moduleInputChannel.receive((int)(2000 * timeoutMultiplier));
+		Message<?> inbound = receive(moduleInputChannel);
 		assertNotNull(inbound);
 		assertArrayEquals(ratherBigPayload, (byte[]) inbound.getPayload());
 		Collection<Partition> partitions = binder.getCoreBinder().getConnectionFactory().getPartitions(
@@ -342,11 +342,11 @@ public class KafkaBinderTests extends PartitionCapableBinderTests {
 		String testPayload1 = "foo-" + UUID.randomUUID().toString();
 		output.send(new GenericMessage<>(testPayload1.getBytes()));
 		binder.bindConsumer(testTopicName, "startOffsets", input1, properties);
-		Message<byte[]> receivedMessage1 = (Message<byte[]>) input1.receive((int)(1000 * timeoutMultiplier));
+		Message<byte[]> receivedMessage1 = (Message<byte[]>) receive(input1);
 		assertThat(receivedMessage1, is(nullValue()));
 		String testPayload2 = "foo-" + UUID.randomUUID().toString();
 		output.send(new GenericMessage<>(testPayload2.getBytes()));
-		Message<byte[]> receivedMessage2 = (Message<byte[]>) input1.receive((int)(1000 * timeoutMultiplier));
+		Message<byte[]> receivedMessage2 = (Message<byte[]>) receive(input1);
 		assertThat(receivedMessage2, not(nullValue()));
 		assertThat(new String(receivedMessage2.getPayload()), equalTo(testPayload2));
 	}
@@ -370,11 +370,11 @@ public class KafkaBinderTests extends PartitionCapableBinderTests {
 		String testPayload1 = "foo-" + UUID.randomUUID().toString();
 		output.send(new GenericMessage<>(testPayload1.getBytes()));
 		binder.bindConsumer(testTopicName, "startOffsets", input1, properties);
-		Message<byte[]> receivedMessage1 = (Message<byte[]>) input1.receive((int)(1000 * timeoutMultiplier));
+		Message<byte[]> receivedMessage1 = (Message<byte[]>) receive(input1);
 		assertThat(receivedMessage1, not(nullValue()));
 		String testPayload2 = "foo-" + UUID.randomUUID().toString();
 		output.send(new GenericMessage<>(testPayload2.getBytes()));
-		Message<byte[]> receivedMessage2 = (Message<byte[]>) input1.receive((int)(1000 * timeoutMultiplier));
+		Message<byte[]> receivedMessage2 = (Message<byte[]>) receive(input1);
 		assertThat(receivedMessage2, not(nullValue()));
 		assertThat(new String(receivedMessage2.getPayload()), equalTo(testPayload2));
 	}
@@ -401,11 +401,11 @@ public class KafkaBinderTests extends PartitionCapableBinderTests {
 		output.send(new GenericMessage<>(testPayload1.getBytes()));
 		Binding<MessageChannel> consumerBinding =
 				binder.bindConsumer(testTopicName, "startOffsets", input1, properties);
-		Message<byte[]> receivedMessage1 = (Message<byte[]>) input1.receive((int)(1000 * timeoutMultiplier));
+		Message<byte[]> receivedMessage1 = (Message<byte[]>) receive(input1);
 		assertThat(receivedMessage1, not(nullValue()));
 		String testPayload2 = "foo-" + UUID.randomUUID().toString();
 		output.send(new GenericMessage<>(testPayload2.getBytes()));
-		Message<byte[]> receivedMessage2 = (Message<byte[]>) input1.receive((int)(1000 * timeoutMultiplier));
+		Message<byte[]> receivedMessage2 = (Message<byte[]>) receive(input1);
 		assertThat(receivedMessage2, not(nullValue()));
 		assertThat(new String(receivedMessage2.getPayload()), equalTo(testPayload2));
 		binder.unbind(consumerBinding);
@@ -415,13 +415,13 @@ public class KafkaBinderTests extends PartitionCapableBinderTests {
 
 		consumerBinding =
 				binder.bindConsumer(testTopicName, "startOffsets", input1, properties);
-		Message<byte[]> receivedMessage4 = (Message<byte[]>) input1.receive((int)(1000 * timeoutMultiplier));
+		Message<byte[]> receivedMessage4 = (Message<byte[]>) receive(input1);
 		assertThat(receivedMessage4, not(nullValue()));
 		assertThat(new String(receivedMessage4.getPayload()), equalTo(testPayload1));
-		Message<byte[]> receivedMessage5 = (Message<byte[]>) input1.receive((int)(1000 * timeoutMultiplier));
+		Message<byte[]> receivedMessage5 = (Message<byte[]>) receive(input1);
 		assertThat(receivedMessage5, not(nullValue()));
 		assertThat(new String(receivedMessage5.getPayload()), equalTo(testPayload2));
-		Message<byte[]> receivedMessage6 = (Message<byte[]>) input1.receive((int)(1000 * timeoutMultiplier));
+		Message<byte[]> receivedMessage6 = (Message<byte[]>) receive(input1);
 		assertThat(receivedMessage6, not(nullValue()));
 		assertThat(new String(receivedMessage6.getPayload()), equalTo(testPayload3));
 		binder.unbind(consumerBinding);
@@ -447,11 +447,11 @@ public class KafkaBinderTests extends PartitionCapableBinderTests {
 		String testPayload1 = "foo-" + UUID.randomUUID().toString();
 		output.send(new GenericMessage<>(testPayload1.getBytes()));
 		Binding<MessageChannel> consumerBinding = binder.bindConsumer(testTopicName, "startOffsets", input1, properties);
-		Message<byte[]> receivedMessage1 = (Message<byte[]>) input1.receive((int)(1000 * timeoutMultiplier));
+		Message<byte[]> receivedMessage1 = (Message<byte[]>) receive(input1);
 		assertThat(receivedMessage1, not(nullValue()));
 		String testPayload2 = "foo-" + UUID.randomUUID().toString();
 		output.send(new GenericMessage<>(testPayload2.getBytes()));
-		Message<byte[]> receivedMessage2 = (Message<byte[]>) input1.receive((int)(1000 * timeoutMultiplier));
+		Message<byte[]> receivedMessage2 = (Message<byte[]>) receive(input1);
 		assertThat(receivedMessage2, not(nullValue()));
 		assertThat(new String(receivedMessage2.getPayload()), equalTo(testPayload2));
 		binder.unbind(consumerBinding);
@@ -461,7 +461,7 @@ public class KafkaBinderTests extends PartitionCapableBinderTests {
 
 		consumerBinding =
 				binder.bindConsumer(testTopicName, "startOffsets", input1, properties);
-		Message<byte[]> receivedMessage3 = (Message<byte[]>) input1.receive((int)(1000 * timeoutMultiplier));
+		Message<byte[]> receivedMessage3 = (Message<byte[]>) receive(input1);
 		assertThat(receivedMessage3, not(nullValue()));
 		assertThat(new String(receivedMessage3.getPayload()), equalTo(testPayload3));
 		binder.unbind(consumerBinding);

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/RawModeKafkaBinderTests.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/RawModeKafkaBinderTests.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -52,6 +53,14 @@ import org.springframework.messaging.support.GenericMessage;
  * @author Mark Fisher
  */
 public class RawModeKafkaBinderTests extends KafkaBinderTests {
+
+	@Before
+	public void init() {
+		String multiplier = System.getenv("KAFKA_TIMEOUT_MULTIPLIER");
+		if (multiplier != null) {
+			timeoutMultiplier = Double.parseDouble(multiplier);
+		}
+	}
 
 	@Override
 	protected KafkaTestBinder createKafkaTestBinder() {
@@ -95,11 +104,11 @@ public class RawModeKafkaBinderTests extends KafkaBinderTests {
 		output.send(new GenericMessage<>(new byte[]{(byte)1}));
 		output.send(new GenericMessage<>(new byte[]{(byte)2}));
 
-		Message<?> receive0 = input0.receive(1000);
+		Message<?> receive0 = input0.receive((int)(1000 * timeoutMultiplier));
 		assertNotNull(receive0);
-		Message<?> receive1 = input1.receive(1000);
+		Message<?> receive1 = input1.receive((int)(1000 * timeoutMultiplier));
 		assertNotNull(receive1);
-		Message<?> receive2 = input2.receive(1000);
+		Message<?> receive2 = input2.receive((int)(1000 * timeoutMultiplier));
 		assertNotNull(receive2);
 
 		assertThat(Arrays.asList(
@@ -164,11 +173,11 @@ public class RawModeKafkaBinderTests extends KafkaBinderTests {
 		output.send(new GenericMessage<>(new byte[]{1}));
 		output.send(new GenericMessage<>(new byte[]{0}));
 
-		Message<?> receive0 = input0.receive(1000);
+		Message<?> receive0 = input0.receive((int)(1000 * timeoutMultiplier));
 		assertNotNull(receive0);
-		Message<?> receive1 = input1.receive(1000);
+		Message<?> receive1 = input1.receive((int)(1000 * timeoutMultiplier));
 		assertNotNull(receive1);
-		Message<?> receive2 = input2.receive(1000);
+		Message<?> receive2 = input2.receive((int)(1000 * timeoutMultiplier));
 		assertNotNull(receive2);
 
 
@@ -196,7 +205,7 @@ public class RawModeKafkaBinderTests extends KafkaBinderTests {
 		// Let the consumer actually bind to the producer before sending a msg
 		binderBindUnbindLatency();
 		moduleOutputChannel.send(message);
-		Message<?> inbound = moduleInputChannel.receive(5000);
+		Message<?> inbound = moduleInputChannel.receive((int)(5000 * timeoutMultiplier));
 		assertNotNull(inbound);
 		assertEquals("foo", new String((byte[])inbound.getPayload()));
 		binder.unbind(producerBinding);
@@ -233,12 +242,12 @@ public class RawModeKafkaBinderTests extends KafkaBinderTests {
 		boolean retried = false;
 		while (!success) {
 			moduleOutputChannel.send(message);
-			Message<?> inbound = module1InputChannel.receive(5000);
+			Message<?> inbound = module1InputChannel.receive((int)(5000 * timeoutMultiplier));
 			assertNotNull(inbound);
 			assertEquals("foo", new String((byte[])inbound.getPayload()));
 
-			Message<?> tapped1 = module2InputChannel.receive(5000);
-			Message<?> tapped2 = module3InputChannel.receive(5000);
+			Message<?> tapped1 = module2InputChannel.receive((int)(5000 * timeoutMultiplier));
+			Message<?> tapped2 = module3InputChannel.receive((int)(5000 * timeoutMultiplier));
 			if (tapped1 == null || tapped2 == null) {
 				// listener may not have started
 				assertFalse("Failed to receive tap after retry", retried);
@@ -255,15 +264,15 @@ public class RawModeKafkaBinderTests extends KafkaBinderTests {
 		moduleOutputChannel.send(message2);
 
 		// other tap still receives messages
-		Message<?> tapped = module2InputChannel.receive(5000);
+		Message<?> tapped = module2InputChannel.receive((int)(5000 * timeoutMultiplier));
 		assertNotNull(tapped);
 
 		// removed tap does not
-		assertNull(module3InputChannel.receive(1000));
+		assertNull(module3InputChannel.receive((int)(1000 * timeoutMultiplier)));
 
 		// re-subscribed tap does receive the message
 		input3Binding = binder.bindConsumer(barTapName, "tap2", module3InputChannel, null);
-		assertNotNull(module3InputChannel.receive(1000));
+		assertNotNull(module3InputChannel.receive((int)(1000 * timeoutMultiplier)));
 
 		// clean up
 		binder.unbind(input1Binding);

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/RawModeKafkaBinderTests.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/RawModeKafkaBinderTests.java
@@ -104,11 +104,11 @@ public class RawModeKafkaBinderTests extends KafkaBinderTests {
 		output.send(new GenericMessage<>(new byte[]{(byte)1}));
 		output.send(new GenericMessage<>(new byte[]{(byte)2}));
 
-		Message<?> receive0 = input0.receive((int)(1000 * timeoutMultiplier));
+		Message<?> receive0 = receive(input0);
 		assertNotNull(receive0);
-		Message<?> receive1 = input1.receive((int)(1000 * timeoutMultiplier));
+		Message<?> receive1 = receive(input1);
 		assertNotNull(receive1);
-		Message<?> receive2 = input2.receive((int)(1000 * timeoutMultiplier));
+		Message<?> receive2 = receive(input2);
 		assertNotNull(receive2);
 
 		assertThat(Arrays.asList(
@@ -173,11 +173,11 @@ public class RawModeKafkaBinderTests extends KafkaBinderTests {
 		output.send(new GenericMessage<>(new byte[]{1}));
 		output.send(new GenericMessage<>(new byte[]{0}));
 
-		Message<?> receive0 = input0.receive((int)(1000 * timeoutMultiplier));
+		Message<?> receive0 = receive(input0);
 		assertNotNull(receive0);
-		Message<?> receive1 = input1.receive((int)(1000 * timeoutMultiplier));
+		Message<?> receive1 = receive(input1);
 		assertNotNull(receive1);
-		Message<?> receive2 = input2.receive((int)(1000 * timeoutMultiplier));
+		Message<?> receive2 = receive(input2);
 		assertNotNull(receive2);
 
 
@@ -205,7 +205,7 @@ public class RawModeKafkaBinderTests extends KafkaBinderTests {
 		// Let the consumer actually bind to the producer before sending a msg
 		binderBindUnbindLatency();
 		moduleOutputChannel.send(message);
-		Message<?> inbound = moduleInputChannel.receive((int)(5000 * timeoutMultiplier));
+		Message<?> inbound = receive(moduleInputChannel);
 		assertNotNull(inbound);
 		assertEquals("foo", new String((byte[])inbound.getPayload()));
 		binder.unbind(producerBinding);
@@ -242,12 +242,12 @@ public class RawModeKafkaBinderTests extends KafkaBinderTests {
 		boolean retried = false;
 		while (!success) {
 			moduleOutputChannel.send(message);
-			Message<?> inbound = module1InputChannel.receive((int)(5000 * timeoutMultiplier));
+			Message<?> inbound = receive(module1InputChannel);
 			assertNotNull(inbound);
 			assertEquals("foo", new String((byte[])inbound.getPayload()));
 
-			Message<?> tapped1 = module2InputChannel.receive((int)(5000 * timeoutMultiplier));
-			Message<?> tapped2 = module3InputChannel.receive((int)(5000 * timeoutMultiplier));
+			Message<?> tapped1 = receive(module2InputChannel);
+			Message<?> tapped2 = receive(module3InputChannel);
 			if (tapped1 == null || tapped2 == null) {
 				// listener may not have started
 				assertFalse("Failed to receive tap after retry", retried);
@@ -264,15 +264,15 @@ public class RawModeKafkaBinderTests extends KafkaBinderTests {
 		moduleOutputChannel.send(message2);
 
 		// other tap still receives messages
-		Message<?> tapped = module2InputChannel.receive((int)(5000 * timeoutMultiplier));
+		Message<?> tapped = receive(module2InputChannel);
 		assertNotNull(tapped);
 
 		// removed tap does not
-		assertNull(module3InputChannel.receive((int)(1000 * timeoutMultiplier)));
+		assertNull(receive(module3InputChannel));
 
 		// re-subscribed tap does receive the message
 		input3Binding = binder.bindConsumer(barTapName, "tap2", module3InputChannel, null);
-		assertNotNull(module3InputChannel.receive((int)(1000 * timeoutMultiplier)));
+		assertNotNull(receive(module3InputChannel));
 
 		// clean up
 		binder.unbind(input1Binding);

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-test/src/main/java/org/springframework/cloud/stream/binder/AbstractBinderTests.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-test/src/main/java/org/springframework/cloud/stream/binder/AbstractBinderTests.java
@@ -36,6 +36,7 @@ import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.PollableChannel;
 
 /**
  * @author Gary Russell
@@ -55,6 +56,14 @@ public abstract class AbstractBinderTests {
 	 * in an environment that is known to be slow (e.g. travis).
 	 */
 	protected double timeoutMultiplier = 1.0D;
+
+	/**
+	 * Attempt to receive a message on the given channel,
+	 * waiting up to 1s (times the {@link #timeoutMultiplier}).
+	 */
+	protected Message<?> receive(PollableChannel channel) {
+		return channel.receive((int)(1000 * timeoutMultiplier));
+	}
 
 	@Test
 	public void testClean() throws Exception {
@@ -88,7 +97,7 @@ public abstract class AbstractBinderTests {
 		// Let the consumer actually bind to the producer before sending a msg
 		binderBindUnbindLatency();
 		moduleOutputChannel.send(message);
-		Message<?> inbound = moduleInputChannel.receive((int) (5000 * timeoutMultiplier));
+		Message<?> inbound = receive(moduleInputChannel);
 		assertNotNull(inbound);
 		assertEquals("foo", inbound.getPayload());
 		assertNull(inbound.getHeaders().get(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE));
@@ -108,7 +117,7 @@ public abstract class AbstractBinderTests {
 
 		Message<?> message = MessageBuilder.withPayload("foo").build();
 		moduleOutputChannel.send(message);
-		Message<?> inbound = moduleInputChannel.receive((int) (5000 * timeoutMultiplier));
+		Message<?> inbound = receive(moduleInputChannel);
 		assertNotNull(inbound);
 		assertEquals("foo", inbound.getPayload());
 		assertNull(inbound.getHeaders().get(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE));

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-test/src/main/java/org/springframework/cloud/stream/binder/AbstractBinderTests.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-test/src/main/java/org/springframework/cloud/stream/binder/AbstractBinderTests.java
@@ -49,6 +49,13 @@ public abstract class AbstractBinderTests {
 
 	protected AbstractTestBinder<?> testBinder;
 
+	/**
+	 * Subclasses may override this default value to have tests wait longer for a message receive, for example if
+	 * running
+	 * in an environment that is known to be slow (e.g. travis).
+	 */
+	protected double timeoutMultiplier = 1.0D;
+
 	@Test
 	public void testClean() throws Exception {
 		Binder<MessageChannel> binder = getBinder();
@@ -81,7 +88,7 @@ public abstract class AbstractBinderTests {
 		// Let the consumer actually bind to the producer before sending a msg
 		binderBindUnbindLatency();
 		moduleOutputChannel.send(message);
-		Message<?> inbound = moduleInputChannel.receive(5000);
+		Message<?> inbound = moduleInputChannel.receive((int) (5000 * timeoutMultiplier));
 		assertNotNull(inbound);
 		assertEquals("foo", inbound.getPayload());
 		assertNull(inbound.getHeaders().get(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE));
@@ -101,7 +108,7 @@ public abstract class AbstractBinderTests {
 
 		Message<?> message = MessageBuilder.withPayload("foo").build();
 		moduleOutputChannel.send(message);
-		Message<?> inbound = moduleInputChannel.receive(5000);
+		Message<?> inbound = moduleInputChannel.receive((int) (5000 * timeoutMultiplier));
 		assertNotNull(inbound);
 		assertEquals("foo", inbound.getPayload());
 		assertNull(inbound.getHeaders().get(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE));

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-test/src/main/java/org/springframework/cloud/stream/binder/PartitionCapableBinderTests.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-test/src/main/java/org/springframework/cloud/stream/binder/PartitionCapableBinderTests.java
@@ -72,11 +72,11 @@ abstract public class PartitionCapableBinderTests extends BrokerBinderTests {
 		String testPayload1 = "foo-" + UUID.randomUUID().toString();
 		output.send(new GenericMessage<>(testPayload1.getBytes()));
 
-		Message<byte[]> receivedMessage1 = (Message<byte[]>) input1.receive(1000);
+		Message<byte[]> receivedMessage1 = (Message<byte[]>) input1.receive((int) (1000 * timeoutMultiplier));
 		assertThat(receivedMessage1, not(nullValue()));
 		assertThat(new String(receivedMessage1.getPayload()), equalTo(testPayload1));
 
-		Message<byte[]> receivedMessage2 = (Message<byte[]>) input2.receive(1000);
+		Message<byte[]> receivedMessage2 = (Message<byte[]>) input2.receive((int) (1000 * timeoutMultiplier));
 		assertThat(receivedMessage2, not(nullValue()));
 		assertThat(new String(receivedMessage2.getPayload()), equalTo(testPayload1));
 
@@ -89,14 +89,14 @@ abstract public class PartitionCapableBinderTests extends BrokerBinderTests {
 		String testPayload3 = "foo-" + UUID.randomUUID().toString();
 		output.send(new GenericMessage<>(testPayload3.getBytes()));
 
-		receivedMessage1 = (Message<byte[]>) input1.receive(1000);
+		receivedMessage1 = (Message<byte[]>) input1.receive((int) (1000 * timeoutMultiplier));
 		assertThat(receivedMessage1, not(nullValue()));
 		assertThat(new String(receivedMessage1.getPayload()), equalTo(testPayload2));
-		receivedMessage1 = (Message<byte[]>) input1.receive(1000);
+		receivedMessage1 = (Message<byte[]>) input1.receive((int) (1000 * timeoutMultiplier));
 		assertThat(receivedMessage1, not(nullValue()));
 		assertThat(new String(receivedMessage1.getPayload()), equalTo(testPayload3));
 
-		receivedMessage2 = (Message<byte[]>) input2.receive(1000);
+		receivedMessage2 = (Message<byte[]>) input2.receive((int) (1000 * timeoutMultiplier));
 		assertThat(receivedMessage2, not(nullValue()));
 		assertThat(new String(receivedMessage2.getPayload()), equalTo(testPayload3));
 
@@ -181,14 +181,14 @@ abstract public class PartitionCapableBinderTests extends BrokerBinderTests {
 				.setHeader(BinderHeaders.BINDER_REPLY_CHANNEL, "bar")
 				.build();
 		output.send(message2);
-		output.send(new GenericMessage<Integer>(1));
-		output.send(new GenericMessage<Integer>(0));
+		output.send(new GenericMessage<>(1));
+		output.send(new GenericMessage<>(0));
 
-		Message<?> receive0 = input0.receive(1000);
+		Message<?> receive0 = input0.receive((int) (1000 * timeoutMultiplier));
 		assertNotNull(receive0);
-		Message<?> receive1 = input1.receive(1000);
+		Message<?> receive1 = input1.receive((int) (1000 * timeoutMultiplier));
 		assertNotNull(receive1);
-		Message<?> receive2 = input2.receive(1000);
+		Message<?> receive2 = input2.receive((int) (1000 * timeoutMultiplier));
 		assertNotNull(receive2);
 
 		Matcher<Message<?>> fooMatcher = new CustomMatcher<Message<?>>("the message with 'foo' as its correlationId") {
@@ -270,15 +270,15 @@ abstract public class PartitionCapableBinderTests extends BrokerBinderTests {
 					getExpectedRoutingBaseDestination("partJ.0", "test") + "-' + headers['partition']"));
 		}
 
-		output.send(new GenericMessage<Integer>(2));
-		output.send(new GenericMessage<Integer>(1));
-		output.send(new GenericMessage<Integer>(0));
+		output.send(new GenericMessage<>(2));
+		output.send(new GenericMessage<>(1));
+		output.send(new GenericMessage<>(0));
 
-		Message<?> receive0 = input0.receive(1000);
+		Message<?> receive0 = input0.receive((int) (1000 * timeoutMultiplier));
 		assertNotNull(receive0);
-		Message<?> receive1 = input1.receive(1000);
+		Message<?> receive1 = input1.receive((int) (1000 * timeoutMultiplier));
 		assertNotNull(receive1);
-		Message<?> receive2 = input2.receive(1000);
+		Message<?> receive2 = input2.receive((int) (1000 * timeoutMultiplier));
 		assertNotNull(receive2);
 
 		if (usesExplicitRouting()) {

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-test/src/main/java/org/springframework/cloud/stream/binder/PartitionCapableBinderTests.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-test/src/main/java/org/springframework/cloud/stream/binder/PartitionCapableBinderTests.java
@@ -72,11 +72,11 @@ abstract public class PartitionCapableBinderTests extends BrokerBinderTests {
 		String testPayload1 = "foo-" + UUID.randomUUID().toString();
 		output.send(new GenericMessage<>(testPayload1.getBytes()));
 
-		Message<byte[]> receivedMessage1 = (Message<byte[]>) input1.receive((int) (1000 * timeoutMultiplier));
+		Message<byte[]> receivedMessage1 = (Message<byte[]>) receive(input1);
 		assertThat(receivedMessage1, not(nullValue()));
 		assertThat(new String(receivedMessage1.getPayload()), equalTo(testPayload1));
 
-		Message<byte[]> receivedMessage2 = (Message<byte[]>) input2.receive((int) (1000 * timeoutMultiplier));
+		Message<byte[]> receivedMessage2 = (Message<byte[]>) receive(input2);
 		assertThat(receivedMessage2, not(nullValue()));
 		assertThat(new String(receivedMessage2.getPayload()), equalTo(testPayload1));
 
@@ -89,14 +89,14 @@ abstract public class PartitionCapableBinderTests extends BrokerBinderTests {
 		String testPayload3 = "foo-" + UUID.randomUUID().toString();
 		output.send(new GenericMessage<>(testPayload3.getBytes()));
 
-		receivedMessage1 = (Message<byte[]>) input1.receive((int) (1000 * timeoutMultiplier));
+		receivedMessage1 = (Message<byte[]>) receive(input1);
 		assertThat(receivedMessage1, not(nullValue()));
 		assertThat(new String(receivedMessage1.getPayload()), equalTo(testPayload2));
-		receivedMessage1 = (Message<byte[]>) input1.receive((int) (1000 * timeoutMultiplier));
+		receivedMessage1 = (Message<byte[]>) receive(input1);
 		assertThat(receivedMessage1, not(nullValue()));
 		assertThat(new String(receivedMessage1.getPayload()), equalTo(testPayload3));
 
-		receivedMessage2 = (Message<byte[]>) input2.receive((int) (1000 * timeoutMultiplier));
+		receivedMessage2 = (Message<byte[]>) receive(input2);
 		assertThat(receivedMessage2, not(nullValue()));
 		assertThat(new String(receivedMessage2.getPayload()), equalTo(testPayload3));
 
@@ -184,11 +184,11 @@ abstract public class PartitionCapableBinderTests extends BrokerBinderTests {
 		output.send(new GenericMessage<>(1));
 		output.send(new GenericMessage<>(0));
 
-		Message<?> receive0 = input0.receive((int) (1000 * timeoutMultiplier));
+		Message<?> receive0 = receive(input0);
 		assertNotNull(receive0);
-		Message<?> receive1 = input1.receive((int) (1000 * timeoutMultiplier));
+		Message<?> receive1 = receive(input1);
 		assertNotNull(receive1);
-		Message<?> receive2 = input2.receive((int) (1000 * timeoutMultiplier));
+		Message<?> receive2 = receive(input2);
 		assertNotNull(receive2);
 
 		Matcher<Message<?>> fooMatcher = new CustomMatcher<Message<?>>("the message with 'foo' as its correlationId") {
@@ -274,11 +274,11 @@ abstract public class PartitionCapableBinderTests extends BrokerBinderTests {
 		output.send(new GenericMessage<>(1));
 		output.send(new GenericMessage<>(0));
 
-		Message<?> receive0 = input0.receive((int) (1000 * timeoutMultiplier));
+		Message<?> receive0 = receive(input0);
 		assertNotNull(receive0);
-		Message<?> receive1 = input1.receive((int) (1000 * timeoutMultiplier));
+		Message<?> receive1 = receive(input1);
 		assertNotNull(receive1);
-		Message<?> receive2 = input2.receive((int) (1000 * timeoutMultiplier));
+		Message<?> receive2 = receive(input2);
 		assertNotNull(receive2);
 
 		if (usesExplicitRouting()) {


### PR DESCRIPTION
Fixes spring-cloud/spring-cloud-stream#314

* Adds setup commands for kafka on travis
* re-enables tests on PR branch builds
* as a consequence of that, allows a bit more time (currently x3 and x10, x3 & x3 did not work) for tests that interact with the binder on travis, as it seems to be way slower than what we're usually used to