### PR TITLE
Rabbit binder environment should be named rabbitmq

### DIFF
--- a/spring-cloud-stream-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
+++ b/spring-cloud-stream-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
@@ -284,13 +284,13 @@ spring:
           type: rabbit
           environment:
             spring:
-              rabbit:
+              rabbitmq:
                 host: <host1>
         rabbit2:
           type: rabbit
           environment:
             spring:
-              rabbit:
+              rabbitmq:
                 host: <host2>
 ----
 


### PR DESCRIPTION
In the context of trying to configure Rabbit, the docs mention that the Rabbit config properties be added under `rabbit`:

```
      ...
      binders:
        rabbit1:
          type: rabbit
          environment:
            spring:
              rabbit: <-- here
                host: <host1>
      ...
```

however, the properties should be configured under `rabbitmq` as reference in the [Spring Boot Appendix A](https://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html)