### PR TITLE
Make history tracker properties configurable

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/MessageHistoryTrackerConfigurer.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/MessageHistoryTrackerConfigurer.java
@@ -54,10 +54,10 @@ public class MessageHistoryTrackerConfigurer implements MessageChannelConfigurer
 	public void configureMessageChannel(MessageChannel messageChannel, String channelName) {
 		BindingProperties bindingProperties = channelBindingServiceProperties.getBindings().get(channelName);
 		if (bindingProperties != null && Boolean.TRUE.equals(bindingProperties.isTrackHistory())) {
-			final Set<String> trackHistoryProperties = StringUtils.commaDelimitedListToSet(bindingProperties.getTrackHistoryProperties());
+			final Set<String> trackHistoryProperties = StringUtils.commaDelimitedListToSet(bindingProperties.getTrackedProperties());
 			Map<String, Object> channelBindingServicePropertiesMap = channelBindingServiceProperties.asMapProperties();
 			final Map<String, Object> historyMap = new HashMap<>();
-			if (bindingProperties.getTrackHistoryProperties().equalsIgnoreCase("all")) {
+			if (bindingProperties.getTrackedProperties().equalsIgnoreCase("all")) {
 				historyMap.putAll(channelBindingServicePropertiesMap);
 			}
 			else {

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingProperties.java
@@ -55,6 +55,8 @@ public class BindingProperties {
 
 	private Boolean trackHistory;
 
+	private String trackHistoryProperties = "all";
+
 	// Outbound properties
 
 	private String requiredGroups;
@@ -252,6 +254,14 @@ public class BindingProperties {
 
 	public void setRequiredGroups(String requiredGroups) {
 		this.requiredGroups = requiredGroups;
+	}
+
+	public String getTrackHistoryProperties() {
+		return this.trackHistoryProperties;
+	}
+
+	public void setTrackHistoryProperties(String trackHistoryProperties) {
+		this.trackHistoryProperties = trackHistoryProperties;
 	}
 
 	public String toString() {

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingProperties.java
@@ -53,9 +53,17 @@ public class BindingProperties {
 
 	private String binder;
 
+	/**
+	 * Flag to indicate if the message header needs to be updated with the trackedProperties.
+	 */
 	private Boolean trackHistory;
 
-	private String trackHistoryProperties = "all";
+	/**
+	 * Comma separated list of binding properties to track.
+	 * By default the properties such as the current thread name and 'timestamp' are added if the 'trackHistory` is
+	 * enabled.
+	 */
+	private String trackedProperties = "all";
 
 	// Outbound properties
 
@@ -256,12 +264,12 @@ public class BindingProperties {
 		this.requiredGroups = requiredGroups;
 	}
 
-	public String getTrackHistoryProperties() {
-		return this.trackHistoryProperties;
+	public String getTrackedProperties() {
+		return this.trackedProperties;
 	}
 
-	public void setTrackHistoryProperties(String trackHistoryProperties) {
-		this.trackHistoryProperties = trackHistoryProperties;
+	public void setTrackedProperties(String trackedProperties) {
+		this.trackedProperties = trackedProperties;
 	}
 
 	public String toString() {

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceConfiguration.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactoryUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -50,6 +51,7 @@ import org.springframework.expression.PropertyAccessor;
 import org.springframework.integration.config.IntegrationEvaluationContextFactoryBean;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.json.JsonPropertyAccessor;
+import org.springframework.integration.support.MessageBuilderFactory;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.core.DestinationResolutionException;
 import org.springframework.messaging.core.DestinationResolver;
@@ -66,6 +68,9 @@ import org.springframework.messaging.core.DestinationResolver;
 @Configuration
 @EnableConfigurationProperties(ChannelBindingServiceProperties.class)
 public class ChannelBindingServiceConfiguration {
+
+	@Autowired
+	MessageBuilderFactory messageBuilderFactory;
 
 	@Bean
 	// This conditional is intentionally not in an autoconfig (usually a bad idea) because
@@ -92,7 +97,7 @@ public class ChannelBindingServiceConfiguration {
 	@Bean
 	public MessageHistoryTrackerConfigurer messageHistoryTrackerConfigurer
 			(ChannelBindingServiceProperties channelBindingServiceProperties) {
-		return new MessageHistoryTrackerConfigurer(channelBindingServiceProperties);
+		return new MessageHistoryTrackerConfigurer(channelBindingServiceProperties, messageBuilderFactory);
 	}
 
 	@Bean

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceProperties.java
@@ -232,6 +232,8 @@ public class ChannelBindingServiceProperties {
 		Map<String, Object> properties = new HashMap<>();
 		properties.put("instanceIndex", String.valueOf(getInstanceIndex()));
 		properties.put("instanceCount", String.valueOf(getInstanceCount()));
+		properties.put("defaultBinder", getDefaultBinder());
+		properties.put("dynamicDestinations", getDynamicDestinations());
 		// Add Bindings properties
 		for (Map.Entry<String, BindingProperties> entry : getBindings().entrySet()) {
 			properties.put(entry.getKey(), entry.getValue().toString());

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binding/MessageHistoryTrackerConfigurerTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binding/MessageHistoryTrackerConfigurerTests.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.binding;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.springframework.cloud.stream.config.BindingProperties;
+import org.springframework.cloud.stream.config.ChannelBindingServiceProperties;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.support.MutableMessageBuilderFactory;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.MessagingException;
+import org.springframework.util.Assert;
+
+/**
+ * @author Ilayaperumal Gopinathan
+ */
+public class MessageHistoryTrackerConfigurerTests {
+
+	@Test
+	public void testHistoryTrackAll() {
+		ChannelBindingServiceProperties serviceProperties = new ChannelBindingServiceProperties();
+		serviceProperties.setInstanceCount(2);
+		serviceProperties.setInstanceIndex(0);
+		Map<String, BindingProperties> bindingPropertiesMap = new HashMap<>();
+		BindingProperties bindingProperties = new BindingProperties();
+		bindingProperties.setTrackHistory(true);
+		bindingPropertiesMap.put("input", bindingProperties);
+		bindingPropertiesMap.put("test1", new BindingProperties());
+		serviceProperties.setBindings(bindingPropertiesMap);
+		MessageHistoryTrackerConfigurer historyTrackerConfigurer = new MessageHistoryTrackerConfigurer(serviceProperties,
+				new MutableMessageBuilderFactory());
+		DirectChannel messageChannel = new DirectChannel();
+		messageChannel.subscribe(new MessageHandler() {
+			@Override
+			public void handleMessage(Message<?> message) throws MessagingException {
+				Assert.isTrue(message.getHeaders().containsKey(MessageHistoryTrackerConfigurer.HISTORY_TRACKING_HEADER));
+				List<Map<String, Object>> headerValues =  (List<Map<String, Object>>) message.getHeaders().get(MessageHistoryTrackerConfigurer.HISTORY_TRACKING_HEADER);
+				Map<String, Object> historyValues = headerValues.get(0);
+				Assert.isTrue(historyValues.containsKey("instanceIndex") && historyValues.get("instanceIndex").equals("0"), "Instance index must exist with value '0'");
+				Assert.isTrue(historyValues.containsKey("instanceCount") && historyValues.get("instanceCount").equals("2"), "Instance count must exist with value '2'");
+				Assert.isTrue(historyValues.containsKey("input"), "Binding properties must exist for the channel 'input'");
+				Assert.isTrue(historyValues.containsKey("test1"), "Binding properties must exist for the channel 'test1'");
+			}
+		});
+		historyTrackerConfigurer.configureMessageChannel(messageChannel, "input");
+		messageChannel.send(MessageBuilder.withPayload("test").build());
+	}
+
+	@Test
+	public void testHistoryTrackSpecificProperties() {
+		ChannelBindingServiceProperties serviceProperties = new ChannelBindingServiceProperties();
+		serviceProperties.setInstanceCount(2);
+		serviceProperties.setInstanceIndex(0);
+		Map<String, BindingProperties> bindingPropertiesMap = new HashMap<>();
+		BindingProperties bindingProperties = new BindingProperties();
+		bindingProperties.setTrackHistory(true);
+		bindingProperties.setTrackHistoryProperties("input,instanceIndex");
+		bindingPropertiesMap.put("input", bindingProperties);
+		bindingPropertiesMap.put("test1", new BindingProperties());
+		serviceProperties.setBindings(bindingPropertiesMap);
+		MessageHistoryTrackerConfigurer historyTrackerConfigurer = new MessageHistoryTrackerConfigurer(serviceProperties,
+				new MutableMessageBuilderFactory());
+		DirectChannel messageChannel = new DirectChannel();
+		messageChannel.subscribe(new MessageHandler() {
+			@Override
+			public void handleMessage(Message<?> message) throws MessagingException {
+				Assert.isTrue(message.getHeaders().containsKey(MessageHistoryTrackerConfigurer.HISTORY_TRACKING_HEADER));
+				List<Map<String, Object>> headerValues =  (List<Map<String, Object>>) message.getHeaders().get(MessageHistoryTrackerConfigurer.HISTORY_TRACKING_HEADER);
+				Map<String, Object> historyValues = headerValues.get(0);
+				Assert.isTrue(historyValues.containsKey("instanceIndex") && historyValues.get("instanceIndex").equals("0"), "Instance index must exist with value '0'");
+				Assert.isTrue(!historyValues.containsKey("instanceCount"), "Instance count should not be in the tracker header");
+				Assert.isTrue(historyValues.containsKey("input"), "Binding properties must exist for the channel 'input'");
+				Assert.isTrue(!historyValues.containsKey("test1"), "Binding properties for the channel 'test1' should not be in the tracker header");
+			}
+		});
+		historyTrackerConfigurer.configureMessageChannel(messageChannel, "input");
+		messageChannel.send(MessageBuilder.withPayload("test").build());
+	}
+}


### PR DESCRIPTION
 - Add property `spring.cloud.stream.bindings.<channelName>.trackHistoryProperties` with comma separated string values that specify the exact
property names in `ChannelBindingServiceProperties` to be added in the message tracker header
 - Add tests

This resolves #252