### PR TITLE
Fix RxJava processor lifecycle

### DIFF
--- a/spring-cloud-stream-rxjava/src/main/java/org/springframework/cloud/stream/annotation/rxjava/RxJavaProcessorConfiguration.java
+++ b/spring-cloud-stream-rxjava/src/main/java/org/springframework/cloud/stream/annotation/rxjava/RxJavaProcessorConfiguration.java
@@ -33,7 +33,7 @@ public class RxJavaProcessorConfiguration {
 	@Autowired
 	RxJavaProcessor processor;
 
-	@ServiceActivator(inputChannel = Processor.INPUT)
+	@ServiceActivator(inputChannel = Processor.INPUT, phase = "0")
 	@Bean
 	public MessageHandler subjectMessageHandler() {
 		SubjectMessageHandler messageHandler = new SubjectMessageHandler(processor);


### PR DESCRIPTION
-  Make SubjectMessageHandler a SmartLifecycle and assign it to phase 0, allowing it to be started after the outputs are bound and before the inputs are bound;
- Setup Rx in the start() method;
- Set the ServiceActivator associated with the handler to phase 0 as well;

This resolves #351 