### PR TITLE
Ignore binder property keys when not supported

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderPropertyKeys.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderPropertyKeys.java
@@ -136,4 +136,11 @@ public abstract class BinderPropertyKeys {
 	 */
 	public static final String MIN_PARTITION_COUNT = "minPartitionCount";
 
+	/**
+	 * The property keys which can be ignored by the binder when they are not supported by the corresponding
+	 * implementation.
+	 */
+	public static final String[] IGNORABLE_KEYS = { DURABLE, MIN_PARTITION_COUNT, BATCHING_ENABLED, BATCH_SIZE,
+			BATCH_BUFFER_LIMIT, BATCH_TIMEOUT };
+
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/MessageChannelBinderSupport.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/MessageChannelBinderSupport.java
@@ -668,8 +668,9 @@ public abstract class MessageChannelBinderSupport
 	private void validateProperties(String name, Properties properties, Set<Object> supported, String type) {
 		StringBuilder builder = new StringBuilder();
 		int errors = 0;
+		List<String> ignorableKeys = Arrays.asList(BinderPropertyKeys.IGNORABLE_KEYS);
 		for (Entry<Object, Object> entry : properties.entrySet()) {
-			if (!supported.contains(entry.getKey())) {
+			if (!supported.contains(entry.getKey()) && !ignorableKeys.contains(entry.getKey())) {
 				builder.append(entry.getKey()).append(",");
 				errors++;
 			}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/MessageChannelBinderSupport.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/MessageChannelBinderSupport.java
@@ -670,7 +670,12 @@ public abstract class MessageChannelBinderSupport
 		int errors = 0;
 		List<String> ignorableKeys = Arrays.asList(BinderPropertyKeys.IGNORABLE_KEYS);
 		for (Entry<Object, Object> entry : properties.entrySet()) {
-			if (!supported.contains(entry.getKey()) && !ignorableKeys.contains(entry.getKey())) {
+			if (ignorableKeys.contains(entry.getKey())) {
+				logger.warn("Property '" + entry.getKey() + "' is ignored as it is not supported by the binder:" +
+						this.toString());
+				break;
+			}
+			if (!supported.contains(entry.getKey())) {
 				builder.append(entry.getKey()).append(",");
 				errors++;
 			}


### PR DESCRIPTION
  - When the binder implementation doesn't support the producer/consumer properties that are passed along by the `ChannelBindingService` when binding,
those properties can be ignored(instead of failing the validation) during the validation of producer/consumer properties.

This resolves #355