### PR TITLE
Use TestSupportBinder instead of redis binder in integration tests

### DIFF
--- a/spring-cloud-stream-integration-tests/pom.xml
+++ b/spring-cloud-stream-integration-tests/pom.xml
@@ -20,7 +20,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-stream-redis</artifactId>
+			<artifactId>spring-cloud-stream-test-support</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/ErrorChannelTests.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/ErrorChannelTests.java
@@ -15,32 +15,25 @@
  */
 package org.springframework.cloud.stream.config;
 
-import static org.junit.Assert.assertTrue;
-
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.SpringApplicationConfiguration;
-import org.springframework.cloud.stream.annotation.Bindings;
 import org.springframework.cloud.stream.annotation.EnableBinding;
-import org.springframework.cloud.stream.binder.redis.config.RedisMessageChannelBinderConfiguration;
-import org.springframework.cloud.stream.messaging.Sink;
+import org.springframework.cloud.stream.binder.BinderFactory;
 import org.springframework.cloud.stream.messaging.Source;
-import org.springframework.cloud.stream.test.junit.redis.RedisTestSupport;
+import org.springframework.cloud.stream.test.binder.TestSupportBinder;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.integration.annotation.InboundChannelAdapter;
 import org.springframework.integration.annotation.Poller;
+import org.springframework.integration.channel.PublishSubscribeChannel;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -50,37 +43,27 @@ import org.springframework.util.Assert;
  * @author Ilayaperumal Gopinathan
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration({ErrorChannelTests.TestSource.class, ErrorChannelTests.TestErrorSink.class})
+@SpringApplicationConfiguration({ErrorChannelTests.TestSource.class})
 public class ErrorChannelTests {
 
-	@Rule
-	public RedisTestSupport redisTestSupport = new RedisTestSupport();
+	@Autowired
+	private PublishSubscribeChannel errorChannel;
 
 	@Autowired
-	@Bindings(TestErrorSink.class)
-	private Sink testErrorSink;
+	private BinderFactory binderFactory;
 
 	@Test
 	public void testErrorChannelBinding() throws Exception {
-		final CountDownLatch latch = new CountDownLatch(1);
-		MessageHandler errorMessageHandler = new MessageHandler() {
-			@Override
-			public void handleMessage(Message<?> message) throws MessagingException {
-				Assert.isTrue(message instanceof ErrorMessage, "Message should be an instance of ErrorMessage");
-				Assert.isTrue(message.getPayload() instanceof MessagingException, "Message payload should be an instance" +
-						"of MessagingException");
-				Assert.isTrue(message.getPayload().toString()
-						.equals("org.springframework.messaging.MessagingException: test"));
-				latch.countDown();
-			}
-		};
-		testErrorSink.input().subscribe(errorMessageHandler);
-		assertTrue(latch.await(10, TimeUnit.SECONDS));
+		Message<?> message = (Message<?>) ((TestSupportBinder) binderFactory.getBinder(null)).messageCollector().forChannel(errorChannel).poll(10, TimeUnit.SECONDS);
+		Assert.isTrue(message instanceof ErrorMessage, "Message should be an instance of ErrorMessage");
+		Assert.isTrue(message.getPayload() instanceof MessagingException, "Message payload should be an instance" +
+				"of MessagingException");
+		Assert.isTrue(message.getPayload().toString()
+				.equals("org.springframework.messaging.MessagingException: test"));
 	}
 
 	@EnableBinding(Source.class)
 	@EnableAutoConfiguration
-	@Import(RedisMessageChannelBinderConfiguration.class)
 	@PropertySource("classpath:/org/springframework/cloud/stream/config/errorchannel/source-channel.properties")
 	public static class TestSource {
 
@@ -94,14 +77,6 @@ public class ErrorChannelTests {
 				}
 			};
 		}
-	}
-
-	@EnableBinding(Sink.class)
-	@EnableAutoConfiguration
-	@Import(RedisMessageChannelBinderConfiguration.class)
-	@PropertySource("classpath:/org/springframework/cloud/stream/config/errorchannel/errorsink-channel.properties")
-	public static class TestErrorSink {
-
 	}
 }
 

--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/MessageChannelConfigurerTests.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/MessageChannelConfigurerTests.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -33,11 +32,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.cloud.stream.annotation.Bindings;
 import org.springframework.cloud.stream.annotation.EnableBinding;
-import org.springframework.cloud.stream.binder.redis.config.RedisMessageChannelBinderConfiguration;
 import org.springframework.cloud.stream.messaging.Sink;
-import org.springframework.cloud.stream.messaging.Source;
-import org.springframework.cloud.stream.test.junit.redis.RedisTestSupport;
-import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
@@ -50,19 +45,11 @@ import org.springframework.tuple.Tuple;
  * @author Ilayaperumal Gopinathan
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration({MessageChannelConfigurerTests.TestSource.class,
-		MessageChannelConfigurerTests.TestSink.class})
+@SpringApplicationConfiguration({MessageChannelConfigurerTests.TestSink.class})
 public class MessageChannelConfigurerTests {
-
-	@Rule
-	public RedisTestSupport redisTestSupport = new RedisTestSupport();
 
 	@Autowired @Bindings(TestSink.class)
 	private Sink testSink;
-
-	@Autowired
-	@Bindings(TestSource.class)
-	private Source testSource;
 
 	@Test
 	public void testContentTypeConfigurer() throws Exception {
@@ -77,15 +64,15 @@ public class MessageChannelConfigurerTests {
 			}
 		};
 		testSink.input().subscribe(messageHandler);
-		testSource.output().send(MessageBuilder.withPayload("{\"message\":\"Hi\"}").build());
+		testSink.input().send(MessageBuilder.withPayload("{\"message\":\"Hi\"}").build());
 		assertTrue(latch.await(10, TimeUnit.SECONDS));
 		testSink.input().unsubscribe(messageHandler);
 	}
 
 	@Test
 	public void testHistoryTrackerConfigurer() throws Exception {
-		final CountDownLatch latch1 = new CountDownLatch(1);
-		MessageHandler messageHandler1 = new MessageHandler() {
+		final CountDownLatch latch = new CountDownLatch(1);
+		MessageHandler messageHandler = new MessageHandler() {
 			@Override
 			public void handleMessage(Message<?> message) throws MessagingException {
 				assertTrue("Message header should have tracking history info",
@@ -99,32 +86,17 @@ public class MessageChannelConfigurerTests {
 				assertTrue(inputBindingProps.contains("concurrency=1"));
 				assertTrue(headerValue.get("instanceIndex").equals("0"));
 				assertTrue(headerValue.get("instanceCount").equals("1"));
-				String outputBindingProps = (String) ((Map<?, ?>) ((List<?>) message.getHeaders()
-						.get("SPRING_CLOUD_STREAM_HISTORY")).get(0)).get("output");
-				;
-				assertTrue(outputBindingProps.contains("destination=configure"));
-				assertTrue(!outputBindingProps.contains("trackHistory"));
-				assertTrue(outputBindingProps.contains("nextModuleCount=1"));
-				latch1.countDown();
+				latch.countDown();
 			}
 		};
-		testSink.input().subscribe(messageHandler1);
-		testSource.output().send(MessageBuilder.withPayload("{\"test\":\"value\"}").build());
-		assertTrue(latch1.await(10, TimeUnit.SECONDS));
-		testSink.input().unsubscribe(messageHandler1);
-	}
-
-	@EnableBinding(Source.class)
-	@EnableAutoConfiguration
-	@Import(RedisMessageChannelBinderConfiguration.class)
-	@PropertySource("classpath:/org/springframework/cloud/stream/config/channel/source-channel-configurers.properties")
-	public static class TestSource {
-
+		testSink.input().subscribe(messageHandler);
+		testSink.input().send(MessageBuilder.withPayload("{\"test\":\"value\"}").build());
+		assertTrue(latch.await(10, TimeUnit.SECONDS));
+		testSink.input().unsubscribe(messageHandler);
 	}
 
 	@EnableBinding(Sink.class)
 	@EnableAutoConfiguration
-	@Import(RedisMessageChannelBinderConfiguration.class)
 	@PropertySource("classpath:/org/springframework/cloud/stream/config/channel/sink-channel-configurers.properties")
 	public static class TestSink {
 

--- a/spring-cloud-stream-integration-tests/src/test/resources/org/springframework/cloud/stream/config/channel/source-channel-configurers.properties
+++ b/spring-cloud-stream-integration-tests/src/test/resources/org/springframework/cloud/stream/config/channel/source-channel-configurers.properties
@@ -1,3 +1,0 @@
-spring.cloud.stream.bindings.output.destination=configure1
-spring.cloud.stream.bindings.output.nextModuleCount=1
-spring.cloud.stream.bindings.output.contentType=application/json

--- a/spring-cloud-stream-integration-tests/src/test/resources/org/springframework/cloud/stream/config/errorchannel/errorsink-channel.properties
+++ b/spring-cloud-stream-integration-tests/src/test/resources/org/springframework/cloud/stream/config/errorchannel/errorsink-channel.properties
@@ -1,1 +1,0 @@
-spring.cloud.stream.bindings.input.destination=errorchannel-test

--- a/spring-cloud-stream-test-support/pom.xml
+++ b/spring-cloud-stream-test-support/pom.xml
@@ -23,11 +23,6 @@
 			<artifactId>spring-cloud-stream</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-binder-redis</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure</artifactId>
 		</dependency>


### PR DESCRIPTION
 - Modify the integration tests to verify the usecases per app basis (that uses the TestSupportBinder for its channel binding)
 - Remove redis binder usage in integration tests

This resolves #380