### PR TITLE
AbstractBinder's afterPropertiesSet() is now final

### DIFF
--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -325,7 +325,7 @@ public class KafkaMessageChannelBinder extends AbstractBinder<MessageChannel> {
 	}
 
 	@Override
-	public void afterPropertiesSet() throws Exception {
+	public void onInit() throws Exception {
 		// we instantiate the connection factory here due to https://jira.spring.io/browse/XD-2647
 		ZookeeperConfiguration configuration = new ZookeeperConfiguration(this.zookeeperConnect);
 		configuration.setBufferSize(socketBufferSize);
@@ -348,7 +348,6 @@ public class KafkaMessageChannelBinder extends AbstractBinder<MessageChannel> {
 			retryTemplate.setBackOffPolicy(backOffPolicy);
 			retryOperations = retryTemplate;
 		}
-		super.afterPropertiesSet();
 	}
 
 	/**

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitMessageChannelBinder.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitMessageChannelBinder.java
@@ -393,8 +393,7 @@ public class RabbitMessageChannelBinder extends AbstractBinder<MessageChannel> {
 	}
 
 	@Override
-	public void afterPropertiesSet() throws Exception {
-		super.afterPropertiesSet();
+	public void onInit() {
 		if (this.clustered) {
 			Assert.state(this.addresses.length == this.adminAddresses.length
 					&& this.addresses.length == this.nodes.length,

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/src/main/java/org/springframework/cloud/stream/binder/redis/RedisMessageChannelBinder.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/src/main/java/org/springframework/cloud/stream/binder/redis/RedisMessageChannelBinder.java
@@ -132,8 +132,7 @@ public class RedisMessageChannelBinder extends AbstractBinder<MessageChannel> {
 	}
 
 	@Override
-	public void afterPropertiesSet() throws Exception {
-		super.afterPropertiesSet();
+	public void onInit() {
 		this.errorAdapter.setIntegrationEvaluationContext(this.evaluationContext);
 		this.errorAdapter.setBeanFactory(getBeanFactory());
 		this.errorAdapter.afterPropertiesSet();

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
@@ -317,13 +317,21 @@ public abstract class AbstractBinder<T> implements ApplicationContextAware, Init
 		this.defaultCompress = defaultCompress;
 	}
 
-
 	@Override
-	public void afterPropertiesSet() throws Exception {
-		Assert.notNull(this.applicationContext, "The 'applicationContext' property cannot be null");
+	public final void afterPropertiesSet() throws Exception {
+		Assert.notNull(this.applicationContext, "The 'applicationContext' property must not be null");
 		if (this.evaluationContext == null) {
 			this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
 		}
+		onInit();
+	}
+
+	/**
+	 * Subclasses may implement this method to perform any necessary initialization.
+	 * It will be invoked from {@link #afterPropertiesSet()} which is itself {@code final}.
+	 */
+	protected void onInit() throws Exception {
+		// no-op default
 	}
 
 	@Override


### PR DESCRIPTION
- subclasses should implement the new onInit() method instead of overriding
- avoids the potential for a NPE in case an overriding subclass did not call the superclass method