### PR TITLE
Remove unused binder headers

### DIFF
--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/src/test/java/org/springframework/cloud/stream/binder/redis/RedisBinderTests.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-redis/src/test/java/org/springframework/cloud/stream/binder/redis/RedisBinderTests.java
@@ -188,7 +188,7 @@ public class RedisBinderTests extends PartitionCapableBinderTests {
 	public void testMoreHeaders() {
 		RedisMessageChannelBinder binder = new RedisMessageChannelBinder(mock(RedisConnectionFactory.class), "foo", "bar");
 		Collection<String> headers = Arrays.asList(TestUtils.getPropertyValue(binder, "headersToMap", String[].class));
-		assertEquals(10, headers.size());
+		assertEquals(7, headers.size());
 		assertTrue(headers.contains("foo"));
 		assertTrue(headers.contains("bar"));
 	}

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-test/src/main/java/org/springframework/cloud/stream/binder/PartitionCapableBinderTests.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-test/src/main/java/org/springframework/cloud/stream/binder/PartitionCapableBinderTests.java
@@ -233,7 +233,6 @@ abstract public class PartitionCapableBinderTests extends BrokerBinderTests {
 				.setHeader(IntegrationMessageHeaderAccessor.CORRELATION_ID, "foo")
 				.setHeader(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER, 42)
 				.setHeader(IntegrationMessageHeaderAccessor.SEQUENCE_SIZE, 43)
-				.setHeader(BinderHeaders.BINDER_REPLY_CHANNEL, "bar")
 				.build();
 		output.send(message2);
 		output.send(new GenericMessage<>(1));
@@ -253,8 +252,7 @@ abstract public class PartitionCapableBinderTests extends BrokerBinderTests {
 				IntegrationMessageHeaderAccessor accessor = new IntegrationMessageHeaderAccessor((Message<?>) item);
 				boolean result = "foo".equals(accessor.getCorrelationId()) &&
 						42 == accessor.getSequenceNumber() &&
-						43 == accessor.getSequenceSize() &&
-						"bar".equals(accessor.getHeader(BinderHeaders.BINDER_REPLY_CHANNEL));
+						43 == accessor.getSequenceSize();
 				return result;
 			}
 		};

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderHeaders.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,25 +21,16 @@ import org.springframework.messaging.MessageHeaders;
 
 
 /**
- * Spring Integration message headers for XD.
+ * Spring Integration message headers for Spring Cloud Stream.
  * @author Gary Russell
  * @author David Turanski
  */
 public final class BinderHeaders {
 
-	public static final String BINDER_REPLY_CHANNEL = "binderReplyChannel";
-
-	public static final String BINDER_HISTORY = "binderHistory";
-
 	/*
 	 * no xd prefix for backwards compatibility
 	 */
 	public static final String BINDER_ORIGINAL_CONTENT_TYPE = "originalContentType";
-
-	/*
-	 * no xd prefix for backwards compatibility
-	 */
-	public static final String REPLY_TO = "replyTo";
 
 	/**
 	 * The headers that will be propagated, by default, by binder implementations
@@ -49,11 +40,8 @@ public final class BinderHeaders {
 			IntegrationMessageHeaderAccessor.CORRELATION_ID,
 			IntegrationMessageHeaderAccessor.SEQUENCE_SIZE,
 			IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER,
-			BINDER_REPLY_CHANNEL,
 			MessageHeaders.CONTENT_TYPE,
-			BINDER_ORIGINAL_CONTENT_TYPE,
-			REPLY_TO,
-			BINDER_HISTORY
+			BINDER_ORIGINAL_CONTENT_TYPE
 	};
 
 	private BinderHeaders() {


### PR DESCRIPTION
 - Remove `binderReplyChannel`, `replyTo` and `binderHistory` headers