### PR TITLE
Set string value for originalContentType in message header

### DIFF
--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-test/src/test/java/org/springframework/cloud/stream/binder/MessageChannelBinderSupportTests.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-test/src/test/java/org/springframework/cloud/stream/binder/MessageChannelBinderSupportTests.java
@@ -121,7 +121,7 @@ public class MessageChannelBinderSupportTests {
 
 		Message<?> converted = convertedValues.toMessage();
 
-		assertEquals(MimeTypeUtils.APPLICATION_JSON,
+		assertEquals(MimeTypeUtils.TEXT_PLAIN,
 				contentTypeResolver.resolve(converted.getHeaders()));
 		assertEquals(MimeTypeUtils.APPLICATION_JSON.toString(),
 				converted.getHeaders().get(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE));
@@ -192,35 +192,35 @@ public class MessageChannelBinderSupportTests {
 
 	@Test
 	public void mimeTypeIsSimpleObject() throws ClassNotFoundException {
-		MimeType mt = JavaClassMimeTypeConversion.mimeTypeFromObject(new Object(), new Object());
+		MimeType mt = JavaClassMimeTypeConversion.mimeTypeFromObject(new Object());
 		String className = JavaClassMimeTypeConversion.classNameFromMimeType(mt);
 		assertEquals(Object.class, Class.forName(className));
 	}
 
 	@Test
 	public void mimeTypeIsObjectArray() throws ClassNotFoundException {
-		MimeType mt = JavaClassMimeTypeConversion.mimeTypeFromObject(new String[0], new Object());
+		MimeType mt = JavaClassMimeTypeConversion.mimeTypeFromObject(new String[0]);
 		String className = JavaClassMimeTypeConversion.classNameFromMimeType(mt);
 		assertEquals(String[].class, Class.forName(className));
 	}
 
 	@Test
 	public void mimeTypeIsMultiDimensionalObjectArray() throws ClassNotFoundException {
-		MimeType mt = JavaClassMimeTypeConversion.mimeTypeFromObject(new String[0][0][0], new Object());
+		MimeType mt = JavaClassMimeTypeConversion.mimeTypeFromObject(new String[0][0][0]);
 		String className = JavaClassMimeTypeConversion.classNameFromMimeType(mt);
 		assertEquals(String[][][].class, Class.forName(className));
 	}
 
 	@Test
 	public void mimeTypeIsPrimitiveArray() throws ClassNotFoundException {
-		MimeType mt = JavaClassMimeTypeConversion.mimeTypeFromObject(new int[0], new Object());
+		MimeType mt = JavaClassMimeTypeConversion.mimeTypeFromObject(new int[0]);
 		String className = JavaClassMimeTypeConversion.classNameFromMimeType(mt);
 		assertEquals(int[].class, Class.forName(className));
 	}
 
 	@Test
 	public void mimeTypeIsMultiDimensionalPrimitiveArray() throws ClassNotFoundException {
-		MimeType mt = JavaClassMimeTypeConversion.mimeTypeFromObject(new int[0][0][0], new Object());
+		MimeType mt = JavaClassMimeTypeConversion.mimeTypeFromObject(new int[0][0][0]);
 		String className = JavaClassMimeTypeConversion.classNameFromMimeType(mt);
 		assertEquals(int[][][].class, Class.forName(className));
 	}

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-test/src/test/java/org/springframework/cloud/stream/binder/MessageChannelBinderSupportTests.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-test/src/test/java/org/springframework/cloud/stream/binder/MessageChannelBinderSupportTests.java
@@ -50,6 +50,7 @@ import com.esotericsoftware.kryo.Registration;
 /**
  * @author Gary Russell
  * @author David Turanski
+ * @author Ilayaperumal Gopinathan
  */
 public class MessageChannelBinderSupportTests {
 
@@ -120,13 +121,13 @@ public class MessageChannelBinderSupportTests {
 
 		Message<?> converted = convertedValues.toMessage();
 
-		assertEquals(MimeTypeUtils.TEXT_PLAIN,
-				contentTypeResolver.resolve(converted.getHeaders()));
 		assertEquals(MimeTypeUtils.APPLICATION_JSON,
+				contentTypeResolver.resolve(converted.getHeaders()));
+		assertEquals(MimeTypeUtils.APPLICATION_JSON.toString(),
 				converted.getHeaders().get(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE));
 		MessageValues reconstructed = binder.deserializePayloadIfNecessary(converted);
 		assertEquals("{\"foo\":\"foo\"}", reconstructed.getPayload());
-		assertEquals(MimeTypeUtils.APPLICATION_JSON, reconstructed.get(MessageHeaders.CONTENT_TYPE));
+		assertEquals(MimeTypeUtils.APPLICATION_JSON.toString(), reconstructed.get(MessageHeaders.CONTENT_TYPE));
 	}
 
 	@Test
@@ -191,35 +192,35 @@ public class MessageChannelBinderSupportTests {
 
 	@Test
 	public void mimeTypeIsSimpleObject() throws ClassNotFoundException {
-		MimeType mt = JavaClassMimeTypeConversion.mimeTypeFromObject(new Object());
+		MimeType mt = JavaClassMimeTypeConversion.mimeTypeFromObject(new Object(), new Object());
 		String className = JavaClassMimeTypeConversion.classNameFromMimeType(mt);
 		assertEquals(Object.class, Class.forName(className));
 	}
 
 	@Test
 	public void mimeTypeIsObjectArray() throws ClassNotFoundException {
-		MimeType mt = JavaClassMimeTypeConversion.mimeTypeFromObject(new String[0]);
+		MimeType mt = JavaClassMimeTypeConversion.mimeTypeFromObject(new String[0], new Object());
 		String className = JavaClassMimeTypeConversion.classNameFromMimeType(mt);
 		assertEquals(String[].class, Class.forName(className));
 	}
 
 	@Test
 	public void mimeTypeIsMultiDimensionalObjectArray() throws ClassNotFoundException {
-		MimeType mt = JavaClassMimeTypeConversion.mimeTypeFromObject(new String[0][0][0]);
+		MimeType mt = JavaClassMimeTypeConversion.mimeTypeFromObject(new String[0][0][0], new Object());
 		String className = JavaClassMimeTypeConversion.classNameFromMimeType(mt);
 		assertEquals(String[][][].class, Class.forName(className));
 	}
 
 	@Test
 	public void mimeTypeIsPrimitiveArray() throws ClassNotFoundException {
-		MimeType mt = JavaClassMimeTypeConversion.mimeTypeFromObject(new int[0]);
+		MimeType mt = JavaClassMimeTypeConversion.mimeTypeFromObject(new int[0], new Object());
 		String className = JavaClassMimeTypeConversion.classNameFromMimeType(mt);
 		assertEquals(int[].class, Class.forName(className));
 	}
 
 	@Test
 	public void mimeTypeIsMultiDimensionalPrimitiveArray() throws ClassNotFoundException {
-		MimeType mt = JavaClassMimeTypeConversion.mimeTypeFromObject(new int[0][0][0]);
+		MimeType mt = JavaClassMimeTypeConversion.mimeTypeFromObject(new int[0][0][0], new Object());
 		String className = JavaClassMimeTypeConversion.classNameFromMimeType(mt);
 		assertEquals(int[][][].class, Class.forName(className));
 	}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.stream.binder;
 
-import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON;
 import static org.springframework.util.MimeTypeUtils.APPLICATION_OCTET_STREAM;
 import static org.springframework.util.MimeTypeUtils.TEXT_PLAIN;
 
@@ -364,7 +363,7 @@ public abstract class AbstractBinder<T> implements ApplicationContextAware, Init
 		Object originalContentType = message.getHeaders().get(MessageHeaders.CONTENT_TYPE);
 
 		//Pass content type as String since some transport adapters will exclude CONTENT_TYPE Header otherwise
-		Object contentType = JavaClassMimeTypeConversion.mimeTypeFromObject(originalPayload, originalContentType).toString();
+		Object contentType = JavaClassMimeTypeConversion.mimeTypeFromObject(originalPayload).toString();
 		Object payload = serializePayloadIfNecessary(originalPayload);
 		MessageValues messageValues = new MessageValues(message);
 		messageValues.setPayload(payload);
@@ -426,7 +425,7 @@ public abstract class AbstractBinder<T> implements ApplicationContextAware, Init
 	}
 
 	private Object deserializePayload(byte[] bytes, MimeType contentType) {
-		if (TEXT_PLAIN.equals(contentType) || APPLICATION_JSON.equals(contentType)) {
+		if (TEXT_PLAIN.equals(contentType)) {
 			try {
 				return new String(bytes, "UTF-8");
 			}
@@ -546,16 +545,12 @@ public abstract class AbstractBinder<T> implements ApplicationContextAware, Init
 
 		private static ConcurrentMap<String, MimeType> mimeTypesCache = new ConcurrentHashMap<>();
 
-		static MimeType mimeTypeFromObject(Object payload, Object originalContentType) {
+		static MimeType mimeTypeFromObject(Object payload) {
 			Assert.notNull(payload, "payload object cannot be null.");
 			if (payload instanceof byte[]) {
 				return MimeTypeUtils.APPLICATION_OCTET_STREAM;
 			}
 			if (payload instanceof String) {
-				if (originalContentType != null &&
-						originalContentType.toString().equals(MimeTypeUtils.APPLICATION_JSON_VALUE)) {
-					return MimeTypeUtils.APPLICATION_JSON;
-				}
 				return MimeTypeUtils.TEXT_PLAIN;
 			}
 			String className = payload.getClass().getName();

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
@@ -16,10 +16,9 @@
 
 package org.springframework.cloud.stream.binder;
 
+import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON;
 import static org.springframework.util.MimeTypeUtils.APPLICATION_OCTET_STREAM;
-import static org.springframework.util.MimeTypeUtils.APPLICATION_OCTET_STREAM_VALUE;
 import static org.springframework.util.MimeTypeUtils.TEXT_PLAIN;
-import static org.springframework.util.MimeTypeUtils.TEXT_PLAIN_VALUE;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -57,6 +56,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.IdGenerator;
 import org.springframework.util.MimeType;
+import org.springframework.util.MimeTypeUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -364,13 +364,13 @@ public abstract class AbstractBinder<T> implements ApplicationContextAware, Init
 		Object originalContentType = message.getHeaders().get(MessageHeaders.CONTENT_TYPE);
 
 		//Pass content type as String since some transport adapters will exclude CONTENT_TYPE Header otherwise
-		Object contentType = JavaClassMimeTypeConversion.mimeTypeFromObject(originalPayload).toString();
+		Object contentType = JavaClassMimeTypeConversion.mimeTypeFromObject(originalPayload, originalContentType).toString();
 		Object payload = serializePayloadIfNecessary(originalPayload);
 		MessageValues messageValues = new MessageValues(message);
 		messageValues.setPayload(payload);
 		messageValues.put(MessageHeaders.CONTENT_TYPE, contentType);
 		if (originalContentType != null) {
-			messageValues.put(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE, originalContentType);
+			messageValues.put(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE, originalContentType.toString());
 		}
 		return messageValues;
 	}
@@ -399,18 +399,18 @@ public abstract class AbstractBinder<T> implements ApplicationContextAware, Init
 		return deserializePayloadIfNecessary(new MessageValues(message));
 	}
 
-	protected final MessageValues deserializePayloadIfNecessary(MessageValues message) {
-		Object originalPayload = message.getPayload();
-		MimeType contentType = this.contentTypeResolver.resolve(message);
+	protected final MessageValues deserializePayloadIfNecessary(MessageValues messageValues) {
+		Object originalPayload = messageValues.getPayload();
+		MimeType contentType = this.contentTypeResolver.resolve(messageValues);
 		Object payload = deserializePayload(originalPayload, contentType);
 		if (payload != null) {
-			message.setPayload(payload);
+			messageValues.setPayload(payload);
 
-			Object originalContentType = message.get(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE);
-			message.put(MessageHeaders.CONTENT_TYPE, originalContentType);
-			message.put(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE, null);
+			Object originalContentType = messageValues.get(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE);
+			messageValues.put(MessageHeaders.CONTENT_TYPE, originalContentType);
+			messageValues.remove(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE);
 		}
-		return message;
+		return messageValues;
 	}
 
 	private Object deserializePayload(Object payload, MimeType contentType) {
@@ -426,7 +426,7 @@ public abstract class AbstractBinder<T> implements ApplicationContextAware, Init
 	}
 
 	private Object deserializePayload(byte[] bytes, MimeType contentType) {
-		if (TEXT_PLAIN.equals(contentType)) {
+		if (TEXT_PLAIN.equals(contentType) || APPLICATION_JSON.equals(contentType)) {
 			try {
 				return new String(bytes, "UTF-8");
 			}
@@ -538,31 +538,31 @@ public abstract class AbstractBinder<T> implements ApplicationContextAware, Init
 
 	/**
 	 * Handles representing any java class as a {@link MimeType}.
+	 *
 	 * @author David Turanski
-	 * @see <a href="http://docs.oracle.com/javase/7/docs/api/java/lang/Class.html#getName"/>
+	 * @author Ilayaperumal Gopinathan
 	 */
 	abstract static class JavaClassMimeTypeConversion {
 
-		public static final MimeType APPLICATION_OCTET_STREAM_MIME_TYPE = MimeType.valueOf
-				(APPLICATION_OCTET_STREAM_VALUE);
-
-		public static final MimeType TEXT_PLAIN_MIME_TYPE = MimeType.valueOf(TEXT_PLAIN_VALUE);
-
 		private static ConcurrentMap<String, MimeType> mimeTypesCache = new ConcurrentHashMap<>();
 
-		static MimeType mimeTypeFromObject(Object obj) {
-			Assert.notNull(obj, "object cannot be null.");
-			if (obj instanceof byte[]) {
-				return APPLICATION_OCTET_STREAM_MIME_TYPE;
+		static MimeType mimeTypeFromObject(Object payload, Object originalContentType) {
+			Assert.notNull(payload, "payload object cannot be null.");
+			if (payload instanceof byte[]) {
+				return MimeTypeUtils.APPLICATION_OCTET_STREAM;
 			}
-			if (obj instanceof String) {
-				return TEXT_PLAIN_MIME_TYPE;
+			if (payload instanceof String) {
+				if (originalContentType != null &&
+						originalContentType.toString().equals(MimeTypeUtils.APPLICATION_JSON_VALUE)) {
+					return MimeTypeUtils.APPLICATION_JSON;
+				}
+				return MimeTypeUtils.TEXT_PLAIN;
 			}
-			String className = obj.getClass().getName();
+			String className = payload.getClass().getName();
 			MimeType mimeType = mimeTypesCache.get(className);
 			if (mimeType == null) {
 				String modifiedClassName = className;
-				if (obj.getClass().isArray()) {
+				if (payload.getClass().isArray()) {
 					// Need to remove trailing ';' for an object array, e.g. "[Ljava.lang.String;" or multi-dimensional
 					// "[[[Ljava.lang.String;"
 					if (modifiedClassName.endsWith(";")) {


### PR DESCRIPTION
 - Since the `originalContentType` header is preserved across the wire while the serialization/de-serialization processes take place using the deduced `contentType`,
it is convenient to set the `String` value of the `originalContentType` instead of setting the actual `MimeType` object in the header.
 - Once the `de-serialization` has taken place, the deduced `contentType` is always replaced with the `originalContentType` as the `contentType` in the message header and this preserved contentType can be resolved to its corresponding MimeType using `ContentTypeResolver` anytime. Hence, using the `String` object for `originalContentType` doesn't do any harm.

 - Fix the issue while setting the deduced contentType based on the `payload` when the `originalContentType` is `application/json`
   - Currently, the contentType is set to `text/plain` which seems incorrect
 - Also, add the `application/json` contentType to return `String` object during de-serialization process.

This resolves #383