### PR TITLE
Support text/* contentType sent by non-SCSt applications

### DIFF
--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-test/src/test/java/org/springframework/cloud/stream/binder/MessageChannelBinderSupportTests.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-test/src/test/java/org/springframework/cloud/stream/binder/MessageChannelBinderSupportTests.java
@@ -112,6 +112,19 @@ public class MessageChannelBinderSupportTests {
 	}
 
 	@Test
+	public void testStringXML() throws IOException {
+		Message<?> message = MessageBuilder
+				.withPayload("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?><test></test>")
+				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_XML)
+				.build();
+		Message<?> converted = binder.serializePayloadIfNecessary(message).toMessage();
+		assertEquals(MimeTypeUtils.TEXT_PLAIN, contentTypeResolver.resolve(converted.getHeaders()));
+		MessageValues reconstructed = binder.deserializePayloadIfNecessary(converted);
+		assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?><test></test>", reconstructed.getPayload());
+		assertEquals(MimeTypeUtils.TEXT_XML.toString(), reconstructed.get(MessageHeaders.CONTENT_TYPE));
+	}
+
+	@Test
 	public void testContentTypePreserved() throws IOException {
 		Message<String> inbound = MessageBuilder.withPayload("{\"foo\":\"foo\"}")
 				.copyHeaders(Collections.singletonMap(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.APPLICATION_JSON))

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.stream.binder;
 
 import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON;
 import static org.springframework.util.MimeTypeUtils.APPLICATION_OCTET_STREAM;
-import static org.springframework.util.MimeTypeUtils.TEXT_PLAIN;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -426,7 +425,7 @@ public abstract class AbstractBinder<T> implements ApplicationContextAware, Init
 	}
 
 	private Object deserializePayload(byte[] bytes, MimeType contentType) {
-		if (TEXT_PLAIN.equals(contentType) || APPLICATION_JSON.equals(contentType)) {
+		if ("text".equalsIgnoreCase(contentType.getType()) || APPLICATION_JSON.equals(contentType)) {
 			try {
 				return new String(bytes, "UTF-8");
 			}


### PR DESCRIPTION
 - When deserializing the payload at the consumer endpoint, the non-byte stream payload type requires to use `String` object when the underlying message content-type is of any `text` type contentType (text/plain, text/xml and text/html).
 - This fix is only needed to support any non-SCSt applications that will have the 'text/*` contentType of the deserializing message
 - Add test

This resolves #403