### PR TITLE
Preserve contentType when de-serializing messages from non-SCSt app

### DIFF
--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-test/src/main/java/org/springframework/cloud/stream/binder/AbstractBinderTests.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-test/src/main/java/org/springframework/cloud/stream/binder/AbstractBinderTests.java
@@ -41,6 +41,7 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.PollableChannel;
+import org.springframework.util.MimeTypeUtils;
 
 /**
  * @author Gary Russell
@@ -169,7 +170,7 @@ public abstract class AbstractBinderTests {
 		assertNotNull(inbound);
 		assertEquals("foo", inbound.getPayload());
 		assertNull(inbound.getHeaders().get(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE));
-		assertNull(inbound.getHeaders().get(MessageHeaders.CONTENT_TYPE));
+		assertEquals(MimeTypeUtils.TEXT_PLAIN_VALUE, inbound.getHeaders().get(MessageHeaders.CONTENT_TYPE));
 		producerBinding.unbind();
 		consumerBinding.unbind();
 	}

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-test/src/test/java/org/springframework/cloud/stream/binder/MessageChannelBinderSupportTests.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-test/src/test/java/org/springframework/cloud/stream/binder/MessageChannelBinderSupportTests.java
@@ -108,7 +108,8 @@ public class MessageChannelBinderSupportTests {
 				contentTypeResolver.resolve(converted.getHeaders()));
 		MessageValues reconstructed = binder.deserializePayloadIfNecessary(converted);
 		assertEquals("foo", reconstructed.getPayload());
-		assertNull(reconstructed.get(MessageHeaders.CONTENT_TYPE));
+		assertNull(reconstructed.get(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE));
+		assertEquals(MimeTypeUtils.TEXT_PLAIN_VALUE, reconstructed.get(MessageHeaders.CONTENT_TYPE));
 	}
 
 	@Test
@@ -127,7 +128,17 @@ public class MessageChannelBinderSupportTests {
 				converted.getHeaders().get(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE));
 		MessageValues reconstructed = binder.deserializePayloadIfNecessary(converted);
 		assertEquals("{\"foo\":\"foo\"}", reconstructed.getPayload());
-		assertEquals(MimeTypeUtils.APPLICATION_JSON.toString(), reconstructed.get(MessageHeaders.CONTENT_TYPE));
+		assertEquals(MimeTypeUtils.APPLICATION_JSON_VALUE, reconstructed.get(MessageHeaders.CONTENT_TYPE));
+	}
+
+	@Test
+	public void testContentTypePreservedForNonSCStApp() {
+		Message<String> inbound = MessageBuilder.withPayload("{\"foo\":\"bar\"}")
+				.copyHeaders(Collections.singletonMap(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.APPLICATION_JSON))
+				.build();
+		MessageValues reconstructed = binder.deserializePayloadIfNecessary(inbound);
+		assertEquals("{\"foo\":\"bar\"}", reconstructed.getPayload());
+		assertEquals(MimeTypeUtils.APPLICATION_JSON, reconstructed.get(MessageHeaders.CONTENT_TYPE));
 	}
 
 	@Test
@@ -142,7 +153,9 @@ public class MessageChannelBinderSupportTests {
 
 		MessageValues reconstructed = binder.deserializePayloadIfNecessary(converted);
 		assertEquals("bar", ((Foo) reconstructed.getPayload()).getBar());
-		assertNull(reconstructed.get(MessageHeaders.CONTENT_TYPE));
+		assertNull(reconstructed.get(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE));
+		assertEquals("application/x-java-object;type=org.springframework.cloud.stream.binder.MessageChannelBinderSupportTests$Foo",
+				reconstructed.get(MessageHeaders.CONTENT_TYPE));
 	}
 
 	@Test
@@ -157,7 +170,9 @@ public class MessageChannelBinderSupportTests {
 
 		MessageValues reconstructed = binder.deserializePayloadIfNecessary(converted);
 		assertEquals("bar", ((Foo) reconstructed.getPayload()).getBar());
-		assertNull(reconstructed.get(MessageHeaders.CONTENT_TYPE));
+		assertNull(reconstructed.get(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE));
+		assertEquals("application/x-java-object;type=org.springframework.cloud.stream.binder.MessageChannelBinderSupportTests$Foo",
+				reconstructed.get(MessageHeaders.CONTENT_TYPE));
 	}
 
 	@Test
@@ -172,7 +187,9 @@ public class MessageChannelBinderSupportTests {
 
 		MessageValues reconstructed = binder.deserializePayloadIfNecessary(converted);
 		assertEquals("bar", ((Foo) reconstructed.getPayload()).getBar());
-		assertNull(reconstructed.get(MessageHeaders.CONTENT_TYPE));
+		assertNull(reconstructed.get(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE));
+		assertEquals("application/x-java-object;type=org.springframework.cloud.stream.binder.MessageChannelBinderSupportTests$Foo",
+				reconstructed.get(MessageHeaders.CONTENT_TYPE));
 	}
 
 	@Test
@@ -187,7 +204,9 @@ public class MessageChannelBinderSupportTests {
 
 		MessageValues reconstructed = binder.deserializePayloadIfNecessary(converted);
 		assertEquals("bar", ((Tuple) reconstructed.getPayload()).getString("foo"));
-		assertNull(reconstructed.get(MessageHeaders.CONTENT_TYPE));
+		assertNull(reconstructed.get(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE));
+		assertEquals("application/x-java-object;type=org.springframework.tuple.DefaultTuple",
+				reconstructed.get(MessageHeaders.CONTENT_TYPE));
 	}
 
 	@Test

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
@@ -405,10 +405,13 @@ public abstract class AbstractBinder<T> implements ApplicationContextAware, Init
 		Object payload = deserializePayload(originalPayload, contentType);
 		if (payload != null) {
 			messageValues.setPayload(payload);
-
 			Object originalContentType = messageValues.get(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE);
-			messageValues.put(MessageHeaders.CONTENT_TYPE, originalContentType);
-			messageValues.remove(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE);
+			// Reset content-type only if the original content type is not null (when receiving messages from
+			// non-SCSt applications.
+			if (originalContentType != null) {
+				messageValues.put(MessageHeaders.CONTENT_TYPE, originalContentType);
+				messageValues.remove(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE);
+			}
 		}
 		return messageValues;
 	}


### PR DESCRIPTION
 - When deserialising the message, replace `contentType` with the `originalContentType` only if the `originalContentType` isn't null which means the original content type was set by the producer before serialising.
 - Add and fix tests

This resolves #404