### PR TITLE
Move message header mode as a generic property

### DIFF
--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaConsumerProperties.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaConsumerProperties.java
@@ -29,8 +29,6 @@ public class KafkaConsumerProperties {
 
 	private KafkaMessageChannelBinder.StartOffset startOffset = null;
 
-	private KafkaMessageChannelBinder.Mode mode = KafkaMessageChannelBinder.Mode.embeddedHeaders;
-
 	public void setMinPartitionCount(int minPartitionCount) {
 		this.minPartitionCount = minPartitionCount;
 	}
@@ -45,14 +43,6 @@ public class KafkaConsumerProperties {
 
 	public void setAutoCommitOffset(boolean autoCommitOffset) {
 		this.autoCommitOffset = autoCommitOffset;
-	}
-
-	public KafkaMessageChannelBinder.Mode getMode() {
-		return mode;
-	}
-
-	public void setMode(KafkaMessageChannelBinder.Mode mode) {
-		this.mode = mode;
 	}
 
 	public boolean isResetOffsets() {

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -41,7 +41,6 @@ import org.springframework.cloud.stream.binder.BinderException;
 import org.springframework.cloud.stream.binder.BinderHeaders;
 import org.springframework.cloud.stream.binder.Binding;
 import org.springframework.cloud.stream.binder.DefaultBinding;
-import org.springframework.cloud.stream.binder.EmbeddedHeadersMessageConverter;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.ExtendedPropertiesBinder;
@@ -110,9 +109,6 @@ public class KafkaMessageChannelBinder extends AbstractBinder<MessageChannel, Ex
 	private RetryOperations retryOperations;
 
 	private final Map<String, Collection<Partition>> topicsInUse = new HashMap<>();
-
-	private final EmbeddedHeadersMessageConverter embeddedHeadersMessageConverter = new
-			EmbeddedHeadersMessageConverter();
 
 	private final ZookeeperConnect zookeeperConnect;
 
@@ -580,16 +576,7 @@ public class KafkaMessageChannelBinder extends AbstractBinder<MessageChannel, Ex
 		@SuppressWarnings("unchecked")
 		protected Object handleRequestMessage(Message<?> requestMessage) {
 			if (HeaderMode.embeddedHeaders.equals(consumerProperties.getHeaderMode())) {
-				MessageValues messageValues;
-				try {
-					messageValues = embeddedHeadersMessageConverter.extractHeaders((Message<byte[]>) requestMessage,
-							true);
-				}
-				catch (Exception e) {
-					logger.error(EmbeddedHeadersMessageConverter.decodeExceptionMessage(requestMessage), e);
-					messageValues = new MessageValues(requestMessage);
-				}
-				messageValues = deserializePayloadIfNecessary(messageValues);
+				MessageValues messageValues = extractMessageValues(requestMessage);
 				return MessageBuilder.createMessage(messageValues.getPayload(), new KafkaBinderHeaders(
 						messageValues));
 			}

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -29,16 +29,9 @@ import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import kafka.admin.AdminUtils;
-import kafka.api.OffsetRequest;
-import kafka.serializer.Decoder;
-import kafka.serializer.DefaultDecoder;
-import kafka.utils.ZKStringSerializer$;
-import kafka.utils.ZkUtils;
 import org.I0Itec.zkclient.ZkClient;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
-import scala.collection.Seq;
 
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
@@ -52,6 +45,7 @@ import org.springframework.cloud.stream.binder.EmbeddedHeadersMessageConverter;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.ExtendedPropertiesBinder;
+import org.springframework.cloud.stream.binder.HeaderMode;
 import org.springframework.cloud.stream.binder.MessageValues;
 import org.springframework.cloud.stream.binder.PartitionHandler;
 import org.springframework.http.MediaType;
@@ -89,6 +83,14 @@ import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
+
+import kafka.admin.AdminUtils;
+import kafka.api.OffsetRequest;
+import kafka.serializer.Decoder;
+import kafka.serializer.DefaultDecoder;
+import kafka.utils.ZKStringSerializer$;
+import kafka.utils.ZkUtils;
+import scala.collection.Seq;
 
 /**
  * A {@link Binder} that uses Kafka as the underlying middleware.
@@ -577,7 +579,7 @@ public class KafkaMessageChannelBinder extends AbstractBinder<MessageChannel, Ex
 		@Override
 		@SuppressWarnings("unchecked")
 		protected Object handleRequestMessage(Message<?> requestMessage) {
-			if (Mode.embeddedHeaders.equals(consumerProperties.getExtension().getMode())) {
+			if (HeaderMode.embeddedHeaders.equals(consumerProperties.getHeaderMode())) {
 				MessageValues messageValues;
 				try {
 					messageValues = embeddedHeadersMessageConverter.extractHeaders((Message<byte[]>) requestMessage,
@@ -648,14 +650,13 @@ public class KafkaMessageChannelBinder extends AbstractBinder<MessageChannel, Ex
 			else {
 				targetPartition = roundRobin() % numberOfKafkaPartitions;
 			}
-
-			if (Mode.embeddedHeaders.equals(producerProperties.getExtension().getMode())) {
+			if (HeaderMode.embeddedHeaders.equals(producerProperties.getHeaderMode())) {
 				MessageValues transformed = serializePayloadIfNecessary(message);
 				byte[] messageToSend = embeddedHeadersMessageConverter.embedHeaders(transformed,
 						KafkaMessageChannelBinder.this.headersToMap);
 				producerConfiguration.send(topicName, targetPartition, null, messageToSend);
 			}
-			else if (Mode.raw.equals(producerProperties.getExtension().getMode())) {
+			else if (HeaderMode.raw.equals(producerProperties.getHeaderMode())) {
 				Object contentType = message.getHeaders().get(MessageHeaders.CONTENT_TYPE);
 				if (contentType != null
 						&& !contentType.equals(MediaType.APPLICATION_OCTET_STREAM_VALUE)) {
@@ -680,11 +681,6 @@ public class KafkaMessageChannelBinder extends AbstractBinder<MessageChannel, Ex
 			return result;
 		}
 
-	}
-
-	public enum Mode {
-		raw,
-		embeddedHeaders
 	}
 
 	public enum StartOffset {

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaProducerProperties.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaProducerProperties.java
@@ -29,8 +29,6 @@ public class KafkaProducerProperties {
 
 	private boolean sync = false;
 
-	private KafkaMessageChannelBinder.Mode mode = KafkaMessageChannelBinder.Mode.embeddedHeaders;
-
 	private int batchTimeout = 0;
 
 	public int getBufferSize() {
@@ -55,14 +53,6 @@ public class KafkaProducerProperties {
 
 	public void setSync(boolean sync) {
 		this.sync = sync;
-	}
-
-	public KafkaMessageChannelBinder.Mode getMode() {
-		return mode;
-	}
-
-	public void setMode(KafkaMessageChannelBinder.Mode mode) {
-		this.mode = mode;
 	}
 
 	public int getBatchTimeout() {

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaBinderConfigurationProperties.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaBinderConfigurationProperties.java
@@ -17,8 +17,6 @@
 package org.springframework.cloud.stream.binder.kafka.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.cloud.stream.binder.kafka.KafkaMessageChannelBinder;
-import org.springframework.cloud.stream.binder.kafka.KafkaMessageChannelBinder.Mode;
 import org.springframework.util.StringUtils;
 
 /**
@@ -38,8 +36,6 @@ class KafkaBinderConfigurationProperties {
 	private String defaultBrokerPort = "9092";
 
 	private String[] headers = new String[] {};
-
-	private KafkaMessageChannelBinder.Mode mode = Mode.embeddedHeaders;
 
 	private int offsetUpdateTimeWindow = 10000;
 
@@ -81,10 +77,6 @@ class KafkaBinderConfigurationProperties {
 		return headers;
 	}
 
-	public Mode getMode() {
-		return this.mode;
-	}
-
 	public int getOffsetUpdateTimeWindow() {
 		return this.offsetUpdateTimeWindow;
 	}
@@ -116,10 +108,6 @@ class KafkaBinderConfigurationProperties {
 
 	public void setHeaders(String[] headers) {
 		this.headers = headers;
-	}
-
-	public void setMode(KafkaMessageChannelBinder.Mode mode) {
-		this.mode = mode;
 	}
 
 	public void setOffsetUpdateTimeWindow(int offsetUpdateTimeWindow) {

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ConsumerProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ConsumerProperties.java
@@ -20,6 +20,7 @@ package org.springframework.cloud.stream.binder;
  * Common consumer properties.
  *
  * @author Marius Bogoevici
+ * @author Ilayaperumal Gopinathan
  */
 public class ConsumerProperties {
 
@@ -38,6 +39,8 @@ public class ConsumerProperties {
 	private int backOffMaxInterval = 10000;
 
 	private double backOffMultiplier = 2.0;
+
+	private HeaderMode headerMode = HeaderMode.embeddedHeaders;
 
 	public int getConcurrency() {
 		return concurrency;
@@ -103,5 +106,12 @@ public class ConsumerProperties {
 		return backOffMultiplier;
 	}
 
+	public HeaderMode getHeaderMode() {
+		return this.headerMode;
+	}
+
+	public void setHeaderMode(HeaderMode headerMode) {
+		this.headerMode = headerMode;
+	}
 }
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/HeaderMode.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/HeaderMode.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.binder;
+
+/**
+ * @author Marius Bogoevici
+ */
+public enum HeaderMode {
+	raw,
+	embeddedHeaders
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ProducerProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ProducerProperties.java
@@ -22,6 +22,7 @@ import org.springframework.expression.Expression;
  * Common producer properties.
  *
  * @author Marius Bogoevici
+ * @author Ilayaperumal Gopinathan
  */
 public class ProducerProperties {
 
@@ -36,6 +37,8 @@ public class ProducerProperties {
 	private int partitionCount = 1;
 
 	private String[] requiredGroups = new String[] {};
+
+	private HeaderMode headerMode = HeaderMode.embeddedHeaders;
 
 	public Expression getPartitionKeyExpression() {
 		return partitionKeyExpression;
@@ -87,6 +90,14 @@ public class ProducerProperties {
 
 	public void setRequiredGroups(String... requiredGroups) {
 		this.requiredGroups = requiredGroups;
+	}
+
+	public HeaderMode getHeaderMode() {
+		return this.headerMode;
+	}
+
+	public void setHeaderMode(HeaderMode headerMode) {
+		this.headerMode = headerMode;
 	}
 
 }


### PR DESCRIPTION
- Both the producer and consumer properties have `HeaderMode`
 - Handle the case of embeddedHeaders and raw for both the Sending/ReceivingHandlers in Redis binder

This resolves #408