### PR TITLE
Introduce BindingListener annotation

### DIFF
--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/BindingListenerTests.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/BindingListenerTests.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.config;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.cloud.stream.annotation.BindingListener;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.messaging.Processor;
+import org.springframework.cloud.stream.messaging.Sink;
+import org.springframework.cloud.stream.test.binder.MessageCollector;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Headers;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.SendTo;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class BindingListenerTests {
+
+	@Test
+	public void testContentTypeConversion() throws Exception {
+		ConfigurableApplicationContext context = SpringApplication.run(TestSink.class);
+		@SuppressWarnings("unchecked")
+		TestSink testSink = context.getBean(TestSink.class);
+		Sink sink = context.getBean(Sink.class);
+		String id = UUID.randomUUID().toString();
+		sink.input().send(MessageBuilder.withPayload("{\"bar\":\"barbar" + id + "\"}")
+				.setHeader("contentType","application/json").build());
+		assertTrue(testSink.latch.await(10, TimeUnit.SECONDS));
+		assertThat(testSink.receivedArguments, hasSize(1));
+		assertThat(testSink.receivedArguments.get(0), hasProperty("bar", equalTo("barbar" + id)));
+		context.close();
+	}
+
+	@Test
+	public void testAnnotatedArguments() throws Exception {
+		ConfigurableApplicationContext context = SpringApplication.run(TestPojoWithAnnotatedArguments.class);
+		@SuppressWarnings("unchecked")
+		TestPojoWithAnnotatedArguments testPojoWithAnnotatedArguments = context.getBean(TestPojoWithAnnotatedArguments.class);
+		Sink sink = context.getBean(Sink.class);
+		String id = UUID.randomUUID().toString();
+		sink.input().send(MessageBuilder.withPayload("{\"bar\":\"barbar" + id + "\"}")
+								  .setHeader("contentType", "application/json").setHeader("testHeader", "testValue").build());
+		assertThat(testPojoWithAnnotatedArguments.receivedArguments, hasSize(3));
+		assertThat(testPojoWithAnnotatedArguments.receivedArguments.get(0), instanceOf(FooPojo.class));
+		assertThat(testPojoWithAnnotatedArguments.receivedArguments.get(0), hasProperty("bar", equalTo("barbar" + id)));
+		assertThat(testPojoWithAnnotatedArguments.receivedArguments.get(1), instanceOf(Map.class));
+		assertThat((Map<String, String>) testPojoWithAnnotatedArguments.receivedArguments.get(1), hasEntry(MessageHeaders.CONTENT_TYPE, "application/json"));
+		assertThat((Map<String, String>) testPojoWithAnnotatedArguments.receivedArguments.get(1), hasEntry(equalTo("testHeader"), equalTo("testValue")));
+		assertThat((String) testPojoWithAnnotatedArguments.receivedArguments.get(2), equalTo("application/json"));
+		context.close();
+	}
+
+	@Test
+	public void testReturn() throws Exception {
+		ConfigurableApplicationContext context = SpringApplication.run(TestStringProcessor.class);
+		MessageCollector collector = context.getBean(MessageCollector.class);
+		Processor processor = context.getBean(Processor.class);
+		String id = UUID.randomUUID().toString();
+		processor.input().send(MessageBuilder.withPayload("{\"bar\":\"barbar" + id + "\"}")
+				.setHeader("contentType","application/json").build());
+		@SuppressWarnings("unchecked")
+		Message<String> message = (Message<String>) collector.forChannel(processor.output()).poll(1, TimeUnit.SECONDS);
+		TestStringProcessor testStringProcessor = context.getBean(TestStringProcessor.class);
+		assertThat(testStringProcessor.receivedPojos, hasSize(1));
+		assertThat(testStringProcessor.receivedPojos.get(0), hasProperty("bar", equalTo("barbar" + id)));
+		assertThat(message, not(nullValue(Message.class)));
+		assertThat(message.getPayload(), equalTo("barbar"+id));
+		context.close();
+	}
+
+	@Test
+	public void testReturnConversion() throws Exception {
+		ConfigurableApplicationContext context = SpringApplication.run(TestPojoWithMimeType.class,
+				"--spring.cloud.stream.bindings.output.contentType=application/json");
+		MessageCollector collector = context.getBean(MessageCollector.class);
+		Processor processor = context.getBean(Processor.class);
+		String id = UUID.randomUUID().toString();
+		processor.input().send(MessageBuilder.withPayload("{\"bar\":\"barbar" + id + "\"}")
+				.setHeader("contentType","application/json").build());
+		@SuppressWarnings("unchecked")
+		TestPojoWithMimeType testPojoWithMimeType = context.getBean(TestPojoWithMimeType.class);
+		assertThat(testPojoWithMimeType.receivedPojos, hasSize(1));
+		assertThat(testPojoWithMimeType.receivedPojos.get(0), hasProperty("bar", equalTo("barbar" + id)));
+		Message<String> message = (Message<String>) collector.forChannel(processor.output()).poll(1, TimeUnit.SECONDS);
+		assertThat(message, not(nullValue(Message.class)));
+		assertThat(message.getPayload(), equalTo("{\"qux\":\"barbar" + id + "\"}"));
+		assertThat(message.getHeaders().get(MessageHeaders.CONTENT_TYPE, String.class), equalTo("application/json"));
+		context.close();
+	}
+
+	@Test
+	public void testReturnNoConversion() throws Exception {
+		ConfigurableApplicationContext context = SpringApplication.run(TestPojoWithMimeType.class);
+		MessageCollector collector = context.getBean(MessageCollector.class);
+		Processor processor = context.getBean(Processor.class);
+		String id = UUID.randomUUID().toString();
+		processor.input().send(MessageBuilder.withPayload("{\"bar\":\"barbar" + id + "\"}")
+				.setHeader("contentType","application/json").build());
+		@SuppressWarnings("unchecked")
+		TestPojoWithMimeType testPojoWithMimeType = context.getBean(TestPojoWithMimeType.class);
+		assertThat(testPojoWithMimeType.receivedPojos, hasSize(1));
+		assertThat(testPojoWithMimeType.receivedPojos.get(0), hasProperty("bar", equalTo("barbar" + id)));
+		Message<BazPojo> message = (Message<BazPojo>) collector.forChannel(processor.output()).poll(1, TimeUnit.SECONDS);
+		assertThat(message, not(nullValue(Message.class)));
+		assertThat(message.getPayload().getQux(), equalTo("barbar" + id));
+		context.close();
+	}
+
+	@Test
+	public void testReturnMessage() throws Exception {
+		ConfigurableApplicationContext context = SpringApplication.run(TestPojoWithMessageReturn.class);
+		MessageCollector collector = context.getBean(MessageCollector.class);
+		Processor processor = context.getBean(Processor.class);
+		String id = UUID.randomUUID().toString();
+		processor.input().send(MessageBuilder.withPayload("{\"bar\":\"barbar" + id + "\"}")
+				.setHeader("contentType", "application/json").build());
+		@SuppressWarnings("unchecked")
+		TestPojoWithMessageReturn testPojoWithMessageReturn = context.getBean(TestPojoWithMessageReturn.class);
+		assertThat(testPojoWithMessageReturn.receivedPojos, hasSize(1));
+		assertThat(testPojoWithMessageReturn.receivedPojos.get(0), hasProperty("bar", equalTo("barbar" + id)));
+		Message<BazPojo> message = (Message<BazPojo>) collector.forChannel(processor.output()).poll(1, TimeUnit.SECONDS);
+		assertThat(message, not(nullValue(Message.class)));
+		assertThat(message.getPayload().getQux(), equalTo("barbar" + id));
+		context.close();
+	}
+
+	@Test
+	public void testMessageArgument() throws Exception {
+		ConfigurableApplicationContext context = SpringApplication.run(TestPojoWithMessageArgument.class);
+		MessageCollector collector = context.getBean(MessageCollector.class);
+		Processor processor = context.getBean(Processor.class);
+		String id = UUID.randomUUID().toString();
+		processor.input().send(MessageBuilder.withPayload("barbar" + id)
+									   .setHeader("contentType", "text/plain").build());
+		@SuppressWarnings("unchecked")
+		TestPojoWithMessageArgument testPojoWithMessageArgument = context.getBean(TestPojoWithMessageArgument.class);
+		assertThat(testPojoWithMessageArgument.receivedMessages, hasSize(1));
+		assertThat(testPojoWithMessageArgument.receivedMessages.get(0).getPayload(), equalTo("barbar" + id));
+		Message<BazPojo> message = (Message<BazPojo>) collector.forChannel(processor.output()).poll(1, TimeUnit.SECONDS);
+		assertThat(message, not(nullValue(Message.class)));
+		assertThat(message.getPayload().getQux(), equalTo("barbar" + id));
+		context.close();
+	}
+
+	@EnableBinding(Sink.class)
+	@EnableAutoConfiguration
+	public static class TestSink {
+
+		List<FooPojo> receivedArguments = new ArrayList<>();
+
+		CountDownLatch latch = new CountDownLatch(1);
+
+
+		@BindingListener(Sink.INPUT)
+		public void receive(FooPojo fooPojo) {
+			receivedArguments.add(fooPojo);
+			latch.countDown();
+		}
+	}
+
+	@EnableBinding(Processor.class)
+	@EnableAutoConfiguration
+	public static class TestStringProcessor {
+
+		List<FooPojo> receivedPojos = new ArrayList<>();
+
+		@BindingListener(Processor.INPUT) @SendTo(Processor.OUTPUT)
+		public String receive(FooPojo fooPojo) {
+			receivedPojos.add(fooPojo);
+			return fooPojo.getBar();
+		}
+	}
+
+	@EnableBinding(Processor.class)
+	@EnableAutoConfiguration
+	public static class TestPojoWithMimeType {
+
+		List<FooPojo> receivedPojos = new ArrayList<>();
+
+		@BindingListener(Processor.INPUT) @SendTo(Processor.OUTPUT)
+		public BazPojo receive(FooPojo fooPojo) {
+			receivedPojos.add(fooPojo);
+			BazPojo bazPojo = new BazPojo();
+			bazPojo.setQux(fooPojo.getBar());
+			return bazPojo;
+		}
+	}
+
+	@EnableBinding(Processor.class)
+	@EnableAutoConfiguration
+	public static class TestPojoWithAnnotatedArguments {
+
+		List<Object> receivedArguments = new ArrayList<>();
+
+		@BindingListener(Processor.INPUT)
+		public void receive(@Payload FooPojo fooPojo, @Headers Map<String, Object> headers, @Header(MessageHeaders.CONTENT_TYPE) String contentType) {
+			receivedArguments.add(fooPojo);
+			receivedArguments.add(headers);
+			receivedArguments.add(contentType);
+		}
+	}
+
+	@EnableBinding(Processor.class)
+	@EnableAutoConfiguration
+	public static class TestPojoWithMessageReturn {
+
+		List<FooPojo> receivedPojos = new ArrayList<>();
+
+		@BindingListener(Processor.INPUT)
+		@SendTo(Processor.OUTPUT)
+		public Message<?> receive(FooPojo fooPojo) {
+			receivedPojos.add(fooPojo);
+			BazPojo bazPojo = new BazPojo();
+			bazPojo.setQux(fooPojo.getBar());
+			return MessageBuilder.withPayload(bazPojo).setHeader("foo", "bar").build();
+		}
+	}
+
+	@EnableBinding(Processor.class)
+	@EnableAutoConfiguration
+	public static class TestPojoWithMessageArgument {
+
+		List<Message<String>> receivedMessages = new ArrayList<>();
+
+		@BindingListener(Processor.INPUT)
+		@SendTo(Processor.OUTPUT)
+		public BazPojo receive(Message<String> fooMessage) {
+			receivedMessages.add(fooMessage);
+			BazPojo bazPojo = new BazPojo();
+			bazPojo.setQux(fooMessage.getPayload());
+			return bazPojo;
+		}
+	}
+
+	@EnableBinding(Processor.class)
+	@EnableAutoConfiguration
+	public static class TestPojoThrowingException {
+
+		List<Message<String>> receivedMessages = new ArrayList<>();
+
+		@BindingListener(Processor.INPUT)
+		@SendTo(Processor.OUTPUT)
+		public BazPojo receive(Message<String> fooMessage) {
+			throw new IllegalStateException("Foo exception");
+		}
+	}
+
+	public static class FooPojo {
+
+		private String bar;
+
+		public String getBar() {
+			return bar;
+		}
+
+		public void setBar(String bar) {
+			this.bar = bar;
+		}
+	}
+
+	public static class BazPojo {
+
+		private String qux;
+
+		public String getQux() {
+			return qux;
+		}
+
+		public void setQux(String qux) {
+			this.qux = qux;
+		}
+	}
+}

--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/BindingListenerTests.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/BindingListenerTests.java
@@ -37,8 +37,8 @@ import org.junit.Test;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.cloud.stream.annotation.BindingListener;
 import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.annotation.StreamListener;
 import org.springframework.cloud.stream.messaging.Processor;
 import org.springframework.cloud.stream.messaging.Sink;
 import org.springframework.cloud.stream.test.binder.MessageCollector;
@@ -72,9 +72,10 @@ public class BindingListenerTests {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void testAnnotatedArguments() throws Exception {
 		ConfigurableApplicationContext context = SpringApplication.run(TestPojoWithAnnotatedArguments.class);
-		@SuppressWarnings("unchecked")
+
 		TestPojoWithAnnotatedArguments testPojoWithAnnotatedArguments = context.getBean(TestPojoWithAnnotatedArguments.class);
 		Sink sink = context.getBean(Sink.class);
 		String id = UUID.randomUUID().toString();
@@ -91,6 +92,7 @@ public class BindingListenerTests {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void testReturn() throws Exception {
 		ConfigurableApplicationContext context = SpringApplication.run(TestStringProcessor.class);
 		MessageCollector collector = context.getBean(MessageCollector.class);
@@ -98,7 +100,6 @@ public class BindingListenerTests {
 		String id = UUID.randomUUID().toString();
 		processor.input().send(MessageBuilder.withPayload("{\"bar\":\"barbar" + id + "\"}")
 				.setHeader("contentType","application/json").build());
-		@SuppressWarnings("unchecked")
 		Message<String> message = (Message<String>) collector.forChannel(processor.output()).poll(1, TimeUnit.SECONDS);
 		TestStringProcessor testStringProcessor = context.getBean(TestStringProcessor.class);
 		assertThat(testStringProcessor.receivedPojos, hasSize(1));
@@ -109,6 +110,7 @@ public class BindingListenerTests {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void testReturnConversion() throws Exception {
 		ConfigurableApplicationContext context = SpringApplication.run(TestPojoWithMimeType.class,
 				"--spring.cloud.stream.bindings.output.contentType=application/json");
@@ -117,7 +119,6 @@ public class BindingListenerTests {
 		String id = UUID.randomUUID().toString();
 		processor.input().send(MessageBuilder.withPayload("{\"bar\":\"barbar" + id + "\"}")
 				.setHeader("contentType","application/json").build());
-		@SuppressWarnings("unchecked")
 		TestPojoWithMimeType testPojoWithMimeType = context.getBean(TestPojoWithMimeType.class);
 		assertThat(testPojoWithMimeType.receivedPojos, hasSize(1));
 		assertThat(testPojoWithMimeType.receivedPojos.get(0), hasProperty("bar", equalTo("barbar" + id)));
@@ -129,6 +130,7 @@ public class BindingListenerTests {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void testReturnNoConversion() throws Exception {
 		ConfigurableApplicationContext context = SpringApplication.run(TestPojoWithMimeType.class);
 		MessageCollector collector = context.getBean(MessageCollector.class);
@@ -136,7 +138,6 @@ public class BindingListenerTests {
 		String id = UUID.randomUUID().toString();
 		processor.input().send(MessageBuilder.withPayload("{\"bar\":\"barbar" + id + "\"}")
 				.setHeader("contentType","application/json").build());
-		@SuppressWarnings("unchecked")
 		TestPojoWithMimeType testPojoWithMimeType = context.getBean(TestPojoWithMimeType.class);
 		assertThat(testPojoWithMimeType.receivedPojos, hasSize(1));
 		assertThat(testPojoWithMimeType.receivedPojos.get(0), hasProperty("bar", equalTo("barbar" + id)));
@@ -147,6 +148,7 @@ public class BindingListenerTests {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void testReturnMessage() throws Exception {
 		ConfigurableApplicationContext context = SpringApplication.run(TestPojoWithMessageReturn.class);
 		MessageCollector collector = context.getBean(MessageCollector.class);
@@ -154,7 +156,6 @@ public class BindingListenerTests {
 		String id = UUID.randomUUID().toString();
 		processor.input().send(MessageBuilder.withPayload("{\"bar\":\"barbar" + id + "\"}")
 				.setHeader("contentType", "application/json").build());
-		@SuppressWarnings("unchecked")
 		TestPojoWithMessageReturn testPojoWithMessageReturn = context.getBean(TestPojoWithMessageReturn.class);
 		assertThat(testPojoWithMessageReturn.receivedPojos, hasSize(1));
 		assertThat(testPojoWithMessageReturn.receivedPojos.get(0), hasProperty("bar", equalTo("barbar" + id)));
@@ -165,6 +166,7 @@ public class BindingListenerTests {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void testMessageArgument() throws Exception {
 		ConfigurableApplicationContext context = SpringApplication.run(TestPojoWithMessageArgument.class);
 		MessageCollector collector = context.getBean(MessageCollector.class);
@@ -172,7 +174,6 @@ public class BindingListenerTests {
 		String id = UUID.randomUUID().toString();
 		processor.input().send(MessageBuilder.withPayload("barbar" + id)
 									   .setHeader("contentType", "text/plain").build());
-		@SuppressWarnings("unchecked")
 		TestPojoWithMessageArgument testPojoWithMessageArgument = context.getBean(TestPojoWithMessageArgument.class);
 		assertThat(testPojoWithMessageArgument.receivedMessages, hasSize(1));
 		assertThat(testPojoWithMessageArgument.receivedMessages.get(0).getPayload(), equalTo("barbar" + id));
@@ -191,7 +192,7 @@ public class BindingListenerTests {
 		CountDownLatch latch = new CountDownLatch(1);
 
 
-		@BindingListener(Sink.INPUT)
+		@StreamListener(Sink.INPUT)
 		public void receive(FooPojo fooPojo) {
 			receivedArguments.add(fooPojo);
 			latch.countDown();
@@ -204,7 +205,8 @@ public class BindingListenerTests {
 
 		List<FooPojo> receivedPojos = new ArrayList<>();
 
-		@BindingListener(Processor.INPUT) @SendTo(Processor.OUTPUT)
+		@StreamListener(Processor.INPUT)
+		@SendTo(Processor.OUTPUT)
 		public String receive(FooPojo fooPojo) {
 			receivedPojos.add(fooPojo);
 			return fooPojo.getBar();
@@ -217,7 +219,8 @@ public class BindingListenerTests {
 
 		List<FooPojo> receivedPojos = new ArrayList<>();
 
-		@BindingListener(Processor.INPUT) @SendTo(Processor.OUTPUT)
+		@StreamListener(Processor.INPUT)
+		@SendTo(Processor.OUTPUT)
 		public BazPojo receive(FooPojo fooPojo) {
 			receivedPojos.add(fooPojo);
 			BazPojo bazPojo = new BazPojo();
@@ -232,7 +235,7 @@ public class BindingListenerTests {
 
 		List<Object> receivedArguments = new ArrayList<>();
 
-		@BindingListener(Processor.INPUT)
+		@StreamListener(Processor.INPUT)
 		public void receive(@Payload FooPojo fooPojo, @Headers Map<String, Object> headers, @Header(MessageHeaders.CONTENT_TYPE) String contentType) {
 			receivedArguments.add(fooPojo);
 			receivedArguments.add(headers);
@@ -246,7 +249,7 @@ public class BindingListenerTests {
 
 		List<FooPojo> receivedPojos = new ArrayList<>();
 
-		@BindingListener(Processor.INPUT)
+		@StreamListener(Processor.INPUT)
 		@SendTo(Processor.OUTPUT)
 		public Message<?> receive(FooPojo fooPojo) {
 			receivedPojos.add(fooPojo);
@@ -262,7 +265,7 @@ public class BindingListenerTests {
 
 		List<Message<String>> receivedMessages = new ArrayList<>();
 
-		@BindingListener(Processor.INPUT)
+		@StreamListener(Processor.INPUT)
 		@SendTo(Processor.OUTPUT)
 		public BazPojo receive(Message<String> fooMessage) {
 			receivedMessages.add(fooMessage);
@@ -278,7 +281,7 @@ public class BindingListenerTests {
 
 		List<Message<String>> receivedMessages = new ArrayList<>();
 
-		@BindingListener(Processor.INPUT)
+		@StreamListener(Processor.INPUT)
 		@SendTo(Processor.OUTPUT)
 		public BazPojo receive(Message<String> fooMessage) {
 			throw new IllegalStateException("Foo exception");

--- a/spring-cloud-stream-integration-tests/src/test/resources/org/springframework/cloud/stream/config/custom/source-channel-configurers.properties
+++ b/spring-cloud-stream-integration-tests/src/test/resources/org/springframework/cloud/stream/config/custom/source-channel-configurers.properties
@@ -1,2 +1,2 @@
 spring.cloud.stream.bindings.output.destination=configure1
-spring.cloud.stream.bindings.output.contentType=foo/test
+spring.cloud.stream.bindings.output.contentType=test/bar

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/annotation/BindingListener.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/annotation/BindingListener.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.messaging.handler.annotation.MessageMapping;
+
+/**
+ * Annotation that marks a method to be a listener to an input channel declared through {@link EnableBinding}.
+ *
+ * Annotated methods are allowed to have flexible signatures, as described by {@link MessageMapping}.
+ *
+ * If the method returns a {@link org.springframework.messaging.Message}, the result will be automatically sent
+ * to a channel, as follows:
+ * <ul>
+ * <li>A result of the type {@link org.springframework.messaging.Message} will be sent as-is</li>
+ * <li>All other results will become the payload of a {@link org.springframework.messaging.Message}</li>
+ * </ul>
+ *
+ * The target channel of the return message is determined by consulting in the following order:
+ * <ul>
+ * <li>The {@link org.springframework.messaging.MessageHeaders} of the resulting message.</li>
+ * <li>The value set on the {@link org.springframework.messaging.handler.annotation.SendTo} annotation, if present</li>
+ * </ul>
+ *
+ * @see {@link MessageMapping}
+ * @see {@link org.springframework.messaging.handler.annotation.SendTo}
+ * @author Marius Bogoevici
+ */
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@MessageMapping
+@Documented
+public @interface BindingListener {
+
+	/**
+	 * The name of the binding that the method subscribes to.
+	 *
+	 */
+	String value() default "";
+
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/annotation/StreamListener.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/annotation/StreamListener.java
@@ -25,7 +25,8 @@ import java.lang.annotation.Target;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 
 /**
- * Annotation that marks a method to be a listener to an input channel declared through {@link EnableBinding}.
+ * Annotation that marks a method to be a listener to an input component declared through {@link EnableBinding}
+ * (e.g. a channel).
  *
  * Annotated methods are allowed to have flexible signatures, as described by {@link MessageMapping}.
  *
@@ -43,6 +44,7 @@ import org.springframework.messaging.handler.annotation.MessageMapping;
  * </ul>
  *
  * @see {@link MessageMapping}
+ * @see {@link EnableBinding}
  * @see {@link org.springframework.messaging.handler.annotation.SendTo}
  * @author Marius Bogoevici
  */
@@ -50,10 +52,10 @@ import org.springframework.messaging.handler.annotation.MessageMapping;
 @Retention(RetentionPolicy.RUNTIME)
 @MessageMapping
 @Documented
-public @interface BindingListener {
+public @interface StreamListener {
 
 	/**
-	 * The name of the binding that the method subscribes to.
+	 * The name of the bound component (e.g. channel) that the method subscribes to.
 	 *
 	 */
 	String value() default "";

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
@@ -305,7 +305,7 @@ public abstract class AbstractBinder<T, C extends ConsumerProperties, P extends 
 	 * @author David Turanski
 	 * @author Ilayaperumal Gopinathan
 	 */
-	abstract static class JavaClassMimeTypeConversion {
+	public abstract static class JavaClassMimeTypeConversion {
 
 		private static ConcurrentMap<String, MimeType> mimeTypesCache = new ConcurrentHashMap<>();
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindingListenerAnnotationBeanPostProcessor.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindingListenerAnnotationBeanPostProcessor.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binding;
+
+import java.lang.reflect.Method;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanInitializationException;
+import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.cloud.stream.annotation.BindingListener;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.SubscribableChannel;
+import org.springframework.messaging.core.DestinationResolver;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.handler.annotation.support.MessageHandlerMethodFactory;
+import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class BindingListenerAnnotationBeanPostProcessor implements BeanPostProcessor, SmartInitializingSingleton, ApplicationContextAware {
+
+	private final DestinationResolver<MessageChannel> binderAwareChannelResolver;
+
+	private final MessageHandlerMethodFactory messageHandlerMethodFactory;
+
+	private ConfigurableApplicationContext applicationContext;
+
+	public BindingListenerAnnotationBeanPostProcessor(DestinationResolver<MessageChannel> binderAwareChannelResolver, MessageHandlerMethodFactory messageHandlerMethodFactory) {
+		Assert.notNull(binderAwareChannelResolver, "Destination resolver cannot be null");
+		Assert.notNull(messageHandlerMethodFactory, "Message handler method factory cannot be null");
+		this.binderAwareChannelResolver = binderAwareChannelResolver;
+		this.messageHandlerMethodFactory = messageHandlerMethodFactory;
+	}
+
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = (ConfigurableApplicationContext) applicationContext;
+	}
+
+	@Override
+	public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+		return bean;
+	}
+
+	@Override
+	public Object postProcessAfterInitialization(final Object bean, String beanName) throws BeansException {
+		ReflectionUtils.doWithMethods(bean.getClass(), new ReflectionUtils.MethodCallback() {
+
+			@Override
+			public void doWith(final Method method) throws IllegalArgumentException, IllegalAccessException {
+				BindingListener bindingListener = AnnotationUtils.findAnnotation(method, BindingListener.class);
+				if (bindingListener != null) {
+					Assert.hasText(bindingListener.value(), "The binding name cannot be null");
+					final InvocableHandlerMethod invocableHandlerMethod = messageHandlerMethodFactory.createInvocableHandlerMethod(bean, method);
+					if (!StringUtils.hasText(bindingListener.value())) {
+						throw new BeanInitializationException("Only one of 'bindings' or 'value' can be specified");
+					}
+					SubscribableChannel channel = applicationContext.getBean(bindingListener.value(),
+							SubscribableChannel.class);
+					final String defaultOutputChannel = extractDefaultOutput(method);
+					if (invocableHandlerMethod.isVoid()) {
+						Assert.isTrue(StringUtils.isEmpty(defaultOutputChannel), "An output channel cannot be specified for a method that " +
+																						 "does not return a value");
+					}
+					else {
+						Assert.isTrue(!StringUtils.isEmpty(defaultOutputChannel), "An output channel must be specified for a method that " +
+																						  "can return a value");
+					}
+					BindingMessageHandler handler = new BindingMessageHandler(invocableHandlerMethod);
+					handler.setApplicationContext(applicationContext);
+					handler.setChannelResolver(binderAwareChannelResolver);
+					if (!StringUtils.isEmpty(defaultOutputChannel)) {
+						handler.setOutputChannelName(defaultOutputChannel);
+					}
+					handler.afterPropertiesSet();
+					// // TODO: add support for pollable channels
+					channel.subscribe(handler);
+				}
+			}
+		});
+		return bean;
+	}
+
+	private String extractDefaultOutput(Method method) {
+		SendTo sendTo = AnnotationUtils.findAnnotation(method, SendTo.class);
+		if (sendTo != null) {
+			Assert.isTrue(!ObjectUtils.isEmpty(sendTo.value()), "At least one output must be specified");
+			Assert.isTrue(sendTo.value().length == 1, "Multiple destinations cannot be specified");
+			Assert.hasText(sendTo.value()[0], "An empty destination cannot be specified");
+			return sendTo.value()[0];
+		}
+		return null;
+	}
+
+	@Override
+	public void afterSingletonsInstantiated() {
+
+	}
+
+	private class BindingMessageHandler extends AbstractReplyProducingMessageHandler {
+
+		private final InvocableHandlerMethod invocableHandlerMethod;
+
+		public BindingMessageHandler(InvocableHandlerMethod invocableHandlerMethod) {
+			this.invocableHandlerMethod = invocableHandlerMethod;
+		}
+
+		@Override
+		protected boolean shouldCopyRequestHeaders() {
+			return false;
+		}
+
+		@Override
+		protected Object handleRequestMessage(Message<?> requestMessage) {
+			try {
+				return invocableHandlerMethod.invoke(requestMessage);
+			}
+			catch (Exception e) {
+				if (e instanceof MessagingException) {
+					throw (MessagingException) e;
+				}
+				else {
+					throw new MessagingException(requestMessage,
+														"Exception thrown while invoking " + invocableHandlerMethod.getShortLogMessage(),
+														e);
+				}
+			}
+		}
+	}
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindingListenerAnnotationBeanPostProcessor.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindingListenerAnnotationBeanPostProcessor.java
@@ -22,7 +22,7 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.beans.factory.config.BeanPostProcessor;
-import org.springframework.cloud.stream.annotation.BindingListener;
+import org.springframework.cloud.stream.annotation.StreamListener;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -75,15 +75,15 @@ public class BindingListenerAnnotationBeanPostProcessor implements BeanPostProce
 
 			@Override
 			public void doWith(final Method method) throws IllegalArgumentException, IllegalAccessException {
-				BindingListener bindingListener = AnnotationUtils.findAnnotation(method, BindingListener.class);
-				if (bindingListener != null) {
-					Assert.hasText(bindingListener.value(), "The binding name cannot be null");
+				StreamListener streamListener = AnnotationUtils.findAnnotation(method, StreamListener.class);
+				if (streamListener != null) {
+					Assert.hasText(streamListener.value(), "The binding name cannot be null");
 					final InvocableHandlerMethod invocableHandlerMethod = messageHandlerMethodFactory.createInvocableHandlerMethod(bean, method);
-					if (!StringUtils.hasText(bindingListener.value())) {
+					if (!StringUtils.hasText(streamListener.value())) {
 						throw new BeanInitializationException("Only one of 'bindings' or 'value' can be specified");
 					}
-					SubscribableChannel channel = applicationContext.getBean(bindingListener.value(),
-							SubscribableChannel.class);
+					SubscribableChannel channel = applicationContext.getBean(streamListener.value(),
+																			 SubscribableChannel.class);
 					final String defaultOutputChannel = extractDefaultOutput(method);
 					if (invocableHandlerMethod.isVoid()) {
 						Assert.isTrue(StringUtils.isEmpty(defaultOutputChannel), "An output channel cannot be specified for a method that " +

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/MessageConverterConfigurer.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/MessageConverterConfigurer.java
@@ -39,17 +39,14 @@ import org.springframework.util.MimeType;
 import org.springframework.util.StringUtils;
 
 /**
-<<<<<<< HEAD
+
  * A {@link MessageChannelConfigurer} that sets data types and message converters based on {@link
- * BindingProperties#contentType}
- * {@link BindingProperties}. This also adds a {@link org.springframework.messaging.support.ChannelInterceptor} to
+ * BindingProperties#contentType}. Also adds a {@link org.springframework.messaging.support.ChannelInterceptor} to
  * the message channel to set the `ContentType` header for the message (if not already set) based on the `ContentType`
- * binding
- * property of the channel.
-=======
- * A {@link MessageChannelConfigurer} that sets the datatype and message converters for the message channel.
->>>>>>> Introduce BinderListener annotation
+ * binding property of the channel.
+ @
  * @author Ilayaperumal Gopinathan
+ * @author Marius Bogoevici
  */
 public class MessageConverterConfigurer implements MessageChannelConfigurer, BeanFactoryAware, InitializingBean {
 
@@ -91,14 +88,13 @@ public class MessageConverterConfigurer implements MessageChannelConfigurer, Bea
 		AbstractMessageChannel messageChannel = (AbstractMessageChannel) channel;
 		BindingProperties bindingProperties = this.channelBindingServiceProperties.getBindingProperties(channelName);
 		final String contentType = bindingProperties.getContentType();
-		if (bindingProperties != null && StringUtils.hasText(contentType)) {
+		if (StringUtils.hasText(contentType)) {
 			MimeType mimeType = MessageConverterUtils.getMimeType(contentType);
 			SmartMessageConverter messageConverter = this.compositeMessageConverterFactory.getMessageConverterForType(mimeType);
 			Class<?>[] supportedDataTypes = this.compositeMessageConverterFactory.supportedDataTypes(mimeType);
 			messageChannel.setDatatypes(supportedDataTypes);
 			messageChannel.setMessageConverter(new MessageWrappingMessageConverter(messageConverter, mimeType));
 			messageChannel.addInterceptor(new ChannelInterceptorAdapter() {
-
 				@Override
 				public Message<?> preSend(Message<?> message, MessageChannel messageChannel) {
 					Object contentTypeFromMessage = message.getHeaders().get(MessageHeaders.CONTENT_TYPE);

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/MessageConverterConfigurer.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/MessageConverterConfigurer.java
@@ -15,10 +15,8 @@
  */
 package org.springframework.cloud.stream.binding;
 
-import java.util.Collection;
+
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
@@ -27,57 +25,49 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.cloud.stream.config.BindingProperties;
 import org.springframework.cloud.stream.config.ChannelBindingServiceProperties;
-import org.springframework.cloud.stream.converter.AbstractFromMessageConverter;
-import org.springframework.cloud.stream.converter.ByteArrayToStringMessageConverter;
 import org.springframework.cloud.stream.converter.CompositeMessageConverterFactory;
-import org.springframework.cloud.stream.converter.JavaToSerializedMessageConverter;
-import org.springframework.cloud.stream.converter.JsonToPojoMessageConverter;
-import org.springframework.cloud.stream.converter.JsonToTupleMessageConverter;
 import org.springframework.cloud.stream.converter.MessageConverterUtils;
-import org.springframework.cloud.stream.converter.PojoToJsonMessageConverter;
-import org.springframework.cloud.stream.converter.PojoToStringMessageConverter;
-import org.springframework.cloud.stream.converter.SerializedToJavaMessageConverter;
-import org.springframework.cloud.stream.converter.StringToByteArrayMessageConverter;
-import org.springframework.cloud.stream.converter.TupleToJsonMessageConverter;
 import org.springframework.integration.channel.AbstractMessageChannel;
 import org.springframework.integration.support.MessageBuilderFactory;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHeaders;
-import org.springframework.messaging.converter.MessageConverter;
+import org.springframework.messaging.converter.SmartMessageConverter;
 import org.springframework.messaging.support.ChannelInterceptorAdapter;
 import org.springframework.util.Assert;
-import org.springframework.util.CollectionUtils;
 import org.springframework.util.MimeType;
 import org.springframework.util.StringUtils;
 
 /**
+<<<<<<< HEAD
  * A {@link MessageChannelConfigurer} that sets data types and message converters based on {@link
  * BindingProperties#contentType}
  * {@link BindingProperties}. This also adds a {@link org.springframework.messaging.support.ChannelInterceptor} to
  * the message channel to set the `ContentType` header for the message (if not already set) based on the `ContentType`
  * binding
  * property of the channel.
+=======
+ * A {@link MessageChannelConfigurer} that sets the datatype and message converters for the message channel.
+>>>>>>> Introduce BinderListener annotation
  * @author Ilayaperumal Gopinathan
  */
 public class MessageConverterConfigurer implements MessageChannelConfigurer, BeanFactoryAware, InitializingBean {
 
+	private final MessageBuilderFactory messageBuilderFactory;
+
 	private ConfigurableListableBeanFactory beanFactory;
 
-	private CompositeMessageConverterFactory messageConverterFactory;
+	private final CompositeMessageConverterFactory compositeMessageConverterFactory;
 
 	private final ChannelBindingServiceProperties channelBindingServiceProperties;
 
-	private final Collection<AbstractFromMessageConverter> customMessageConverters;
-
-	private final MessageBuilderFactory messageBuilderFactory;
-
 	public MessageConverterConfigurer(ChannelBindingServiceProperties channelBindingServiceProperties,
-									  Collection<AbstractFromMessageConverter> customMessageConverters,
-									  MessageBuilderFactory messageBuilderFactory) {
-		this.channelBindingServiceProperties = channelBindingServiceProperties;
-		this.customMessageConverters = customMessageConverters;
+									  MessageBuilderFactory messageBuilderFactory,
+									  CompositeMessageConverterFactory compositeMessageConverterFactory) {
+		Assert.notNull(compositeMessageConverterFactory, "The message converter factory cannot be null");
 		this.messageBuilderFactory = messageBuilderFactory;
+		this.channelBindingServiceProperties = channelBindingServiceProperties;
+		this.compositeMessageConverterFactory = compositeMessageConverterFactory;
 	}
 
 	@Override
@@ -88,20 +78,6 @@ public class MessageConverterConfigurer implements MessageChannelConfigurer, Bea
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		Assert.notNull(this.beanFactory, "Bean factory cannot be empty");
-		Set<AbstractFromMessageConverter> messageConverters = new HashSet<>();
-		if (!CollectionUtils.isEmpty(customMessageConverters)) {
-			messageConverters.addAll(Collections.unmodifiableCollection(customMessageConverters));
-		}
-		messageConverters.add(new JsonToTupleMessageConverter());
-		messageConverters.add(new TupleToJsonMessageConverter());
-		messageConverters.add(new JsonToPojoMessageConverter());
-		messageConverters.add(new PojoToJsonMessageConverter());
-		messageConverters.add(new ByteArrayToStringMessageConverter());
-		messageConverters.add(new StringToByteArrayMessageConverter());
-		messageConverters.add(new PojoToStringMessageConverter());
-		messageConverters.add(new JavaToSerializedMessageConverter());
-		messageConverters.add(new SerializedToJavaMessageConverter());
-		this.messageConverterFactory = new CompositeMessageConverterFactory(messageConverters);
 	}
 
 	/**
@@ -117,10 +93,10 @@ public class MessageConverterConfigurer implements MessageChannelConfigurer, Bea
 		final String contentType = bindingProperties.getContentType();
 		if (bindingProperties != null && StringUtils.hasText(contentType)) {
 			MimeType mimeType = MessageConverterUtils.getMimeType(contentType);
-			MessageConverter messageConverter = this.messageConverterFactory.newInstance(mimeType);
-			Class<?>[] supportedDataTypes = this.messageConverterFactory.supportedDataTypes(mimeType);
+			SmartMessageConverter messageConverter = this.compositeMessageConverterFactory.getMessageConverterForType(mimeType);
+			Class<?>[] supportedDataTypes = this.compositeMessageConverterFactory.supportedDataTypes(mimeType);
 			messageChannel.setDatatypes(supportedDataTypes);
-			messageChannel.setMessageConverter(messageConverter);
+			messageChannel.setMessageConverter(new MessageWrappingMessageConverter(messageConverter, mimeType));
 			messageChannel.addInterceptor(new ChannelInterceptorAdapter() {
 
 				@Override
@@ -135,6 +111,71 @@ public class MessageConverterConfigurer implements MessageChannelConfigurer, Bea
 					return message;
 				}
 			});
+		}
+	}
+
+	/**
+	 * A {@link SmartMessageConverter} that delegates to another {@link SmartMessageConverter} for conversion.
+	 *
+	 * Will wrap the returning result of the conversion into a {@link Message} if it is not a {@link Message}
+	 * instance already.
+	 */
+	class MessageWrappingMessageConverter implements SmartMessageConverter {
+
+		private final MimeType contentType;
+
+		private final SmartMessageConverter delegate;
+
+		public MessageWrappingMessageConverter(SmartMessageConverter delegate, MimeType contentType) {
+			Assert.notNull(delegate, "Delegate converter cannot be null");
+			Assert.notNull(contentType, "Content type cannot be null");
+			this.delegate = delegate;
+			this.contentType = contentType;
+		}
+
+		@Override
+		public Object fromMessage(Message<?> message, Class<?> targetClass) {
+			Object converted = delegate.fromMessage(message, targetClass);
+			if (converted instanceof Message) {
+				return converted;
+			}
+			else {
+				return build(converted, message.getHeaders());
+			}
+		}
+
+		@Override
+		public Object fromMessage(Message<?> message, Class<?> targetClass, Object conversionHint) {
+			Object converted = delegate.fromMessage(message, targetClass, conversionHint);
+			if (converted == null || converted instanceof Message) {
+				return converted;
+			}
+			else {
+				return build(converted, message.getHeaders());
+			}
+		}
+
+		@Override
+		public Message<?> toMessage(Object payload, MessageHeaders headers) {
+			return delegate.toMessage(payload, headers);
+		}
+
+		@Override
+		public Message<?> toMessage(Object payload, MessageHeaders headers, Object conversionHint) {
+			return delegate.toMessage(payload, headers, conversionHint);
+		}
+
+		/**
+		 * Convenience method to construct a converted message
+		 * @param payload the converted payload
+		 * @param headers the existing message headers
+		 * @return the converted message
+		 */
+		protected final Object build(Object payload, MessageHeaders headers) {
+			MimeType messageContentType = MessageConverterUtils.X_JAVA_OBJECT.equals(contentType) ?
+					MessageConverterUtils.javaObjectMimeType(payload.getClass()) : contentType;
+			return messageBuilderFactory.withPayload(payload).copyHeaders(headers)
+						   .copyHeaders(Collections.singletonMap(MessageHeaders.CONTENT_TYPE, messageContentType.toString())).build();
 		}
 	}
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceConfiguration.java
@@ -35,7 +35,7 @@ import org.springframework.cloud.stream.binder.BinderFactory;
 import org.springframework.cloud.stream.binding.BindableChannelFactory;
 import org.springframework.cloud.stream.binding.BinderAwareChannelResolver;
 import org.springframework.cloud.stream.binding.BinderAwareRouterBeanPostProcessor;
-import org.springframework.cloud.stream.binding.BindingListenerAnnotationBeanPostProcessor;
+import org.springframework.cloud.stream.binding.StreamListenerAnnotationBeanPostProcessor;
 import org.springframework.cloud.stream.binding.ChannelBindingService;
 import org.springframework.cloud.stream.binding.CompositeMessageChannelConfigurer;
 import org.springframework.cloud.stream.binding.ContextStartAfterRefreshListener;
@@ -238,11 +238,10 @@ public class ChannelBindingServiceConfiguration {
 	}
 
 	@Bean
-	public static BindingListenerAnnotationBeanPostProcessor bindToAnnotationBeanPostProcessor(@Lazy BinderAwareChannelResolver binderAwareChannelResolver, @Lazy CompositeMessageConverterFactory compositeMessageConverterFactory) {
+	public static StreamListenerAnnotationBeanPostProcessor bindToAnnotationBeanPostProcessor(@Lazy BinderAwareChannelResolver binderAwareChannelResolver, @Lazy CompositeMessageConverterFactory compositeMessageConverterFactory) {
 		DefaultMessageHandlerMethodFactory messageHandlerMethodFactory = new DefaultMessageHandlerMethodFactory();
 		messageHandlerMethodFactory.setMessageConverter(compositeMessageConverterFactory.getMessageConverterForAllRegistered());
 		messageHandlerMethodFactory.afterPropertiesSet();
-		BindingListenerAnnotationBeanPostProcessor bindingListenerAnnotationBeanPostProcessor = new BindingListenerAnnotationBeanPostProcessor(binderAwareChannelResolver, messageHandlerMethodFactory);
-		return bindingListenerAnnotationBeanPostProcessor;
+		return new StreamListenerAnnotationBeanPostProcessor(binderAwareChannelResolver, messageHandlerMethodFactory);
 	}
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/AbstractFromMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/AbstractFromMessageConverter.java
@@ -40,6 +40,7 @@ import org.springframework.util.MimeType;
  *
  * @author David Turanski
  * @author Ilayaperumal Gopinathan
+ * @author Marius Bogoevici
  */
 public abstract class AbstractFromMessageConverter extends AbstractMessageConverter {
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/AbstractFromMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/AbstractFromMessageConverter.java
@@ -24,7 +24,6 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.converter.AbstractMessageConverter;
@@ -63,8 +62,7 @@ public abstract class AbstractFromMessageConverter extends AbstractMessageConver
 
 	/**
 	 * Creates a converter that handles one or more content-type message headers
-	 *
-	 * @param supportedSourceMimeTypes list of {@link MimeType} that may present in content-type header
+	 *  @param supportedSourceMimeTypes list of {@link MimeType} that may present in content-type header
 	 * @param targetMimeType the required target type
 	 */
 	protected AbstractFromMessageConverter(Collection<MimeType> supportedSourceMimeTypes, MimeType targetMimeType) {
@@ -75,21 +73,19 @@ public abstract class AbstractFromMessageConverter extends AbstractMessageConver
 
 	/**
 	 * Creates a converter that handles one or more content-type message headers and one or more target MIME types
-	 *
-	 * @param supportedSourceMimeTypes a list of supported content types
+	 *  @param supportedSourceMimeTypes a list of supported content types
 	 * @param targetMimeTypes a list of supported target types
 	 */
 	protected AbstractFromMessageConverter(Collection<MimeType> supportedSourceMimeTypes,
-			Collection<MimeType> targetMimeTypes) {
+										   Collection<MimeType> targetMimeTypes) {
 		super(supportedSourceMimeTypes);
 		Assert.notNull(targetMimeTypes, "'targetMimeTypes' cannot be null");
-		this.targetMimeTypes = new ArrayList<MimeType>(targetMimeTypes);
+		this.targetMimeTypes = new ArrayList<>(targetMimeTypes);
 	}
 
 	/**
 	 * Creates a converter that requires a specific content-type message header
-	 *
-	 * @param supportedSourceMimeType {@link MimeType} that must be present in content-type header
+	 *  @param supportedSourceMimeType {@link MimeType} that must be present in content-type header
 	 * @param targetMimeType the required target type
 	 */
 	protected AbstractFromMessageConverter(MimeType supportedSourceMimeType, MimeType targetMimeType) {
@@ -98,8 +94,7 @@ public abstract class AbstractFromMessageConverter extends AbstractMessageConver
 
 	/**
 	 * Creates a converter that requires a specific content-type message header and supports multiple target MIME types.
-	 *
-	 * @param supportedSourceMimeType {@link MimeType} that must be present in content-type header
+	 *  @param supportedSourceMimeType {@link MimeType} that must be present in content-type header
 	 * @param targetMimeTypes a list of supported target types
 	 */
 	protected AbstractFromMessageConverter(MimeType supportedSourceMimeType, Collection<MimeType> targetMimeTypes) {
@@ -148,8 +143,7 @@ public abstract class AbstractFromMessageConverter extends AbstractMessageConver
 
 	public boolean supportsTargetMimeType(MimeType mimeType) {
 		for (MimeType targetMimeType : targetMimeTypes) {
-			if (mimeType.getType().equals(targetMimeType.getType()) && mimeType.getSubtype().equals(
-					targetMimeType.getSubtype())) {
+			if (targetMimeType.includes(mimeType)) {
 				return true;
 			}
 		}
@@ -172,18 +166,4 @@ public abstract class AbstractFromMessageConverter extends AbstractMessageConver
 		throw new UnsupportedOperationException("'convertTo' not supported");
 	}
 
-	/**
-	 * Convenience method to construct a converted message
-	 *
-	 * @param payload the converted payload
-	 * @param headers the existing message headers
-	 * @param contentType the value of the content-type header
-	 * @return the converted message
-	 */
-	protected final Message<?> buildConvertedMessage(Object payload, MessageHeaders headers, MimeType contentType) {
-		return MessageBuilder.withPayload(payload).copyHeaders(headers)
-				.copyHeaders(
-						Collections.singletonMap(MessageHeaders.CONTENT_TYPE,
-								contentType)).build();
-	}
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/ByteArrayToStringMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/ByteArrayToStringMessageConverter.java
@@ -81,6 +81,5 @@ public class ByteArrayToStringMessageConverter extends AbstractFromMessageConver
 			}
 		}
 		return converted;
-
 	}
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/JavaToSerializedMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/JavaToSerializedMessageConverter.java
@@ -55,9 +55,7 @@ public class JavaToSerializedMessageConverter extends AbstractFromMessageConvert
 			logger.error(e.getMessage(), e);
 			return null;
 		}
-
-		return buildConvertedMessage(bos.toByteArray(), message.getHeaders(),
-				MessageConverterUtils.X_JAVA_SERIALIZED_OBJECT);
+		return bos.toByteArray();
 	}
 
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/JsonToPojoMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/JsonToPojoMessageConverter.java
@@ -16,12 +16,11 @@
 
 package org.springframework.cloud.stream.converter;
 
-import org.springframework.messaging.Message;
-import org.springframework.util.MimeTypeUtils;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
+import org.springframework.messaging.Message;
+import org.springframework.util.MimeTypeUtils;
 
 /**
  *
@@ -63,7 +62,6 @@ public class JsonToPojoMessageConverter extends AbstractFromMessageConverter {
 			logger.error(e.getMessage(), e);
 			return null;
 		}
-		return buildConvertedMessage(result, message.getHeaders(),
-				MessageConverterUtils.javaObjectMimeType(targetClass));
+		return result;
 	}
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/JsonToTupleMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/JsonToTupleMessageConverter.java
@@ -64,7 +64,6 @@ public class JsonToTupleMessageConverter extends AbstractFromMessageConverter {
 		else {
 			source = (String) message.getPayload();
 		}
-		Tuple t = TupleBuilder.fromString(source);
-		return buildConvertedMessage(t, message.getHeaders(), MessageConverterUtils.javaObjectMimeType(t.getClass()));
+		return TupleBuilder.fromString(source);
 	}
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/PojoToJsonMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/PojoToJsonMessageConverter.java
@@ -16,13 +16,13 @@
 
 package org.springframework.cloud.stream.converter;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.messaging.Message;
-import org.springframework.util.MimeTypeUtils;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.messaging.Message;
+import org.springframework.util.MimeTypeUtils;
 
 
 /**
@@ -74,6 +74,6 @@ public class PojoToJsonMessageConverter extends AbstractFromMessageConverter {
 			logger.error(e.getMessage(), e);
 			return null;
 		}
-		return buildConvertedMessage(result, message.getHeaders(), MimeTypeUtils.APPLICATION_JSON);
+		return result;
 	}
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/PojoToStringMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/PojoToStringMessageConverter.java
@@ -55,7 +55,7 @@ public class PojoToStringMessageConverter extends AbstractFromMessageConverter {
 		else {
 			payloadString = message.getPayload().toString();
 		}
-		return buildConvertedMessage(payloadString, message.getHeaders(), MimeTypeUtils.TEXT_PLAIN);
+		return payloadString;
 	}
 
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/SerializedToJavaMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/SerializedToJavaMessageConverter.java
@@ -57,7 +57,6 @@ public class SerializedToJavaMessageConverter extends AbstractFromMessageConvert
 			return null;
 		}
 
-		return buildConvertedMessage(result, message.getHeaders(),
-				MessageConverterUtils.javaObjectMimeType(targetClass));
+		return result;
 	}
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/TupleToJsonMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/TupleToJsonMessageConverter.java
@@ -18,13 +18,13 @@ package org.springframework.cloud.stream.converter;
 
 import java.io.IOException;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.messaging.Message;
 import org.springframework.tuple.Tuple;
 import org.springframework.util.MimeTypeUtils;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 
 
 /**
@@ -75,7 +75,7 @@ public class TupleToJsonMessageConverter extends AbstractFromMessageConverter {
 		else {
 			json = t.toString();
 		}
-		return buildConvertedMessage(json, message.getHeaders(), MimeTypeUtils.APPLICATION_JSON);
+		return json;
 	}
 
 }

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/BinderAwareChannelResolverTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/BinderAwareChannelResolverTests.java
@@ -50,6 +50,7 @@ import org.springframework.cloud.stream.binding.DynamicDestinationsBindable;
 import org.springframework.cloud.stream.binding.MessageConverterConfigurer;
 import org.springframework.cloud.stream.config.BindingProperties;
 import org.springframework.cloud.stream.config.ChannelBindingServiceProperties;
+import org.springframework.cloud.stream.converter.CompositeMessageConverterFactory;
 import org.springframework.context.support.StaticApplicationContext;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
@@ -96,7 +97,7 @@ public class BinderAwareChannelResolverTests {
 		bindings.put("foo", bindingProperties);
 		this.channelBindingServiceProperties.setBindings(bindings);
 		MessageConverterConfigurer messageConverterConfigurer = new MessageConverterConfigurer(
-																									  this.channelBindingServiceProperties, null, new DefaultMessageBuilderFactory());
+																									  this.channelBindingServiceProperties, new DefaultMessageBuilderFactory(), new CompositeMessageConverterFactory());
 		messageConverterConfigurer.setBeanFactory(Mockito.mock(ConfigurableListableBeanFactory.class));
 		messageConverterConfigurer.afterPropertiesSet();
 		this.bindableChannelFactory = new DefaultBindableChannelFactory(messageConverterConfigurer);

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binding/ChannelBindingServiceTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binding/ChannelBindingServiceTests.java
@@ -56,6 +56,7 @@ import org.springframework.cloud.stream.binder.DefaultBinderFactory;
 import org.springframework.cloud.stream.binder.ProducerProperties;
 import org.springframework.cloud.stream.config.BindingProperties;
 import org.springframework.cloud.stream.config.ChannelBindingServiceProperties;
+import org.springframework.cloud.stream.converter.CompositeMessageConverterFactory;
 import org.springframework.cloud.stream.utils.MockBinderConfiguration;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
@@ -202,7 +203,7 @@ public class ChannelBindingServiceTests {
 		when(binder.bindProducer(
 				matches("bar"), any(DirectChannel.class), any(ProducerProperties.class))).thenReturn(mockBinding);
 		BinderAwareChannelResolver resolver = new BinderAwareChannelResolver(binderFactory, properties, dynamicDestinationsBindable,
-																			 new DefaultBindableChannelFactory(new MessageConverterConfigurer(properties, null, new DefaultMessageBuilderFactory())));
+																			 new DefaultBindableChannelFactory(new MessageConverterConfigurer(properties, new DefaultMessageBuilderFactory(), new CompositeMessageConverterFactory())));
 		ConfigurableListableBeanFactory beanFactory = mock(ConfigurableListableBeanFactory.class);
 		when(beanFactory.getBean("mock:bar", MessageChannel.class))
 				.thenThrow(new NoSuchBeanDefinitionException(MessageChannel.class));


### PR DESCRIPTION
Fixes #156

- Supports Spring Messaging infrastructure for argument mapping and type conversion, sharing the same configured converters as the ones configured on input/output channels;

- Also: refactored AbstractFromMessageConverter to return only payload - conversion to a message enriched with the content type of the channel is done by a separate wrapping converter;