### PR TITLE
Elliminate duplicate configuration options for Rabbit MQ

### DIFF
--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitBinderConfigurationProperties.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitBinderConfigurationProperties.java
@@ -43,14 +43,6 @@ class RabbitBinderConfigurationProperties {
 
 	private int compressionLevel;
 
-	public String[] getAddresses() {
-		return addresses;
-	}
-
-	public void setAddresses(String[] addresses) {
-		this.addresses = addresses;
-	}
-
 	public String[] getAdminAdresses() {
 		return adminAdresses;
 	}
@@ -65,46 +57,6 @@ class RabbitBinderConfigurationProperties {
 
 	public void setNodes(String[] nodes) {
 		this.nodes = nodes;
-	}
-
-	public String getUsername() {
-		return username;
-	}
-
-	public void setUsername(String username) {
-		this.username = username;
-	}
-
-	public String getPassword() {
-		return password;
-	}
-
-	public void setPassword(String password) {
-		this.password = password;
-	}
-
-	public String getVhost() {
-		return vhost;
-	}
-
-	public void setVhost(String vhost) {
-		this.vhost = vhost;
-	}
-
-	public boolean isUseSSL() {
-		return useSSL;
-	}
-
-	public void setUseSSL(boolean useSSL) {
-		this.useSSL = useSSL;
-	}
-
-	public Resource getSslPropertiesLocation() {
-		return sslPropertiesLocation;
-	}
-
-	public void setSslPropertiesLocation(Resource sslPropertiesLocation) {
-		this.sslPropertiesLocation = sslPropertiesLocation;
 	}
 
 	public int getCompressionLevel() {

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitMessageChannelBinderConfiguration.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitMessageChannelBinderConfiguration.java
@@ -22,6 +22,7 @@ import org.springframework.amqp.support.postprocessor.DelegatingDecompressingPos
 import org.springframework.amqp.support.postprocessor.GZipPostProcessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.autoconfigure.amqp.RabbitProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.binder.rabbit.RabbitExtendedBindingProperties;
 import org.springframework.cloud.stream.binder.rabbit.RabbitMessageChannelBinder;
@@ -50,6 +51,9 @@ public class RabbitMessageChannelBinderConfiguration {
 	private ConnectionFactory rabbitConnectionFactory;
 
 	@Autowired
+	private RabbitProperties rabbitProperties;
+
+	@Autowired
 	private RabbitBinderConfigurationProperties rabbitBinderConfigurationProperties;
 
 	@Autowired
@@ -57,18 +61,12 @@ public class RabbitMessageChannelBinderConfiguration {
 
 	@Bean
 	RabbitMessageChannelBinder rabbitMessageChannelBinder() {
-		RabbitMessageChannelBinder binder = new RabbitMessageChannelBinder(rabbitConnectionFactory);
+		RabbitMessageChannelBinder binder = new RabbitMessageChannelBinder(rabbitConnectionFactory, rabbitProperties);
 		binder.setCodec(codec);
-		binder.setAddresses(rabbitBinderConfigurationProperties.getAddresses());
 		binder.setAdminAddresses(rabbitBinderConfigurationProperties.getAdminAdresses());
 		binder.setCompressingPostProcessor(gZipPostProcessor());
 		binder.setDecompressingPostProcessor(deCompressingPostProcessor());
 		binder.setNodes(rabbitBinderConfigurationProperties.getNodes());
-		binder.setPassword(rabbitBinderConfigurationProperties.getPassword());
-		binder.setSslPropertiesLocation(rabbitBinderConfigurationProperties.getSslPropertiesLocation());
-		binder.setUsername(rabbitBinderConfigurationProperties.getUsername());
-		binder.setUseSSL(rabbitBinderConfigurationProperties.isUseSSL());
-		binder.setVhost(rabbitBinderConfigurationProperties.getVhost());
 		binder.setExtendedBindingProperties(rabbitExtendedBindingProperties);
 		return binder;
 	}

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/LocalizedQueueConnectionFactoryIntegrationTests.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/LocalizedQueueConnectionFactoryIntegrationTests.java
@@ -54,7 +54,7 @@ public class LocalizedQueueConnectionFactoryIntegrationTests {
 		String username = "guest";
 		String password = "guest";
 		this.lqcf = new LocalizedQueueConnectionFactory(defaultConnectionFactory, addresses,
-				adminAddresses, nodes, vhost, username, password, false, null);
+				adminAddresses, nodes, vhost, username, password, false, null, null, null, null);
 	}
 
 	@Test

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderTests.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderTests.java
@@ -54,6 +54,7 @@ import org.springframework.amqp.support.AmqpHeaders;
 import org.springframework.amqp.support.postprocessor.DelegatingDecompressingPostProcessor;
 import org.springframework.amqp.utils.test.TestUtils;
 import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.boot.autoconfigure.amqp.RabbitProperties;
 import org.springframework.cloud.stream.binder.Binding;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
@@ -93,7 +94,7 @@ public class RabbitBinderTests extends PartitionCapableBinderTests<RabbitTestBin
 	@Override
 	protected RabbitTestBinder getBinder() {
 		if (testBinder == null) {
-			testBinder = new RabbitTestBinder(rabbitAvailableRule.getResource());
+			testBinder = new RabbitTestBinder(rabbitAvailableRule.getResource(), new RabbitProperties());
 		}
 		return testBinder;
 	}
@@ -632,7 +633,7 @@ public class RabbitBinderTests extends PartitionCapableBinderTests<RabbitTestBin
 	public void testLateBinding() throws Exception {
 		RabbitTestSupport.RabbitProxy proxy = new RabbitTestSupport.RabbitProxy();
 		CachingConnectionFactory cf = new CachingConnectionFactory("localhost", proxy.getPort());
-		RabbitMessageChannelBinder rabbitBinder = new RabbitMessageChannelBinder(cf);
+		RabbitMessageChannelBinder rabbitBinder = new RabbitMessageChannelBinder(cf, new RabbitProperties());
 		RabbitTestBinder binder = new RabbitTestBinder(cf, rabbitBinder);
 
 		ExtendedProducerProperties<RabbitProducerProperties> properties = createProducerProperties();

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitTestBinder.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitTestBinder.java
@@ -21,6 +21,7 @@ import java.util.Set;
 
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.boot.autoconfigure.amqp.RabbitProperties;
 import org.springframework.cloud.stream.binder.AbstractTestBinder;
 import org.springframework.cloud.stream.binder.Binding;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
@@ -49,8 +50,8 @@ public class RabbitTestBinder extends AbstractTestBinder<RabbitMessageChannelBin
 
 	private final Set<String> exchanges = new HashSet<String>();
 
-	public RabbitTestBinder(ConnectionFactory connectionFactory) {
-		this(connectionFactory, new RabbitMessageChannelBinder(connectionFactory));
+	public RabbitTestBinder(ConnectionFactory connectionFactory, RabbitProperties rabbitProperties) {
+		this(connectionFactory, new RabbitMessageChannelBinder(connectionFactory, rabbitProperties));
 	}
 
 	public RabbitTestBinder(ConnectionFactory connectionFactory, RabbitMessageChannelBinder binder) {

--- a/spring-cloud-stream-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
+++ b/spring-cloud-stream-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
@@ -584,26 +584,15 @@ implementations.
 
 ==== Rabbit MQ Binder properties
 
-The binder supports the all Spring Boot properties for Rabbit MQ configuration.
+By default, the binder uses the Spring Boot `ConnectionFactory` and therefore it supports all the Spring Boot configuration options for Rabbit MQ.
+For reference, consult the [Spring Boot documentation](http://docs.spring.io/spring-boot/docs/1.3.3.RELEASE/reference/htmlsingle/#common-application-properties). Rabbit MQ configuration options use the `spring.rabbitmq` prefix.
 
 In addition to that, it also supports the following properties:
 
-spring.cloud.stream.rabbit.binder.addresses::
-  A comma-separated list of RabbitMQ server addresses (used only for clustering and in conjunction with `nodes`). Default empty.
 spring.cloud.stream.rabbit.binder.adminAddresses. Default empty.
-  A comma-separated list of RabbitMQ management plugin URLs - only used when nodes contains more than one entry. Entries in this list must correspond to the corresponding entry in addresses. Default empty.
+  A comma-separated list of RabbitMQ management plugin URLs - only used when nodes contains more than one entry. Each entry in this list must have a corresponding entry in `spring.rabbitmq.addresses`. Empty by default.
 spring.cloud.stream.rabbit.binder.nodes::
-  A comma-separated list of RabbitMQ node names; when more than one entry, used to locate the server address where a queue is located. Entries in this list must correspond to the corresponding entry in addresses. Default empty.
-spring.cloud.stream.rabbit.rabbit.username::
-  The user name. Default `null`.
-spring.cloud.stream.rabbit.binder.password::
-  The password. Default `null`.
-spring.cloud.stream.rabbit.binder.vhost::
-  The virtual host. Default `null`.
-spring.cloud.stream.rabbit.binder.useSSL::
-  True if Rabbit MQ should use SSL.
-spring.cloud.stream.rabbit.binder.sslPropertiesLocation::
-  The location of the SSL properties file, when certificate exchange is used.
+  A comma-separated list of RabbitMQ node names; when more than one entry, used to locate the server address where a queue is located. Each entry in this list must have a corresponding entry in `spring.rabbitmq.addresses`. Empty by default.
 spring.cloud.stream.rabbit.binder.compressionLevel::
   Compression level for compressed bindings. Defaults to `1` (BEST_LEVEL). See `java.util.zip.Deflater`.
 


### PR DESCRIPTION
Fixes #447

Some binder configuration properties duplicate options already found in Spring Boot.