### PR TITLE
Enabled namespace propagation in AggregateApplication*

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplicationBuilder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplicationBuilder.java
@@ -33,6 +33,7 @@ import org.springframework.util.StringUtils;
  * @author Dave Syer
  * @author Ilayaperumal Gopinathan
  * @author Marius Bogoevici
+ * @author Venil Noronha
  */
 public class AggregateApplicationBuilder {
 
@@ -116,15 +117,20 @@ public class AggregateApplicationBuilder {
 			apps.add(sinkConfigurer);
 		}
 		List<Class<?>> appsToEmbed = new ArrayList<>();
+		String namespace = null;
 		for (int i = 0; i < apps.size(); i++) {
-			appsToEmbed.add(apps.get(i).getApp());
+			AppConfigurer<?> appConfigurer = apps.get(i);
+			appsToEmbed.add(appConfigurer.getApp());
+			if (namespace == null) {
+				namespace = appConfigurer.namespace;
+			}
 		}
 		AggregateApplication.prepareSharedChannelRegistry(sharedChannelRegistry,
-				appsToEmbed.toArray(new Class<?>[0]));
+				appsToEmbed.toArray(new Class<?>[0]), namespace);
 		for (int i = apps.size() - 1; i >= 0; i--) {
 			AppConfigurer<?> appConfigurer = apps.get(i);
 			appConfigurer.namespace(AggregateApplication
-					.getNamespace(appConfigurer.getApp().getName(), i));
+					.getNamespace(namespace, appConfigurer.getApp().getName(), i));
 			appConfigurer.embed();
 		}
 		return parentContext;

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplicationBuilder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplicationBuilder.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.stream.aggregate;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 import org.springframework.boot.SpringApplication;
@@ -116,21 +117,17 @@ public class AggregateApplicationBuilder {
 		if (this.sinkConfigurer != null) {
 			apps.add(sinkConfigurer);
 		}
-		List<Class<?>> appsToEmbed = new ArrayList<>();
-		String namespace = null;
+		LinkedHashMap<Class<?>, String> appsToEmbed = new LinkedHashMap<>();
 		for (int i = 0; i < apps.size(); i++) {
 			AppConfigurer<?> appConfigurer = apps.get(i);
-			appsToEmbed.add(appConfigurer.getApp());
-			if (namespace == null) {
-				namespace = appConfigurer.namespace;
-			}
+			Class<?> appToEmbed = appConfigurer.getApp();
+			appsToEmbed.put(appToEmbed, appConfigurer.namespace);
 		}
-		AggregateApplication.prepareSharedChannelRegistry(sharedChannelRegistry,
-				appsToEmbed.toArray(new Class<?>[0]), namespace);
+		AggregateApplication.prepareSharedChannelRegistry(sharedChannelRegistry, appsToEmbed);
 		for (int i = apps.size() - 1; i >= 0; i--) {
 			AppConfigurer<?> appConfigurer = apps.get(i);
 			appConfigurer.namespace(AggregateApplication
-					.getNamespace(namespace, appConfigurer.getApp().getName(), i));
+					.getNamespace(appConfigurer.namespace, appConfigurer.getApp().getName(), i));
 			appConfigurer.embed();
 		}
 		return parentContext;


### PR DESCRIPTION
I've added conditional logic to `AggregateApplicationBuilder#getNamespace()` so that it returns the namespace if set else generates one as earlier.

Resolves spring-cloud/spring-cloud-stream#428