### PR TITLE
Insist Message channel types on input/output

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindableChannelFactory.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindableChannelFactory.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.stream.binding;
 
-import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.SubscribableChannel;
 
 /**
@@ -35,14 +34,5 @@ public interface BindableChannelFactory {
 	 * @return subscribable message channel
 	 */
 	SubscribableChannel createSubscribableChannel(String name);
-
-	/**
-	 * Create a {@link PollableChannel} that will be bound via the message channel
-	 * {@link org.springframework.cloud.stream.binder.Binder}.
-	 *
-	 * @param name name of the message channel
-	 * @return pollable message channel
-	 */
-	PollableChannel createPollableChannel(String name);
 
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/DefaultBindableChannelFactory.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/DefaultBindableChannelFactory.java
@@ -16,8 +16,6 @@
 package org.springframework.cloud.stream.binding;
 
 import org.springframework.integration.channel.DirectChannel;
-import org.springframework.integration.channel.QueueChannel;
-import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.SubscribableChannel;
 
 /**
@@ -33,13 +31,6 @@ public class DefaultBindableChannelFactory implements BindableChannelFactory {
 
 	public DefaultBindableChannelFactory(MessageChannelConfigurer messageChannelConfigurer) {
 		this.messageChannelConfigurer = messageChannelConfigurer;
-	}
-
-	@Override
-	public PollableChannel createPollableChannel(String name) {
-		PollableChannel pollableChannel = new QueueChannel();
-		messageChannelConfigurer.configureMessageChannel(pollableChannel, name);
-		return pollableChannel;
 	}
 
 	@Override


### PR DESCRIPTION
- Add necessary assertions on the type of message channels for input/output
  - Make sure to support message channel of type `MessageChannel` for input
  - support message channel of type `SubscribableChannel` for output and if the type is exactly equal to `MessageChannel` type then create subscribable channel
 - Remove references of creating PollableChannel for binding

This resolves #469