### PR TITLE
Reinstate checkstyle running by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,6 @@
 	</scm>
 	<properties>
 		<java.version>1.7</java.version>
-		<disable.checks>true</disable.checks>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -51,9 +50,6 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-checkstyle-plugin</artifactId>
 					<version>2.17</version>
-					<configuration>
-						<configLocation>src/checkstyle/checkstyle.xml</configLocation>
-					</configuration>
 					<dependencies>
 						<dependency>
 							<groupId>com.puppycrawl.tools</groupId>
@@ -87,7 +83,6 @@
 						<id>checkstyle-validation</id>
 						<phase>validate</phase>
 						<configuration>
-							<skip>${disable.checks}</skip>
 							<configLocation>src/checkstyle/checkstyle.xml</configLocation>
 							<headerLocation>src/checkstyle/checkstyle-header.txt</headerLocation>
 							<propertyExpansion>checkstyle.build.directory=${project.build.directory}</propertyExpansion>


### PR DESCRIPTION
- Rely on `checkstyle.skip` instead of a custom property
- Remove configuration from plugin definition, rely on execution only to set project-specific dependencies. This prevents inheritors from outside the project to fail on not finding the configuration. Note: on the long run, we will want to create a `build-tools` submodule that hold the configurations.


Note: when merging this, https://github.com/spring-cloud/spring-cloud-stream-modules/pull/253 must be merged as well (ideally beforehand) to prevent Spring Cloud Stream Modules to fail on the checkstyle plugin.