### PR TITLE
Prevent eager initialization of the MessageHandlerMethodFactory

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceConfiguration.java
@@ -62,6 +62,7 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.core.DestinationResolutionException;
 import org.springframework.messaging.core.DestinationResolver;
 import org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory;
+import org.springframework.messaging.handler.annotation.support.MessageHandlerMethodFactory;
 import org.springframework.tuple.spel.TuplePropertyAccessor;
 import org.springframework.util.CollectionUtils;
 
@@ -235,12 +236,17 @@ public class ChannelBindingServiceConfiguration {
 	}
 
 	@Bean
-	public static StreamListenerAnnotationBeanPostProcessor bindToAnnotationBeanPostProcessor(
-			@Lazy BinderAwareChannelResolver binderAwareChannelResolver,
-			@Lazy CompositeMessageConverterFactory compositeMessageConverterFactory) {
+	public static MessageHandlerMethodFactory messageHandlerMethodFactory(CompositeMessageConverterFactory compositeMessageConverterFactory) {
 		DefaultMessageHandlerMethodFactory messageHandlerMethodFactory = new DefaultMessageHandlerMethodFactory();
 		messageHandlerMethodFactory.setMessageConverter(compositeMessageConverterFactory.getMessageConverterForAllRegistered());
-		messageHandlerMethodFactory.afterPropertiesSet();
-		return new StreamListenerAnnotationBeanPostProcessor(binderAwareChannelResolver, messageHandlerMethodFactory);
+		return messageHandlerMethodFactory;
+	}
+
+	@Bean
+	public static StreamListenerAnnotationBeanPostProcessor bindToAnnotationBeanPostProcessor(
+			@Lazy BinderAwareChannelResolver binderAwareChannelResolver,
+			@Lazy MessageHandlerMethodFactory messageHandlerMethodFactory) {
+		return new StreamListenerAnnotationBeanPostProcessor(binderAwareChannelResolver,
+				messageHandlerMethodFactory);
 	}
 }


### PR DESCRIPTION
Fixes #494

The eager initialization of the bean triggers the eager initialization of the ObjectMapper, which causes issues with HATEOAS and Hystrix.