### PR TITLE
Native Kafka ProducerConfig (like: client.id) support has been added

### DIFF
--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -348,6 +348,9 @@ public class KafkaMessageChannelBinder extends AbstractBinder<MessageChannel, Ex
 		Properties additionalProps = new Properties();
 		additionalProps.put(ProducerConfig.ACKS_CONFIG, String.valueOf(requiredAcks));
 		additionalProps.put(ProducerConfig.LINGER_MS_CONFIG, String.valueOf(properties.getExtension().getBatchTimeout()));
+		for(Map.Entry<String, String> configEntry:properties.getExtension().getConfig().entrySet()){
+			additionalProps.put(configEntry.getKey(), configEntry.getValue());
+		}
 		ProducerFactoryBean<byte[], byte[]> producerFB = new ProducerFactoryBean<>(producerMetadata, brokers, additionalProps);
 
 		try {

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -348,9 +348,8 @@ public class KafkaMessageChannelBinder extends AbstractBinder<MessageChannel, Ex
 		Properties additionalProps = new Properties();
 		additionalProps.put(ProducerConfig.ACKS_CONFIG, String.valueOf(requiredAcks));
 		additionalProps.put(ProducerConfig.LINGER_MS_CONFIG, String.valueOf(properties.getExtension().getBatchTimeout()));
-		for(Map.Entry<String, String> configEntry:properties.getExtension().getConfig().entrySet()){
-			additionalProps.put(configEntry.getKey(), configEntry.getValue());
-		}
+		//For supporting native Kafka producer configurations
+		additionalProps.putAll(properties.getExtension().getConfig());
 		ProducerFactoryBean<byte[], byte[]> producerFB = new ProducerFactoryBean<>(producerMetadata, brokers, additionalProps);
 
 		try {

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaProducerProperties.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaProducerProperties.java
@@ -16,9 +16,11 @@
 
 package org.springframework.cloud.stream.binder.kafka;
 
-import javax.validation.constraints.NotNull;
-
 import org.springframework.integration.kafka.support.ProducerMetadata;
+
+import javax.validation.constraints.NotNull;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author Marius Bogoevici
@@ -32,6 +34,8 @@ public class KafkaProducerProperties {
 	private boolean sync = false;
 
 	private int batchTimeout = 0;
+
+	private Map<String, String> config = new HashMap<>();
 
 	public int getBufferSize() {
 		return bufferSize;
@@ -64,5 +68,13 @@ public class KafkaProducerProperties {
 
 	public void setBatchTimeout(int batchTimeout) {
 		this.batchTimeout = batchTimeout;
+	}
+
+	public Map<String, String> getConfig() {
+		return config;
+	}
+
+	public void setConfig(Map<String, String> config) {
+		this.config = config;
 	}
 }


### PR DESCRIPTION
Now key-value pairs under spring.cloud.stream.kafka.bindings.< channelName >.producer.config key are set as native Kafka producer configuration.
This is useful because this way we can configure all Kafka specific producer configuration values through application properties.