### PR TITLE
Use the binder `minPartitionCount` property for consumers

### DIFF
--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaConsumerProperties.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaConsumerProperties.java
@@ -16,29 +16,16 @@
 
 package org.springframework.cloud.stream.binder.kafka;
 
-import javax.validation.constraints.Min;
-
 /**
  * @author Marius Bogoevici
  */
 public class KafkaConsumerProperties {
-
-	private int minPartitionCount = 1;
 
 	private boolean autoCommitOffset = true;
 
 	private boolean resetOffsets = false;
 
 	private KafkaMessageChannelBinder.StartOffset startOffset = null;
-
-	public void setMinPartitionCount(int minPartitionCount) {
-		this.minPartitionCount = minPartitionCount;
-	}
-
-	@Min(value = 1, message = "Min Partition Count should be greater than zero.")
-	public int getMinPartitionCount() {
-		return minPartitionCount;
-	}
 
 	public boolean isAutoCommitOffset() {
 		return autoCommitOffset;

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -433,12 +433,11 @@ public class KafkaMessageChannelBinder extends AbstractBinder<MessageChannel, Ex
 			ExtendedConsumerProperties<KafkaConsumerProperties> properties, String group, long referencePoint) {
 
 		validateTopicName(name);
-		int minKafkaPartitions = properties.getExtension().getMinPartitionCount();
 		int instance = properties.getInstanceCount();
 		if (instance == 0) {
 			throw new IllegalArgumentException("Instance count cannot be zero");
 		}
-		int numPartitions = Math.max(minKafkaPartitions, instance * properties.getConcurrency());
+		int numPartitions = Math.max(this.defaultMinPartitionCount, instance * properties.getConcurrency());
 		Collection<Partition> allPartitions = ensureTopicCreated(name, numPartitions, replicationFactor);
 
 		Decoder<byte[]> valueDecoder = new DefaultDecoder(null);
@@ -485,7 +484,7 @@ public class KafkaMessageChannelBinder extends AbstractBinder<MessageChannel, Ex
 		messageListenerContainer.setConcurrency(concurrency);
 		final ExecutorService dispatcherTaskExecutor = Executors.newFixedThreadPool(concurrency, DAEMON_THREAD_FACTORY);
 		messageListenerContainer.setDispatcherTaskExecutor(dispatcherTaskExecutor);
-		
+
 		final KafkaMessageDrivenChannelAdapter kafkaMessageDrivenChannelAdapter =
 				new KafkaMessageDrivenChannelAdapter(messageListenerContainer);
 		kafkaMessageDrivenChannelAdapter.setBeanFactory(this.getBeanFactory());

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaBinderConfigurationProperties.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaBinderConfigurationProperties.java
@@ -25,7 +25,7 @@ import org.springframework.util.StringUtils;
  * @author Marius Bogoevici
  */
 @ConfigurationProperties(prefix = "spring.cloud.stream.kafka.binder")
-class KafkaBinderConfigurationProperties {
+public class KafkaBinderConfigurationProperties {
 
 	private String[] zkNodes = new String[] {"localhost"};
 

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
@@ -39,6 +39,7 @@ import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.PartitionCapableBinderTests;
 import org.springframework.cloud.stream.binder.Spy;
+import org.springframework.cloud.stream.binder.kafka.config.KafkaBinderConfigurationProperties;
 import org.springframework.cloud.stream.test.junit.kafka.KafkaTestSupport;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.integration.channel.DirectChannel;
@@ -77,7 +78,7 @@ public class KafkaBinderTests extends PartitionCapableBinderTests<KafkaTestBinde
 	@Override
 	protected KafkaTestBinder getBinder() {
 		if (binder == null) {
-			binder = new KafkaTestBinder(kafkaTestSupport);
+			binder = new KafkaTestBinder(kafkaTestSupport, new KafkaBinderConfigurationProperties());
 		}
 		return binder;
 	}
@@ -155,14 +156,15 @@ public class KafkaBinderTests extends PartitionCapableBinderTests<KafkaTestBinde
 
 		byte[] ratherBigPayload = new byte[2048];
 		Arrays.fill(ratherBigPayload, (byte) 65);
-		KafkaTestBinder binder = getBinder();
+		KafkaBinderConfigurationProperties binderConfiguration = new KafkaBinderConfigurationProperties();
+		binderConfiguration.setMinPartitionCount(10);
+		KafkaTestBinder binder = new KafkaTestBinder(kafkaTestSupport, binderConfiguration);
 
 		DirectChannel moduleOutputChannel = new DirectChannel();
 		QueueChannel moduleInputChannel = new QueueChannel();
 		ExtendedProducerProperties<KafkaProducerProperties> producerProperties = createProducerProperties();
 		producerProperties.setPartitionCount(10);
 		ExtendedConsumerProperties<KafkaConsumerProperties> consumerProperties = createConsumerProperties();
-		consumerProperties.getExtension().setMinPartitionCount(10);
 		long uniqueBindingId = System.currentTimeMillis();
 		Binding<MessageChannel> producerBinding = binder.bindProducer("foo" + uniqueBindingId + ".0", moduleOutputChannel, producerProperties);
 		Binding<MessageChannel> consumerBinding = binder.bindConsumer("foo" + uniqueBindingId + ".0", null, moduleInputChannel, consumerProperties);
@@ -185,7 +187,9 @@ public class KafkaBinderTests extends PartitionCapableBinderTests<KafkaTestBinde
 
 		byte[] ratherBigPayload = new byte[2048];
 		Arrays.fill(ratherBigPayload, (byte) 65);
-		KafkaTestBinder binder = getBinder();
+		KafkaBinderConfigurationProperties binderConfiguration = new KafkaBinderConfigurationProperties();
+		binderConfiguration.setMinPartitionCount(5);
+		KafkaTestBinder binder = new KafkaTestBinder(kafkaTestSupport, binderConfiguration);
 
 		DirectChannel moduleOutputChannel = new DirectChannel();
 		QueueChannel moduleInputChannel = new QueueChannel();
@@ -193,7 +197,6 @@ public class KafkaBinderTests extends PartitionCapableBinderTests<KafkaTestBinde
 		producerProperties.setPartitionCount(5);
 		producerProperties.setPartitionKeyExpression(spelExpressionParser.parseExpression("payload"));
 		ExtendedConsumerProperties<KafkaConsumerProperties> consumerProperties = createConsumerProperties();
-		consumerProperties.getExtension().setMinPartitionCount(3);
 		long uniqueBindingId = System.currentTimeMillis();
 		Binding<MessageChannel> producerBinding = binder.bindProducer("foo" + uniqueBindingId + ".0", moduleOutputChannel, producerProperties);
 		Binding<MessageChannel> consumerBinding = binder.bindConsumer("foo" + uniqueBindingId + ".0", null, moduleInputChannel, consumerProperties);
@@ -216,7 +219,9 @@ public class KafkaBinderTests extends PartitionCapableBinderTests<KafkaTestBinde
 
 		byte[] ratherBigPayload = new byte[2048];
 		Arrays.fill(ratherBigPayload, (byte) 65);
-		KafkaTestBinder binder = getBinder();
+		KafkaBinderConfigurationProperties binderConfiguration = new KafkaBinderConfigurationProperties();
+		binderConfiguration.setMinPartitionCount(5);
+		KafkaTestBinder binder = new KafkaTestBinder(kafkaTestSupport, binderConfiguration);
 
 		DirectChannel moduleOutputChannel = new DirectChannel();
 		QueueChannel moduleInputChannel = new QueueChannel();
@@ -224,7 +229,6 @@ public class KafkaBinderTests extends PartitionCapableBinderTests<KafkaTestBinde
 		producerProperties.setPartitionCount(5);
 		producerProperties.setPartitionKeyExpression(spelExpressionParser.parseExpression("payload"));
 		ExtendedConsumerProperties<KafkaConsumerProperties> consumerProperties = createConsumerProperties();
-		consumerProperties.getExtension().setMinPartitionCount(5);
 		long uniqueBindingId = System.currentTimeMillis();
 		Binding<MessageChannel> producerBinding = binder.bindProducer("foo" + uniqueBindingId + ".0", moduleOutputChannel, producerProperties);
 		Binding<MessageChannel> consumerBinding = binder.bindConsumer("foo" + uniqueBindingId + ".0", null, moduleInputChannel, consumerProperties);

--- a/spring-cloud-stream-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
+++ b/spring-cloud-stream-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
@@ -842,6 +842,10 @@ Mutually exclusive with `offsetUpdateTimeWindow`.
 Default: `0`. 
 spring.cloud.stream.kafka.binder.requiredAcks::
   The number of required acks on the broker.
+spring.cloud.stream.kafka.binder.minPartitionCount::
+  The minimum number of partitions expected by the consumer if it creates the consumed topic automatically.
++
+Default: `1`.
 
 ==== Kafka Consumer Properties
 
@@ -862,10 +866,6 @@ startOffset::
 Allowed values: `earliest`, `latest`.
 +
 Default: null (equivalent to `earliest`).
-minPartitionCount::
-  The minimum number of partitions expected by the consumer if it creates the consumed topic automatically.
-+
-Default: `1`.
 
 ==== Kafka Producer Properties
 


### PR DESCRIPTION
Fixes #495

Currently, `minPartitionCount` is available both as a binder default and as a consumer property.
It would be simpler if it only was a binder setting (seeing as it has effect only as a default).