### PR TITLE
Add a flag for controlling topic autoconfiguration by the Kafka binder

### DIFF
--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -463,7 +463,8 @@ public class KafkaMessageChannelBinder
 								if (partitions.size() < minExpectedPartitions) {
 									throw new IllegalStateException(
 											"The number of expected partitions was: " + minExpectedPartitions + ", but "
-													+ partitions.size() + " have been found instead");
+													+ partitions.size() + (partitions.size() > 1 ? " have " : " has ")
+													+ "been found instead");
 								}
 								connectionFactory.getLeaders(partitions);
 								return partitions;

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaBinderConfiguration.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaBinderConfiguration.java
@@ -89,7 +89,7 @@ public class KafkaBinderConfiguration {
 		kafkaMessageChannelBinder.setReplicationFactor(kafkaBinderConfigurationProperties.getReplicationFactor());
 		kafkaMessageChannelBinder.setRequiredAcks(kafkaBinderConfigurationProperties.getRequiredAcks());
 		kafkaMessageChannelBinder.setMaxWait(kafkaBinderConfigurationProperties.getMaxWait());
-
+		kafkaMessageChannelBinder.setAutoConfigureTopics(kafkaBinderConfigurationProperties.isAutoConfigureTopics());
 		kafkaMessageChannelBinder.setProducerListener(producerListener);
 		kafkaMessageChannelBinder.setExtendedBindingProperties(kafkaExtendedBindingProperties);
 		return kafkaMessageChannelBinder;

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaBinderConfigurationProperties.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/config/KafkaBinderConfigurationProperties.java
@@ -45,6 +45,8 @@ class KafkaBinderConfigurationProperties {
 
 	private int maxWait = 100;
 
+	private boolean autoConfigureTopics = true;
+
 	/**
 	 * ZK session timeout in milliseconds.
 	 */
@@ -204,4 +206,11 @@ class KafkaBinderConfigurationProperties {
 		this.queueSize = queueSize;
 	}
 
+	public boolean isAutoConfigureTopics() {
+		return autoConfigureTopics;
+	}
+
+	public void setAutoConfigureTopics(boolean autoConfigureTopics) {
+		this.autoConfigureTopics = autoConfigureTopics;
+	}
 }

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
@@ -16,7 +16,9 @@
 
 package org.springframework.cloud.stream.binder.kafka;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
@@ -25,16 +27,20 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Properties;
 import java.util.UUID;
 
+import kafka.admin.AdminUtils;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
 import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.cloud.stream.binder.BinderException;
 import org.springframework.cloud.stream.binder.Binding;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
@@ -45,6 +51,7 @@ import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.kafka.core.Partition;
+import org.springframework.integration.kafka.core.TopicNotFoundException;
 import org.springframework.integration.kafka.support.ProducerConfiguration;
 import org.springframework.integration.kafka.support.ProducerMetadata;
 import org.springframework.integration.kafka.support.ZookeeperConnect;
@@ -54,6 +61,9 @@ import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.retry.backoff.FixedBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
 
 
 /**
@@ -444,6 +454,88 @@ public class KafkaBinderTests extends PartitionCapableBinderTests<KafkaTestBinde
 		ProducerConfiguration producerConfiguration = (ProducerConfiguration) accessor1.getPropertyValue("producerConfiguration");
 		assertTrue("Kafka Sync Producer should have been enabled.", producerConfiguration.getProducerMetadata().isSync());
 		producerBinding.unbind();
+	}
+	
+	@Test
+	public void testAutoConfigureTopicsDisabledFailsIfTopicMissing() throws Exception {
+
+		KafkaMessageChannelBinder binder = new KafkaMessageChannelBinder(
+				new ZookeeperConnect(kafkaTestSupport.getZkConnectString()), kafkaTestSupport.getBrokerAddress(),
+				kafkaTestSupport.getZkConnectString());
+		GenericApplicationContext context = new GenericApplicationContext();
+		binder.setAutoConfigureTopics(false);
+		context.refresh();
+		binder.setApplicationContext(context);
+		binder.afterPropertiesSet();
+		RetryTemplate metatadataRetrievalRetryOperations = new RetryTemplate();
+		metatadataRetrievalRetryOperations.setRetryPolicy(new SimpleRetryPolicy());
+		FixedBackOffPolicy backOffPolicy = new FixedBackOffPolicy();
+		backOffPolicy.setBackOffPeriod(1000);
+		metatadataRetrievalRetryOperations.setBackOffPolicy(backOffPolicy);
+		binder.setMetadataRetryOperations(metatadataRetrievalRetryOperations);
+		DirectChannel output = new DirectChannel();
+		ExtendedConsumerProperties<KafkaConsumerProperties> consumerProperties = createConsumerProperties();
+		String testTopicName = "nonexisting"  + System.currentTimeMillis();
+		try {
+			binder.doBindConsumer(testTopicName, "test", output, consumerProperties);
+			fail();
+		}
+		catch (Exception e) {
+			assertTrue(e instanceof BinderException);
+			assertThat(e.getCause(), instanceOf(TopicNotFoundException.class));
+			assertThat(e.getCause().getMessage(), containsString(testTopicName));
+		}
+
+		try {
+			binder.getConnectionFactory().getPartitions(testTopicName);
+			fail();
+		}
+		catch (Exception e) {
+			assertThat(e, instanceOf(TopicNotFoundException.class));
+		}
+	}
+
+	@Test
+	public void testAutoConfigureTopicsSucceedsIfTopicExisting() throws Exception {
+
+		String testTopicName = "nonexisting"  + System.currentTimeMillis();
+		AdminUtils.createTopic(kafkaTestSupport.getZkClient(), testTopicName, 5, 1, new Properties());
+
+		KafkaMessageChannelBinder binder = new KafkaMessageChannelBinder(
+				new ZookeeperConnect(kafkaTestSupport.getZkConnectString()), kafkaTestSupport.getBrokerAddress(),
+				kafkaTestSupport.getZkConnectString());
+		GenericApplicationContext context = new GenericApplicationContext();
+		binder.setAutoConfigureTopics(false);
+		context.refresh();
+		binder.setApplicationContext(context);
+		binder.afterPropertiesSet();
+		DirectChannel output = new DirectChannel();
+		ExtendedConsumerProperties<KafkaConsumerProperties> consumerProperties = createConsumerProperties();
+		Binding<MessageChannel> binding = binder.doBindConsumer(testTopicName, "test", output, consumerProperties);
+		binding.unbind();
+	}
+
+	@Test
+	public void testAutoConfigureTopicsEnabledSucceeds() throws Exception {
+		KafkaMessageChannelBinder binder = new KafkaMessageChannelBinder(
+				new ZookeeperConnect(kafkaTestSupport.getZkConnectString()), kafkaTestSupport.getBrokerAddress(),
+				kafkaTestSupport.getZkConnectString());
+		GenericApplicationContext context = new GenericApplicationContext();
+		binder.setAutoConfigureTopics(true);
+		context.refresh();
+		binder.setApplicationContext(context);
+		binder.afterPropertiesSet();
+		RetryTemplate metatadataRetrievalRetryOperations = new RetryTemplate();
+		metatadataRetrievalRetryOperations.setRetryPolicy(new SimpleRetryPolicy());
+		FixedBackOffPolicy backOffPolicy = new FixedBackOffPolicy();
+		backOffPolicy.setBackOffPeriod(1000);
+		metatadataRetrievalRetryOperations.setBackOffPolicy(backOffPolicy);
+		binder.setMetadataRetryOperations(metatadataRetrievalRetryOperations);
+		DirectChannel output = new DirectChannel();
+		ExtendedConsumerProperties<KafkaConsumerProperties> consumerProperties = createConsumerProperties();
+		String testTopicName = "nonexisting"  + System.currentTimeMillis();
+		Binding<?> binding = binder.doBindConsumer(testTopicName, "test", output, consumerProperties);
+		binding.unbind();
 	}
 
 	private static class FailingInvocationCountingMessageHandler implements MessageHandler {

--- a/spring-cloud-stream-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
+++ b/spring-cloud-stream-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
@@ -839,6 +839,15 @@ Mutually exclusive with `offsetUpdateTimeWindow`.
 Default: `0`. 
 spring.cloud.stream.kafka.binder.requiredAcks::
   The number of required acks on the broker.
++
+Default: `1`.
+spring.cloud.stream.kafka.binder.autoConfigureTopics::
+  If set to `true`, the binder will create new topics or add new partitions to existing topics automatically to match the requirements of the producers and consumers.
+If set to `false`, the binder will rely on the topics being already configured.
+In the latter case, if the topics do not exist or the partition count is smaller than the expected partition count, the binder will fail to start.
+Of note, this setting is independent of the `auto.topic.create.enable` of the broker and it does not influence it.
++
+Default: `false`.
 
 ==== Kafka Consumer Properties
 

--- a/spring-cloud-stream-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
+++ b/spring-cloud-stream-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
@@ -845,9 +845,13 @@ spring.cloud.stream.kafka.binder.autoConfigureTopics::
   If set to `true`, the binder will create new topics or add new partitions to existing topics automatically to match the requirements of the producers and consumers.
 If set to `false`, the binder will rely on the topics being already configured.
 In the latter case, if the topics do not exist or the partition count is smaller than the expected partition count, the binder will fail to start.
-Of note, this setting is independent of the `auto.topic.create.enable` of the broker and it does not influence it.
+Of note, this setting is independent of the `auto.topic.create.enable` setting of the broker and it does not influence it: if the server is set to auto-create topics, they may be created as part of the metadata retrieval request, with default broker settings.
 +
 Default: `false`.
+spring.cloud.stream.kafka.binder.replicationFactor::
+  The replication factor of auto-created topics if `autoConfigureTopics` is active.
++
+Default: `1`.
 
 ==== Kafka Consumer Properties
 

--- a/spring-cloud-stream-test-support-internal/src/main/java/org/springframework/cloud/stream/test/junit/kafka/KafkaTestSupport.java
+++ b/spring-cloud-stream-test-support-internal/src/main/java/org/springframework/cloud/stream/test/junit/kafka/KafkaTestSupport.java
@@ -19,6 +19,13 @@ package org.springframework.cloud.stream.test.junit.kafka;
 
 import java.util.Properties;
 
+import kafka.server.KafkaConfig;
+import kafka.server.KafkaServer;
+import kafka.utils.SystemTime$;
+import kafka.utils.TestUtils;
+import kafka.utils.Utils;
+import kafka.utils.ZKStringSerializer$;
+import kafka.utils.ZkUtils;
 import org.I0Itec.zkclient.ZkClient;
 import org.I0Itec.zkclient.exception.ZkInterruptedException;
 import org.apache.commons.logging.Log;
@@ -27,14 +34,6 @@ import org.junit.Rule;
 
 import org.springframework.cloud.stream.test.junit.AbstractExternalResourceTestSupport;
 import org.springframework.util.SocketUtils;
-
-import kafka.server.KafkaConfig;
-import kafka.server.KafkaServer;
-import kafka.utils.SystemTime$;
-import kafka.utils.TestUtils;
-import kafka.utils.Utils;
-import kafka.utils.ZKStringSerializer$;
-import kafka.utils.ZkUtils;
 
 
 /**
@@ -131,6 +130,8 @@ public class KafkaTestSupport extends AbstractExternalResourceTestSupport<String
 						log.debug("Creating Kafka server");
 						Properties brokerConfigProperties = brokerConfig;
 						brokerConfig.put("zookeeper.connect", zookeeper.getConnectString());
+						brokerConfig.put("auto.create.topics.enable", "false");
+						brokerConfig.put("delete.topic.enable", "true");
 						kafkaServer = TestUtils.createServer(new KafkaConfig(brokerConfigProperties), SystemTime$.MODULE$);
 						log.debug("Created Kafka server at " + kafkaServer.config().hostName() + ":" + kafkaServer.config().port());
 					}


### PR DESCRIPTION
Fixes #504

- introduces a new binder setting `autoConfigureTopics` that allows the user to disable the automatic creation of topics by the binder