### PR TITLE
[Proposal - review only] Support registering `MessageConverter` beans directly

### DIFF
--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/CustomMessageConverterTests.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/CustomMessageConverterTests.java
@@ -86,7 +86,7 @@ public class CustomMessageConverterTests {
 		}
 
 		@Override
-		protected Class<?>[] supportedTargetTypes() {
+		public Class<?>[] supportedTargetTypes() {
 			return new Class[] {Bar.class};
 		}
 
@@ -119,7 +119,7 @@ public class CustomMessageConverterTests {
 		}
 
 		@Override
-		protected Class<?>[] supportedTargetTypes() {
+		public Class<?>[] supportedTargetTypes() {
 			return new Class[] {Foo.class};
 		}
 

--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/MessageChannelConfigurerTests.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/MessageChannelConfigurerTests.java
@@ -19,9 +19,15 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,11 +47,6 @@ import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.tuple.Tuple;
 import org.springframework.util.MimeTypeUtils;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 
 /**
  * @author Ilayaperumal Gopinathan
@@ -83,7 +84,7 @@ public class MessageChannelConfigurerTests {
 
 	@Test
 	public void testObjectMapperConfig() throws Exception {
-		CompositeMessageConverter compositeMessageConverter = messageConverterFactory.getMessageConverterForType(MimeTypeUtils.APPLICATION_JSON);
+		CompositeMessageConverter compositeMessageConverter = messageConverterFactory.getMessageConverterForTargetType(MimeTypeUtils.APPLICATION_JSON);
 		List<MessageConverter> converters = compositeMessageConverter.getConverters();
 		for (MessageConverter converter : converters) {
 			DirectFieldAccessor converterAccessor = new DirectFieldAccessor(converter);

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/MessageConverterConfigurer.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/MessageConverterConfigurer.java
@@ -88,7 +88,7 @@ public class MessageConverterConfigurer implements MessageChannelConfigurer, Bea
 		final String contentType = bindingProperties.getContentType();
 		if (StringUtils.hasText(contentType)) {
 			MimeType mimeType = MessageConverterUtils.getMimeType(contentType);
-			SmartMessageConverter messageConverter = this.compositeMessageConverterFactory.getMessageConverterForType(mimeType);
+			SmartMessageConverter messageConverter = this.compositeMessageConverterFactory.getMessageConverterForTargetType(mimeType);
 			Class<?>[] supportedDataTypes = this.compositeMessageConverterFactory.supportedDataTypes(mimeType);
 			messageChannel.setDatatypes(supportedDataTypes);
 			messageChannel.setMessageConverter(new MessageWrappingMessageConverter(messageConverter, mimeType));

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/MessageConverterConfigurer.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/MessageConverterConfigurer.java
@@ -92,6 +92,8 @@ public class MessageConverterConfigurer implements MessageChannelConfigurer, Bea
 			MimeType mimeType = MessageConverterUtils.getMimeType(contentType);
 			CompositeMessageConverter messageConverter = this.compositeMessageConverterFactory
 					.getMessageConverterForTargetType(mimeType);
+			messageChannel.setMessageConverter(messageConverter);
+			messageChannel.setDatatypes(this.compositeMessageConverterFactory.supportedDataTypes(mimeType));
 			if (CollectionUtils.isEmpty(messageConverter.getConverters())) {
 				throw new IllegalStateException(
 						"No converters registered with a target content type of '" + contentType + "'");
@@ -101,7 +103,6 @@ public class MessageConverterConfigurer implements MessageChannelConfigurer, Bea
 			messageChannel.addInterceptor(new ChannelInterceptorAdapter() {
 				@Override
 				public Message<?> preSend(Message<?> message, MessageChannel messageChannel) {
-					message = (Message<?>) wrappingMessageConverter.fromMessage(message, Object.class, null);
 					Object contentTypeFromMessage = message.getHeaders().get(MessageHeaders.CONTENT_TYPE);
 					if (contentTypeFromMessage == null) {
 						return messageBuilderFactory.fromMessage(message)

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/AbstractFromMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/AbstractFromMessageConverter.java
@@ -115,9 +115,11 @@ public abstract class AbstractFromMessageConverter extends AbstractMessageConver
 		return supportsType(clazz, supportedPayloadTypes());
 	}
 
+	protected abstract Class<?>[] supportedTargetTypes();
+
 	@Override
 	protected boolean supports(Class<?> clazz) {
-		return supportsType(clazz, supportedTargetTypes());
+		return clazz == Object.class || supportsType(clazz, supportedTargetTypes());
 	}
 
 	private boolean supportsType(Class<?> clazz, Class<?>[] supportedTypes) {

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/AbstractFromMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/AbstractFromMessageConverter.java
@@ -41,7 +41,7 @@ import org.springframework.util.MimeType;
  * @author Ilayaperumal Gopinathan
  * @author Marius Bogoevici
  */
-public abstract class AbstractFromMessageConverter extends AbstractMessageConverter {
+public abstract class AbstractFromMessageConverter extends AbstractMessageConverter implements TargetTypeMessageConverter {
 
 	protected final Log logger = LogFactory.getLog(getClass());
 
@@ -104,12 +104,6 @@ public abstract class AbstractFromMessageConverter extends AbstractMessageConver
 	protected AbstractFromMessageConverter(MimeType supportedSourceMimeType, Collection<MimeType> targetMimeTypes) {
 		this(Collections.singletonList(supportedSourceMimeType), targetMimeTypes);
 	}
-
-	/**
-	 * Subclasses implement this to specify supported target types
-	 * @return an array of supported classes or null if any target type is supported
-	 */
-	protected abstract Class<?>[] supportedTargetTypes();
 
 	/**
 	 * Subclasses implement this to specify supported payload types

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/AbstractFromMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/AbstractFromMessageConverter.java
@@ -41,7 +41,7 @@ import org.springframework.util.MimeType;
  * @author Ilayaperumal Gopinathan
  * @author Marius Bogoevici
  */
-public abstract class AbstractFromMessageConverter extends AbstractMessageConverter implements TargetTypeMessageConverter {
+public abstract class AbstractFromMessageConverter extends AbstractMessageConverter implements TargetMimeTypeMessageConverter {
 
 	protected final Log logger = LogFactory.getLog(getClass());
 
@@ -116,6 +116,16 @@ public abstract class AbstractFromMessageConverter extends AbstractMessageConver
 	}
 
 	protected abstract Class<?>[] supportedTargetTypes();
+
+	@Override
+	public Class<?>[] getSupportedJavaTypes(MimeType targetMimeType) {
+		if (supportsTargetMimeType(targetMimeType)) {
+			return supportedTargetTypes();
+		}
+		else {
+			return new Class<?>[0];
+		}
+	}
 
 	@Override
 	protected boolean supports(Class<?> clazz) {

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/ByteArrayToStringMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/ByteArrayToStringMessageConverter.java
@@ -48,7 +48,7 @@ public class ByteArrayToStringMessageConverter extends AbstractFromMessageConver
 	}
 
 	@Override
-	protected Class<?>[] supportedTargetTypes() {
+	public Class<?>[] supportedTargetTypes() {
 		return new Class<?>[] { String.class };
 	}
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/CompositeMessageConverterFactory.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/CompositeMessageConverterFactory.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.stream.converter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -29,8 +31,6 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.util.MimeType;
 import org.springframework.util.ObjectUtils;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 
 /**
  * A factory for creating an instance of {@link CompositeMessageConverter} for a given target MIME type
@@ -42,7 +42,7 @@ public class CompositeMessageConverterFactory {
 
 	private final ObjectMapper objectMapper;
 
-	private final List<AbstractFromMessageConverter> converters;
+	private final List<MessageConverter> converters;
 
 	public CompositeMessageConverterFactory() {
 		this(Collections.<AbstractFromMessageConverter>emptyList(), new ObjectMapper());
@@ -51,7 +51,7 @@ public class CompositeMessageConverterFactory {
 	/**
 	 * @param customConverters a list of {@link AbstractFromMessageConverter}
 	 */
-	public CompositeMessageConverterFactory(List<? extends AbstractFromMessageConverter> customConverters,
+	public CompositeMessageConverterFactory(List<? extends MessageConverter> customConverters,
 			ObjectMapper objectMapper) {
 		this.objectMapper = objectMapper;
 		if (!CollectionUtils.isEmpty(customConverters)) {
@@ -81,11 +81,14 @@ public class CompositeMessageConverterFactory {
 	 * @param targetMimeType the target MIME type
 	 * @return a converter for the target MIME type
 	 */
-	public CompositeMessageConverter getMessageConverterForType(MimeType targetMimeType) {
+	public CompositeMessageConverter getMessageConverterForTargetType(MimeType targetMimeType) {
 		List<MessageConverter> targetMimeTypeConverters = new ArrayList<MessageConverter>();
-		for (AbstractFromMessageConverter converter : converters) {
-			if (converter.supportsTargetMimeType(targetMimeType)) {
-				targetMimeTypeConverters.add(converter);
+		for (MessageConverter converter : converters) {
+			if (converter instanceof TargetTypeMessageConverter) {
+				TargetTypeMessageConverter targetTypeMessageConverter = (TargetTypeMessageConverter) converter;
+				if (targetTypeMessageConverter.supportsTargetMimeType(targetMimeType)) {
+					targetMimeTypeConverters.add(converter);
+				}
 			}
 		}
 		if (CollectionUtils.isEmpty(targetMimeTypeConverters)) {
@@ -106,11 +109,14 @@ public class CompositeMessageConverterFactory {
 			supportedDataTypes.add(MessageConverterUtils.getJavaTypeForJavaObjectContentType(targetMimeType));
 		}
 		else {
-			for (AbstractFromMessageConverter converter : converters) {
-				if (converter.supportsTargetMimeType(targetMimeType)) {
-					Class<?>[] targetTypes = converter.supportedTargetTypes();
-					if (!ObjectUtils.isEmpty(targetTypes)) {
-						supportedDataTypes.addAll(Arrays.asList(targetTypes));
+			for (MessageConverter converter : converters) {
+				if (converter instanceof TargetTypeMessageConverter) {
+					TargetTypeMessageConverter targetTypeMessageConverter = (TargetTypeMessageConverter) converter;
+					if (targetTypeMessageConverter.supportsTargetMimeType(targetMimeType)) {
+						Class<?>[] targetTypes = targetTypeMessageConverter.supportedTargetTypes();
+						if (!ObjectUtils.isEmpty(targetTypes)) {
+							supportedDataTypes.addAll(Arrays.asList(targetTypes));
+						}
 					}
 				}
 			}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/CompositeMessageConverterFactory.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/CompositeMessageConverterFactory.java
@@ -19,17 +19,13 @@ package org.springframework.cloud.stream.converter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.springframework.messaging.converter.CompositeMessageConverter;
 import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.MimeType;
-import org.springframework.util.ObjectUtils;
 
 
 /**
@@ -99,28 +95,6 @@ public class CompositeMessageConverterFactory {
 	}
 
 	public CompositeMessageConverter getMessageConverterForAllRegistered() {
-		return new CompositeMessageConverter(new ArrayList<MessageConverter>(converters));
-	}
-
-	public Class<?>[] supportedDataTypes(MimeType targetMimeType) {
-		Set<Class<?>> supportedDataTypes = new HashSet<>();
-		// Make sure to check if the target type is of explicit java object type.
-		if (MessageConverterUtils.X_JAVA_OBJECT.includes(targetMimeType)) {
-			supportedDataTypes.add(MessageConverterUtils.getJavaTypeForJavaObjectContentType(targetMimeType));
-		}
-		else {
-			for (MessageConverter converter : converters) {
-				if (converter instanceof TargetTypeMessageConverter) {
-					TargetTypeMessageConverter targetTypeMessageConverter = (TargetTypeMessageConverter) converter;
-					if (targetTypeMessageConverter.supportsTargetMimeType(targetMimeType)) {
-						Class<?>[] targetTypes = targetTypeMessageConverter.supportedTargetTypes();
-						if (!ObjectUtils.isEmpty(targetTypes)) {
-							supportedDataTypes.addAll(Arrays.asList(targetTypes));
-						}
-					}
-				}
-			}
-		}
-		return supportedDataTypes.toArray(new Class<?>[supportedDataTypes.size()]);
+		return new CompositeMessageConverter(new ArrayList<>(converters));
 	}
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/JavaToSerializedMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/JavaToSerializedMessageConverter.java
@@ -36,7 +36,7 @@ public class JavaToSerializedMessageConverter extends AbstractFromMessageConvert
 	}
 
 	@Override
-	protected Class<?>[] supportedTargetTypes() {
+	public Class<?>[] supportedTargetTypes() {
 		return new Class<?>[] { byte[].class };
 	}
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/JsonToPojoMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/JsonToPojoMessageConverter.java
@@ -16,10 +16,10 @@
 
 package org.springframework.cloud.stream.converter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.springframework.messaging.Message;
 import org.springframework.util.MimeTypeUtils;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  *
@@ -36,12 +36,12 @@ public class JsonToPojoMessageConverter extends AbstractFromMessageConverter {
 	}
 
 	@Override
-	protected Class<?>[] supportedPayloadTypes() {
+	public Class<?>[] supportedPayloadTypes() {
 		return new Class<?>[] {String.class, byte[].class};
 	}
 
 	@Override
-	protected Class<?>[] supportedTargetTypes() {
+	public Class<?>[] supportedTargetTypes() {
 		return null; // any type
 	}
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/JsonToTupleMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/JsonToTupleMessageConverter.java
@@ -46,7 +46,7 @@ public class JsonToTupleMessageConverter extends AbstractFromMessageConverter {
 	}
 
 	@Override
-	protected Class<?>[] supportedTargetTypes() {
+	public Class<?>[] supportedTargetTypes() {
 		return new Class<?>[] { Tuple.class };
 	}
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/PojoToJsonMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/PojoToJsonMessageConverter.java
@@ -16,12 +16,12 @@
 
 package org.springframework.cloud.stream.converter;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.messaging.Message;
 import org.springframework.util.MimeTypeUtils;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 
 /**
@@ -45,7 +45,7 @@ public class PojoToJsonMessageConverter extends AbstractFromMessageConverter {
 	}
 
 	@Override
-	protected Class<?>[] supportedTargetTypes() {
+	public Class<?>[] supportedTargetTypes() {
 		return new Class<?>[] {String.class};
 	}
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/PojoToStringMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/PojoToStringMessageConverter.java
@@ -35,7 +35,7 @@ public class PojoToStringMessageConverter extends AbstractFromMessageConverter {
 	}
 
 	@Override
-	protected Class<?>[] supportedTargetTypes() {
+	public Class<?>[] supportedTargetTypes() {
 		return new Class<?>[] { String.class };
 	}
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/SerializedToJavaMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/SerializedToJavaMessageConverter.java
@@ -36,7 +36,7 @@ public class SerializedToJavaMessageConverter extends AbstractFromMessageConvert
 	}
 
 	@Override
-	protected Class<?>[] supportedTargetTypes() {
+	public Class<?>[] supportedTargetTypes() {
 		return new Class<?>[] { Serializable.class };
 	}
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/StringToByteArrayMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/StringToByteArrayMessageConverter.java
@@ -45,7 +45,7 @@ public class StringToByteArrayMessageConverter extends AbstractFromMessageConver
 	}
 
 	@Override
-	protected Class<?>[] supportedTargetTypes() {
+	public Class<?>[] supportedTargetTypes() {
 		return new Class<?>[] { byte[].class };
 	}
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/TargetMimeTypeMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/TargetMimeTypeMessageConverter.java
@@ -19,13 +19,18 @@ package org.springframework.cloud.stream.converter;
 import org.springframework.util.MimeType;
 
 /**
- * A {@link org.springframework.messaging.converter.MessageConverter} that supports a
- * target {@link MimeType}/{@link Class} combination.
+ * A {@link org.springframework.messaging.converter.MessageConverter} that support
  *
  * @author Marius Bogoevici
  */
-public interface TargetTypeMessageConverter {
+public interface TargetMimeTypeMessageConverter {
 
-	boolean supportsTargetMimeType(MimeType targetMimeType);
+	/**
+	 * If the converter supports a
+	 *
+	 * @param targetMimeType the target mime type to convert to
+	 * @return
+	 */
+	Class<?>[] getSupportedJavaTypes(MimeType targetMimeType);
 
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/TargetTypeMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/TargetTypeMessageConverter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.converter;
+
+import org.springframework.util.MimeType;
+
+/**
+ * A {@link org.springframework.messaging.converter.MessageConverter} that supports a
+ * target {@link MimeType}/{@link Class} combination.
+ *
+ * @author Marius Bogoevici
+ */
+public interface TargetTypeMessageConverter {
+
+	boolean supportsTargetMimeType(MimeType targetMimeType);
+
+	Class<?>[] supportedTargetTypes();
+
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/TargetTypeMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/TargetTypeMessageConverter.java
@@ -28,6 +28,4 @@ public interface TargetTypeMessageConverter {
 
 	boolean supportsTargetMimeType(MimeType targetMimeType);
 
-	Class<?>[] supportedTargetTypes();
-
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/TupleToJsonMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/TupleToJsonMessageConverter.java
@@ -16,14 +16,14 @@
 
 package org.springframework.cloud.stream.converter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.io.IOException;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.messaging.Message;
 import org.springframework.tuple.Tuple;
 import org.springframework.util.MimeTypeUtils;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 
 /**
@@ -50,7 +50,7 @@ public class TupleToJsonMessageConverter extends AbstractFromMessageConverter {
 	}
 
 	@Override
-	protected Class<?>[] supportedTargetTypes() {
+	public Class<?>[] supportedTargetTypes() {
 		return new Class<?>[] { String.class };
 	}
 

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/BinderAwareChannelResolverTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/BinderAwareChannelResolverTests.java
@@ -66,7 +66,6 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.SubscribableChannel;
-import org.springframework.util.Assert;
 
 /**
  * @author Mark Fisher
@@ -197,9 +196,6 @@ public class BinderAwareChannelResolverTests {
 		resolver.setBeanFactory(beanFactory);
 		SubscribableChannel resolved = (SubscribableChannel) resolver.resolveDestination("foo");
 		DirectFieldAccessor accessor = new DirectFieldAccessor(resolved);
-		Class<?>[] dataTypes = (Class<?>[]) accessor.getPropertyValue("datatypes");
-		Assert.isTrue(dataTypes.length == 1, "Data type must be set for the Foo Channel");
-		Assert.isTrue(dataTypes[0].equals(String.class), "Data type should be of type String");
 		verify(binder).bindProducer(eq("foo"), any(MessageChannel.class), any(ProducerProperties.class));
 		assertSame(resolved, beanFactory.getBean("foo"));
 	}


### PR DESCRIPTION
Fixes #505

- introduces the `TargetTypeMessageConverter` extension to `MessageConverter`
   for converters that advertise target MimeTypes and/or target classes
- beans of the type `TargetTypeMessageConverter` are used to register bound channel converters

Note: if accepted, will add documentation