### PR TITLE
Make Starting context autostart optional

### DIFF
--- a/spring-cloud-stream-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
+++ b/spring-cloud-stream-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
@@ -814,6 +814,12 @@ spring.cloud.stream.defaultBinder::
   The default binder to use, if multiple binders are configured.
 See <<multiple-binders,Multiple Binders on the Classpath>>.
 
+spring.cloud.stream.autoStartContext::
+  Auto start the main application context during the application startup. This is useful when the context is
+  started based on some criteria.
++
+Default: `true`.
+
 [[binding-properties]]
 === Binding Properties
 

--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/ChannelBindingServiceTests.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/ChannelBindingServiceTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.stream.config;
+
+import java.util.concurrent.CountDownLatch;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.cloud.stream.annotation.Bindings;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.messaging.Sink;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.event.ContextStartedEvent;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.util.Assert;
+
+/**
+ * @author Ilayaperumal Gopinathan
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration({ChannelBindingServiceTests.TestSink.class})
+public class ChannelBindingServiceTests {
+
+	@Autowired @Bindings(TestSink.class)
+	private Sink testSink;
+
+	@Autowired
+	private ConfigurableApplicationContext applicationContext;
+
+	public static final CountDownLatch latch = new CountDownLatch(1);
+
+	@Test
+	public void testApplicationContextStartup() throws Exception {
+		Assert.isTrue(latch.getCount() == 1, "Application context shouldn't be started.");
+	}
+
+	@EnableBinding(Sink.class)
+	@EnableAutoConfiguration
+	@PropertySource("classpath:/org/springframework/cloud/stream/config/channel/test-sink-channel-configurers.properties")
+	public static class TestSink {
+
+		@Autowired
+		private ConfigurableApplicationContext applicationContext;
+
+		@Bean
+		public ContextRefreshedEventListener contextRefreshedEventListener(ConfigurableApplicationContext applicationContext) {
+			return new ContextRefreshedEventListener(applicationContext);
+		}
+	}
+
+	public static class ContextRefreshedEventListener implements ApplicationListener<ContextStartedEvent> {
+
+		private ConfigurableApplicationContext applicationContext;
+
+		public ContextRefreshedEventListener(ConfigurableApplicationContext applicationContext) {
+			this.applicationContext = applicationContext;
+		}
+
+		@Override
+		public void onApplicationEvent(ContextStartedEvent event) {
+			ConfigurableApplicationContext source = (ConfigurableApplicationContext) event.getSource();
+			if (source == this.applicationContext) {
+				latch.countDown();
+			}
+		}
+	}
+}

--- a/spring-cloud-stream-integration-tests/src/test/resources/org/springframework/cloud/stream/config/channel/test-sink-channel-configurers.properties
+++ b/spring-cloud-stream-integration-tests/src/test/resources/org/springframework/cloud/stream/config/channel/test-sink-channel-configurers.properties
@@ -1,0 +1,2 @@
+spring.cloud.stream.bindings.input.destination=test
+spring.cloud.stream.autoStartContext=false

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/InputBindingLifecycle.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/InputBindingLifecycle.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.stream.binding;
 import java.util.Map;
 
 import org.springframework.beans.BeansException;
-import org.springframework.cloud.stream.config.ChannelBindingServiceProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -46,12 +45,10 @@ public class InputBindingLifecycle implements SmartLifecycle, ApplicationContext
 	@Override
 	public void start() {
 		if (!running) {
-			ChannelBindingServiceProperties channelBindingServiceProperties = null;
 			// retrieve the ChannelBindingService lazily, avoiding early initialization
 			try {
 				ChannelBindingService channelBindingService = this.applicationContext
 						.getBean(ChannelBindingService.class);
-				channelBindingServiceProperties = channelBindingService.getChannelBindingServiceProperties();
 				Map<String, Bindable> bindables = this.applicationContext.getBeansOfType(Bindable.class);
 				for (Bindable bindable : bindables.values()) {
 					bindable.bindInputs(channelBindingService);
@@ -61,9 +58,7 @@ public class InputBindingLifecycle implements SmartLifecycle, ApplicationContext
 				throw new IllegalStateException(
 						"Cannot perform binding, no proper implementation found", e);
 			}
-			if (channelBindingServiceProperties != null && channelBindingServiceProperties.isAutoStartup()) {
-				this.running = true;
-			}
+			this.running = true;
 		}
 	}
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/OutputBindingLifecycle.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/OutputBindingLifecycle.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.stream.binding;
 import java.util.Map;
 
 import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.stream.config.ChannelBindingServiceProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -38,6 +39,9 @@ public class OutputBindingLifecycle implements SmartLifecycle, ApplicationContex
 
 	private ConfigurableApplicationContext applicationContext;
 
+	@Autowired
+	private ChannelBindingServiceProperties channelBindingServiceProperties;
+
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext)
 			throws BeansException {
@@ -47,12 +51,10 @@ public class OutputBindingLifecycle implements SmartLifecycle, ApplicationContex
 	@Override
 	public void start() {
 		if (!running) {
-			ChannelBindingServiceProperties channelBindingServiceProperties = null;
 			// retrieve the ChannelBindingService lazily, avoiding early initialization
 			try {
 				ChannelBindingService channelBindingService = this.applicationContext
 						.getBean(ChannelBindingService.class);
-				channelBindingServiceProperties = channelBindingService.getChannelBindingServiceProperties();
 				Map<String, Bindable> bindables = this.applicationContext.getBeansOfType(Bindable.class);
 				for (Bindable bindable : bindables.values()) {
 					bindable.bindOutputs(channelBindingService);
@@ -62,8 +64,8 @@ public class OutputBindingLifecycle implements SmartLifecycle, ApplicationContex
 				throw new IllegalStateException(
 						"Cannot perform binding, no proper implementation found", e);
 			}
-			if (channelBindingServiceProperties != null && channelBindingServiceProperties.isAutoStartup()) {
-				this.running = true;
+			this.running = true;
+			if (channelBindingServiceProperties != null && channelBindingServiceProperties.isAutoStartContext()) {
 				this.applicationContext.start();
 			}
 		}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceProperties.java
@@ -69,7 +69,7 @@ public class ChannelBindingServiceProperties implements ApplicationContextAware,
 
 	private boolean ignoreUnknownProperties = true;
 
-	private boolean autoStartup = true;
+	private boolean autoStartContext = true;
 
 	private ConfigurableApplicationContext applicationContext;
 
@@ -145,12 +145,12 @@ public class ChannelBindingServiceProperties implements ApplicationContextAware,
 		this.ignoreUnknownProperties = ignoreUnknownProperties;
 	}
 
-	public boolean isAutoStartup() {
-		return this.autoStartup;
+	public boolean isAutoStartContext() {
+		return this.autoStartContext;
 	}
 
-	public void setAutoStartup(boolean autoStartup) {
-		this.autoStartup = autoStartup;
+	public void setAutoStartContext(boolean autoStartContext) {
+		this.autoStartContext = autoStartContext;
 	}
 
 	@Override

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingServiceProperties.java
@@ -69,6 +69,8 @@ public class ChannelBindingServiceProperties implements ApplicationContextAware,
 
 	private boolean ignoreUnknownProperties = true;
 
+	private boolean autoStartup = true;
+
 	private ConfigurableApplicationContext applicationContext;
 
 	public Map<String, BindingProperties> getBindings() {
@@ -141,6 +143,14 @@ public class ChannelBindingServiceProperties implements ApplicationContextAware,
 
 	public void setIgnoreUnknownProperties(boolean ignoreUnknownProperties) {
 		this.ignoreUnknownProperties = ignoreUnknownProperties;
+	}
+
+	public boolean isAutoStartup() {
+		return this.autoStartup;
+	}
+
+	public void setAutoStartup(boolean autoStartup) {
+		this.autoStartup = autoStartup;
 	}
 
 	@Override


### PR DESCRIPTION
- Disable autostarting the main application context if the property `spring.cloud.stream.autoStart` is set to false
 - By default the main application context is autoStarted

This addresses #525