### PR TITLE
GH-542 Add setting for `autoCommitOnError`

### DIFF
--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaConsumerProperties.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaConsumerProperties.java
@@ -23,6 +23,8 @@ public class KafkaConsumerProperties {
 
 	private boolean autoCommitOffset = true;
 
+	private Boolean autoCommitOnError;
+
 	private boolean resetOffsets;
 
 	private KafkaMessageChannelBinder.StartOffset startOffset;
@@ -59,5 +61,13 @@ public class KafkaConsumerProperties {
 
 	public void setEnableDlq(boolean enableDlq) {
 		this.enableDlq = enableDlq;
+	}
+
+	public Boolean getAutoCommitOnError() {
+		return autoCommitOnError;
+	}
+
+	public void setAutoCommitOnError(Boolean autoCommitOnError) {
+		this.autoCommitOnError = autoCommitOnError;
 	}
 }

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -480,6 +480,10 @@ public class KafkaMessageChannelBinder extends
 		messageListenerContainer.setOffsetManager(offsetManager);
 		messageListenerContainer.setQueueSize(configurationProperties.getQueueSize());
 		messageListenerContainer.setMaxFetch(configurationProperties.getFetchSize());
+		boolean autoCommitOnError = properties.getExtension().getAutoCommitOnError() != null
+				? properties.getExtension().getAutoCommitOnError()
+				: properties.getExtension().isAutoCommitOffset() && properties.getExtension().isEnableDlq();
+		messageListenerContainer.setAutoCommitOnError(autoCommitOnError);
 
 		int concurrency = Math.min(properties.getConcurrency(), listenedPartitions.size());
 		messageListenerContainer.setConcurrency(concurrency);

--- a/spring-cloud-stream-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
+++ b/spring-cloud-stream-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
@@ -1136,6 +1136,13 @@ autoCommitOffset::
 If set to `false`, an `Acknowledgment` header will be available in the message headers for late acknowledgment.
 +
 Default: `true`.
+autoCommitOnError::
+  Effective only if `autoCommitOffset` is set to `true`.
+If set to `false` it suppresses auto-commits for messages that result in errors, and will commit only for successful messages, allows a stream to automatically replay from the last successfully processed message, in case of persistent failures.
+If set to `true`, it will always auto-commit (if auto-commit is enabled).
+If not set (default), it effectively has the same value `enableDlq`, auto-committing erroneous messages if they are sent to a DLQ, and not committing them otherwise.
++
+Default: not set.
 resetOffsets::
   Whether to reset offsets on the consumer to the value provided by `startOffset`.
 +


### PR DESCRIPTION
(Only merge after #549 as it relies on the cleanup done there, or merge only this PR with both changes)

Add setting for `autoCommitOnError`
Fixes #542

- add option for `autoCommitOnError`
- make `autoCommitOnError` follow the state of `enableDlq` - no need to suppress commits if messages will be sent elsewhere