### PR TITLE
Allow for binder configurations that do not affect the defaulting process

### DIFF
--- a/spring-cloud-stream-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
+++ b/spring-cloud-stream-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
@@ -729,6 +729,9 @@ If your application should connect to more than one broker of the same type, you
 ====
 Turning on explicit binder configuration will disable the default binder configuration process altogether.
 If you do this, all binders in use must be included in the configuration.
+Frameworks that intend to use Spring Cloud Stream transparently may create binder configurations that will be referenceable by name, but will not affect the default binder configuration.
+In order to do so, a binder configuration may have its the `applicationProvided` flag set to false, e.g. `spring.cloud.stream.binders.<configurationName>.applicationProvided=false`.
+This denotes a configuration that will exist independently of the default binder configuration process.
 ====
 
 For example, this is the typical configuration for a processor application which connects to two RabbitMQ broker instances:
@@ -759,6 +762,32 @@ spring:
               rabbitmq:
                 host: <host2>
 ----
+
+=== Binder configuration properties
+
+The following properties are available when creating custom binder configurations.
+They must be prefixed with `spring.cloud.stream.binder.<configurationName>`.
+
+type::
+  The binder type.
+It typically references one of the binders found on the classpath, in particular a key in a `META-INF/spring.binders` file.
++
+By default, it has the same value as the configuration name.
+inheritEnvironment::
+  Whether the configuration will inherit the environment of the application itself.
++
+Default `true`.
+environment::
+  Root for a set of properties that can be used to customize the environment of the binder.
+When this is configured, the context in which the binder is being created is not a child of the application context.
+This allows for complete separation between the binder components and the application components.
++
+Default `empty`.
+applicationProvided::
+  Whether the binder configuration is provided by the application (the default case) or a framework included by an application.
+This allows framework authors to depend on Spring Cloud Stream and provide their own infrastructure without interfering with the application.
++
+Default `true`.
 
 
 === Implementation strategies

--- a/spring-cloud-stream-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
+++ b/spring-cloud-stream-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
@@ -729,8 +729,8 @@ If your application should connect to more than one broker of the same type, you
 ====
 Turning on explicit binder configuration will disable the default binder configuration process altogether.
 If you do this, all binders in use must be included in the configuration.
-Frameworks that intend to use Spring Cloud Stream transparently may create binder configurations that will be referenceable by name, but will not affect the default binder configuration.
-In order to do so, a binder configuration may have its the `applicationProvided` flag set to false, e.g. `spring.cloud.stream.binders.<configurationName>.applicationProvided=false`.
+Frameworks that intend to use Spring Cloud Stream transparently may create binder configurations that can be referenced by name, but will not affect the default binder configuration.
+In order to do so, a binder configuration may have its the `defaultCandidate` flag set to false, e.g. `spring.cloud.stream.binders.<configurationName>.defaultCandidate=false`.
 This denotes a configuration that will exist independently of the default binder configuration process.
 ====
 
@@ -783,9 +783,9 @@ When this is configured, the context in which the binder is being created is not
 This allows for complete separation between the binder components and the application components.
 +
 Default `empty`.
-applicationProvided::
-  Whether the binder configuration is provided by the application (the default case) or a framework included by an application.
-This allows framework authors to depend on Spring Cloud Stream and provide their own infrastructure without interfering with the application.
+defaultCandidate::
+  Whether the binder configuration is a candidate for being considered a default binder, or can be used only when explicitly referenced.
+This allows adding binder configurations without interfering with the default processing.
 +
 Default `true`.
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderConfiguration.java
@@ -34,15 +34,21 @@ public class BinderConfiguration {
 
 	private final boolean inheritEnvironment;
 
+	private final boolean applicationProvided;
+
 	/**
 	 * @param binderType the binder type used by this configuration
 	 * @param properties the properties for setting up the binder
-	 * @param inheritEnvironment whether the binder should inherit the environment of the module
+	 * @param inheritEnvironment whether the binder should inherit the environment of the
+	 * module
+	 * @param applicationProvided whether the binder is user defined
 	 */
-	public BinderConfiguration(BinderType binderType, Properties properties, boolean inheritEnvironment) {
+	public BinderConfiguration(BinderType binderType, Properties properties, boolean inheritEnvironment,
+			boolean applicationProvided) {
 		this.binderType = binderType;
 		this.properties = properties;
 		this.inheritEnvironment = inheritEnvironment;
+		this.applicationProvided = applicationProvided;
 	}
 
 	public BinderType getBinderType() {
@@ -55,5 +61,9 @@ public class BinderConfiguration {
 
 	public boolean isInheritEnvironment() {
 		return inheritEnvironment;
+	}
+
+	public boolean isApplicationProvided() {
+		return applicationProvided;
 	}
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderConfiguration.java
@@ -34,21 +34,21 @@ public class BinderConfiguration {
 
 	private final boolean inheritEnvironment;
 
-	private final boolean applicationProvided;
+	private final boolean defaultCandidate;
 
 	/**
 	 * @param binderType the binder type used by this configuration
 	 * @param properties the properties for setting up the binder
 	 * @param inheritEnvironment whether the binder should inherit the environment of the
 	 * module
-	 * @param applicationProvided whether the binder is user defined
+	 * @param defaultCandidate whether the binder is user defined
 	 */
 	public BinderConfiguration(BinderType binderType, Properties properties, boolean inheritEnvironment,
-			boolean applicationProvided) {
+			boolean defaultCandidate) {
 		this.binderType = binderType;
 		this.properties = properties;
 		this.inheritEnvironment = inheritEnvironment;
-		this.applicationProvided = applicationProvided;
+		this.defaultCandidate = defaultCandidate;
 	}
 
 	public BinderType getBinderType() {
@@ -63,7 +63,7 @@ public class BinderConfiguration {
 		return inheritEnvironment;
 	}
 
-	public boolean isApplicationProvided() {
-		return applicationProvided;
+	public boolean isDefaultCandidate() {
+		return defaultCandidate;
 	}
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
@@ -98,23 +98,23 @@ public class DefaultBinderFactory<T> implements BinderFactory<T>, DisposableBean
 						"A default binder has been requested, but there there is no binder available");
 			}
 			else if (!StringUtils.hasText(defaultBinder)) {
-				Set<String> applicationProvidedConfigurations = new HashSet<>();
+				Set<String> defaultCandidateConfigurations = new HashSet<>();
 				for (Map.Entry<String, BinderConfiguration> binderConfigurationEntry : binderConfigurations
 						.entrySet()) {
-					if (binderConfigurationEntry.getValue().isApplicationProvided()) {
-						applicationProvidedConfigurations.add(binderConfigurationEntry.getKey());
+					if (binderConfigurationEntry.getValue().isDefaultCandidate()) {
+						defaultCandidateConfigurations.add(binderConfigurationEntry.getKey());
 					}
 				}
-				if (applicationProvidedConfigurations.size() == 1) {
-					this.defaultBinder = applicationProvidedConfigurations.iterator().next();
+				if (defaultCandidateConfigurations.size() == 1) {
+					this.defaultBinder = defaultCandidateConfigurations.iterator().next();
 					configurationName = this.defaultBinder;
 				}
 				else {
-					if (applicationProvidedConfigurations.size() > 1) {
+					if (defaultCandidateConfigurations.size() > 1) {
 						throw new IllegalStateException(
 								"A default binder has been requested, but there is more than one binder available: "
 										+ StringUtils
-												.collectionToCommaDelimitedString(applicationProvidedConfigurations)
+												.collectionToCommaDelimitedString(defaultCandidateConfigurations)
 										+ ", and" + " no default binder has been set.");
 					}
 					else {

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BinderFactoryConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BinderFactoryConfiguration.java
@@ -56,10 +56,10 @@ public class BinderFactoryConfiguration {
 			ChannelBindingServiceProperties channelBindingServiceProperties) {
 		Map<String, BinderConfiguration> binderConfigurations = new HashMap<>();
 		Map<String, BinderProperties> declaredBinders = channelBindingServiceProperties.getBinders();
-		boolean hasUserDefinedBinders = false;
+		boolean defaultCandidatesExist = false;
 		Iterator<Map.Entry<String, BinderProperties>> binderPropertiesIterator = declaredBinders.entrySet().iterator();
-		while (!hasUserDefinedBinders && binderPropertiesIterator.hasNext()) {
-			hasUserDefinedBinders = binderPropertiesIterator.next().getValue().isApplicationProvided();
+		while (!defaultCandidatesExist && binderPropertiesIterator.hasNext()) {
+			defaultCandidatesExist = binderPropertiesIterator.next().getValue().isDefaultCandidate();
 		}
 		for (Map.Entry<String, BinderProperties> binderEntry : declaredBinders.entrySet()) {
 			BinderProperties binderProperties = binderEntry.getValue();
@@ -67,7 +67,7 @@ public class BinderFactoryConfiguration {
 				binderConfigurations.put(binderEntry.getKey(),
 						new BinderConfiguration(binderTypeRegistry.get(binderEntry.getKey()),
 								binderProperties.getEnvironment(), binderProperties.isInheritEnvironment(),
-								binderProperties.isApplicationProvided()));
+								binderProperties.isDefaultCandidate()));
 			}
 			else {
 				Assert.hasText(binderProperties.getType(),
@@ -76,10 +76,10 @@ public class BinderFactoryConfiguration {
 				Assert.notNull(binderType, "Binder type " + binderProperties.getType() + " is not defined");
 				binderConfigurations.put(binderEntry.getKey(),
 						new BinderConfiguration(binderType, binderProperties.getEnvironment(),
-								binderProperties.isInheritEnvironment(), binderProperties.isApplicationProvided()));
+								binderProperties.isInheritEnvironment(), binderProperties.isDefaultCandidate()));
 			}
 		}
-		if (!hasUserDefinedBinders) {
+		if (!defaultCandidatesExist) {
 			for (Map.Entry<String, BinderType> entry : binderTypeRegistry.getAll().entrySet()) {
 				binderConfigurations.put(entry.getKey(),
 						new BinderConfiguration(entry.getValue(), new Properties(), true, true));

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BinderProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BinderProperties.java
@@ -31,7 +31,7 @@ public class BinderProperties {
 
 	private boolean inheritEnvironment = true;
 
-	private boolean applicationProvided = true;
+	private boolean defaultCandidate = true;
 
 	public String getType() {
 		return type;
@@ -57,11 +57,11 @@ public class BinderProperties {
 		this.inheritEnvironment = inheritEnvironment;
 	}
 
-	public boolean isApplicationProvided() {
-		return applicationProvided;
+	public boolean isDefaultCandidate() {
+		return defaultCandidate;
 	}
 
-	public void setApplicationProvided(boolean applicationProvided) {
-		this.applicationProvided = applicationProvided;
+	public void setDefaultCandidate(boolean defaultCandidate) {
+		this.defaultCandidate = defaultCandidate;
 	}
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BinderProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BinderProperties.java
@@ -31,6 +31,8 @@ public class BinderProperties {
 
 	private boolean inheritEnvironment = true;
 
+	private boolean applicationProvided = true;
+
 	public String getType() {
 		return type;
 	}
@@ -53,5 +55,13 @@ public class BinderProperties {
 
 	public void setInheritEnvironment(boolean inheritEnvironment) {
 		this.inheritEnvironment = inheritEnvironment;
+	}
+
+	public boolean isApplicationProvided() {
+		return applicationProvided;
+	}
+
+	public void setApplicationProvided(boolean applicationProvided) {
+		this.applicationProvided = applicationProvided;
 	}
 }

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/BinderFactoryConfigurationTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/BinderFactoryConfigurationTests.java
@@ -101,6 +101,8 @@ public class BinderFactoryConfigurationTests {
 
 		Binder binder1 = binderFactory.getBinder("custom");
 		assertThat(binder1).hasFieldOrPropertyWithValue("name", "foo");
+
+		assertThat(binderFactory.getBinder(null)).isSameAs(binder1);
 	}
 
 	@Test
@@ -148,13 +150,13 @@ public class BinderFactoryConfigurationTests {
 	}
 
 	@Test
-	public void loadBinderTypeRegistryWithUserDefinedBinder() throws Exception {
+	public void loadBinderTypeRegistryWithCustomNonDefaultCandidate() throws Exception {
 
 		ConfigurableApplicationContext context = createBinderTestContext(
 				new String[] { "binder1"},
 				"spring.cloud.stream.binders.custom.type=binder1",
 				"spring.cloud.stream.binders.custom.environment.binder1.name=foo",
-				"spring.cloud.stream.binders.custom.applicationProvided=false",
+				"spring.cloud.stream.binders.custom.defaultCandidate=false",
 				"spring.cloud.stream.binders.custom.inheritEnvironment=false");
 		BinderTypeRegistry binderTypeRegistry = context.getBean(BinderTypeRegistry.class);
 		assertThat(binderTypeRegistry).isNotNull();

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binding/ChannelBindingServiceTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binding/ChannelBindingServiceTests.java
@@ -79,10 +79,9 @@ public class ChannelBindingServiceTests {
 		DefaultBinderFactory<MessageChannel> binderFactory =
 				new DefaultBinderFactory<>(Collections.singletonMap("mock",
 						new BinderConfiguration(new BinderType("mock", new Class[]{MockBinderConfiguration.class}),
-								new Properties(), true)));
+								new Properties(), true, true)));
 		Binder binder = binderFactory.getBinder("mock");
-		ChannelBindingService service = new ChannelBindingService(properties,
-				binderFactory);
+		ChannelBindingService service = new ChannelBindingService(properties, binderFactory);
 		MessageChannel inputChannel = new DirectChannel();
 		@SuppressWarnings("unchecked")
 		Binding<MessageChannel> mockBinding = Mockito.mock(Binding.class);
@@ -111,14 +110,9 @@ public class ChannelBindingServiceTests {
 
 		properties.setBindings(bindingProperties);
 
-		DefaultBinderFactory<MessageChannel> binderFactory = new DefaultBinderFactory<>(
-				Collections
-						.singletonMap("mock",
-								new BinderConfiguration(
-										new BinderType("mock",
-												new Class[] {
-														MockBinderConfiguration.class }),
-										new Properties(), true)));
+		DefaultBinderFactory<MessageChannel> binderFactory = new DefaultBinderFactory<>(Collections.singletonMap("mock",
+				new BinderConfiguration(new BinderType("mock", new Class[] { MockBinderConfiguration.class }),
+						new Properties(), true, true)));
 
 		Binder binder = binderFactory.getBinder("mock");
 		ChannelBindingService service = new ChannelBindingService(properties,
@@ -175,7 +169,7 @@ public class ChannelBindingServiceTests {
 										new BinderType("mock",
 												new Class[] {
 														MockBinderConfiguration.class }),
-										new Properties(), true)));
+										new Properties(), true, true)));
 		Binder binder = binderFactory.getBinder("mock");
 		ChannelBindingService service = new ChannelBindingService(properties,
 				binderFactory);
@@ -207,7 +201,7 @@ public class ChannelBindingServiceTests {
 										new BinderType("mock",
 												new Class[] {
 														MockBinderConfiguration.class }),
-										new Properties(), true)));
+										new Properties(), true, true)));
 		Binder binder = binderFactory.getBinder("mock");
 		@SuppressWarnings("unchecked")
 		Binding<MessageChannel> mockBinding = Mockito.mock(Binding.class);
@@ -277,7 +271,7 @@ public class ChannelBindingServiceTests {
 		DefaultBinderFactory<MessageChannel> binderFactory =
 				new DefaultBinderFactory<>(Collections.singletonMap("mock",
 						new BinderConfiguration(new BinderType("mock", new Class[]{MockBinderConfiguration.class}),
-								new Properties(), true)));
+								new Properties(), true, true)));
 		ChannelBindingService service = new ChannelBindingService(serviceProperties, binderFactory);
 		MessageChannel outputChannel = new DirectChannel();
 		try {
@@ -301,14 +295,9 @@ public class ChannelBindingServiceTests {
 		final String inputChannelName = "input";
 		bindingProperties.put(inputChannelName, props);
 		serviceProperties.setBindings(bindingProperties);
-		DefaultBinderFactory<MessageChannel> binderFactory = new DefaultBinderFactory<>(
-				Collections
-						.singletonMap("mock",
-								new BinderConfiguration(
-										new BinderType("mock",
-												new Class[] {
-														MockBinderConfiguration.class }),
-										new Properties(), true)));
+		DefaultBinderFactory<MessageChannel> binderFactory = new DefaultBinderFactory<>(Collections.singletonMap("mock",
+				new BinderConfiguration(new BinderType("mock", new Class[] { MockBinderConfiguration.class }),
+						new Properties(), true, true)));
 		ChannelBindingService service = new ChannelBindingService(serviceProperties,
 				binderFactory);
 		MessageChannel inputChannel = new DirectChannel();


### PR DESCRIPTION
Fixes #557

Allow for a special `applicationProvided` flag on a binder configuration that
makes it transparent to the default configuration process.