### PR TITLE
Rabbit Configuration Corrections

### DIFF
--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitServiceAutoConfiguration.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitServiceAutoConfiguration.java
@@ -70,6 +70,11 @@ public class RabbitServiceAutoConfiguration {
 		@ConditionalOnClass(Cloud.class)
 		protected static class CloudConnectors {
 
+			@Bean
+			public Cloud cloud() {
+				return new CloudFactory().getCloud();
+			}
+
 			/**
 			 * Active only if {@code spring.cloud.stream.overrideCloudConnectors} is not
 			 * set to {@code true}.
@@ -81,11 +86,6 @@ public class RabbitServiceAutoConfiguration {
 			// configuration is not triggered.
 			@EnableConfigurationProperties(RabbitProperties.class)
 			protected static class UseCloudConnectors {
-
-				@Bean
-				public Cloud cloud() {
-					return new CloudFactory().getCloud();
-				}
 
 				/**
 				 * Creates a {@link ConnectionFactory} using the singleton service

--- a/spring-cloud-stream-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
+++ b/spring-cloud-stream-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
@@ -720,6 +720,7 @@ spring.cloud.stream.bindings.input.binder=kafka
 spring.cloud.stream.bindings.output.binder=rabbit
 ----
 
+[[multiple-systems]]
 === Connecting to Multiple Systems
 
 By default, binders share the application's Spring Boot auto-configuration, so that one instance of each binder found on the classpath will be created.
@@ -842,6 +843,16 @@ Default: empty (allowing any destination to be bound).
 spring.cloud.stream.defaultBinder::
   The default binder to use, if multiple binders are configured.
 See <<multiple-binders,Multiple Binders on the Classpath>>.
++
+Default: empty.
+
+spring.cloud.stream.overrideCloudConnectors::
+  This property is only applicable when the `cloud` profile is active, Spring Cloud Connectors are provided with the application and a service accessible via Spring Cloud Connectors is accessible to the application (e.g. Rabbit MQ service in Cloud Foundry)
+The default behavior in such cases (i.e. when the property is false) is for the binder configuration to access the bound service via Spring Cloud Connectors.
+When set to true, this property instructs binders (e.g. Rabbit MQ binder) to completely ignore the bound services and rely on Spring Boot autoconfiguration behavior (e.g. relying on the `spring.rabbitmq.*` properties provided in the environment).
+The typical usage of this property is to be nested in a customized environment <<multiple-systems, when connecting to multiple systems>>.
++
+Default: false.
 
 [[binding-properties]]
 === Binding Properties

--- a/spring-cloud-stream-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
+++ b/spring-cloud-stream-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
@@ -847,9 +847,9 @@ See <<multiple-binders,Multiple Binders on the Classpath>>.
 Default: empty.
 
 spring.cloud.stream.overrideCloudConnectors::
-  This property is only applicable when the `cloud` profile is active, Spring Cloud Connectors are provided with the application and a service accessible via Spring Cloud Connectors is accessible to the application (e.g. Rabbit MQ service in Cloud Foundry)
-The default behavior in such cases (i.e. when the property is false) is for the binder configuration to access the bound service via Spring Cloud Connectors.
-When set to true, this property instructs binders (e.g. Rabbit MQ binder) to completely ignore the bound services and rely on Spring Boot autoconfiguration behavior (e.g. relying on the `spring.rabbitmq.*` properties provided in the environment).
+  This property is only applicable when the `cloud` profile is active and Spring Cloud Connectors are provided with the application.
+If the property is false (the default), the binder will detect a suitable bound service (e.g. a RabbitMQ service bound in Cloud Foundry for the RabbitMQ binder) and will use it for creating connections (usually via Spring Cloud Connectors).
+When set to true, this property instructs binders to completely ignore the bound services and rely on Spring Boot properties (e.g. relying on the `spring.rabbitmq.*` properties provided in the environment for the RabbitMQ binder).
 The typical usage of this property is to be nested in a customized environment <<multiple-systems, when connecting to multiple systems>>.
 +
 Default: false.


### PR DESCRIPTION
Fixes #564 

To be cherry-picked to master.

- Correct an issue where if the `cloud` profile is enabled but no Connectors are available,
no `ConnectionFactory` will be created;
- Introduce a property named `spring.cloud.stream.overrideCloudConnectors` that allows
to suppress the use of Cloud connectors in the application and fall back to Spring Boot
configuration. This is provided so that specific binders can be created with arbitrary
connectivity parameters if needed.