### PR TITLE
Exposing max.request.size for producers with large payloads

### DIFF
--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -314,6 +314,8 @@ public class KafkaMessageChannelBinder extends
 		additionalProps.put(ProducerConfig.ACKS_CONFIG, String.valueOf(configurationProperties.getRequiredAcks()));
 		additionalProps.put(ProducerConfig.LINGER_MS_CONFIG,
 				String.valueOf(properties.getExtension().getBatchTimeout()));
+		additionalProps.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG,
+				String.valueOf(properties.getExtension().getMaxRequestSize()));
 		ProducerFactoryBean<byte[], byte[]> producerFB = new ProducerFactoryBean<>(producerMetadata,
 				configurationProperties.getKafkaConnectionString(), additionalProps);
 

--- a/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaProducerProperties.java
+++ b/spring-cloud-stream-binders/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaProducerProperties.java
@@ -27,6 +27,8 @@ public class KafkaProducerProperties {
 
 	private int bufferSize = 16384;
 
+	private int maxRequestSize = 1048576;
+
 	private ProducerMetadata.CompressionType compressionType = ProducerMetadata.CompressionType.none;
 
 	private boolean sync;
@@ -39,6 +41,14 @@ public class KafkaProducerProperties {
 
 	public void setBufferSize(int bufferSize) {
 		this.bufferSize = bufferSize;
+	}
+
+	public int getMaxRequestSize() {
+		return maxRequestSize;
+	}
+
+	public void setMaxRequestSize(int maxRequestSize) {
+		this.maxRequestSize = maxRequestSize;
 	}
 
 	@NotNull


### PR DESCRIPTION
Addressing issue #587 .