### PR TITLE
Aggregate application doesn't need binder in its classpath

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BinderFactoryConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BinderFactoryConfiguration.java
@@ -26,14 +26,18 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
 
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.stream.aggregate.SharedChannelRegistry;
 import org.springframework.cloud.stream.binder.BinderConfiguration;
 import org.springframework.cloud.stream.binder.BinderFactory;
 import org.springframework.cloud.stream.binder.BinderType;
 import org.springframework.cloud.stream.binder.BinderTypeRegistry;
 import org.springframework.cloud.stream.binder.DefaultBinderFactory;
 import org.springframework.cloud.stream.binder.DefaultBinderTypeRegistry;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -46,9 +50,12 @@ import org.springframework.util.StringUtils;
 
 /**
  * @author Marius Bogoevici
+ * @author Ilayaperumal Gopinathan
  */
 @Configuration
-public class BinderFactoryConfiguration {
+public class BinderFactoryConfiguration implements ApplicationContextAware {
+
+	private ConfigurableApplicationContext applicationContext;
 
 	@Bean
 	@ConditionalOnMissingBean(BinderFactory.class)
@@ -99,8 +106,15 @@ public class BinderFactoryConfiguration {
 			classLoader = ChannelBindingAutoConfiguration.class.getClassLoader();
 		}
 		try {
+			boolean isAggregate = false;
+			try {
+				isAggregate = this.applicationContext.getBean(SharedChannelRegistry.class) != null;
+			}
+			catch (BeansException be) {
+				//ignore
+			}
 			Enumeration<URL> resources = classLoader.getResources("META-INF/spring.binders");
-			if (resources == null || !resources.hasMoreElements()) {
+			if (!isAggregate && (resources == null || !resources.hasMoreElements())) {
 				throw new BeanCreationException("Cannot create binder factory, no `META-INF/spring.binders` " +
 						"resources found on the classpath");
 			}
@@ -136,4 +150,8 @@ public class BinderFactoryConfiguration {
 		return parsedBinderConfigurations;
 	}
 
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = (ConfigurableApplicationContext) applicationContext;
+	}
 }

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/BinderFactoryConfigurationTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/BinderFactoryConfigurationTests.java
@@ -61,9 +61,25 @@ public class BinderFactoryConfigurationTests {
 	}
 
 	@Test
-	public void loadBinderTypeRegistryWithAggregatorApp() throws Exception {
+	public void loadBinderTypeRegistryWithNonSelfContainedAggregatorApp() throws Exception {
+		try {
 			createBinderTestContextWithSources(
-					new Class[] { SimpleApplication.class, AggregatorParentConfiguration.class}, new String[] {});
+					new Class[]{SimpleApplication.class, AggregatorParentConfiguration.class}, new String[]{},
+					"spring.cloud.stream.internal.selfContained=false");
+			fail();
+		}
+		catch (BeanCreationException e) {
+			assertThat(e.getMessage()).contains(
+					"Cannot create binder factory, no `META-INF/spring.binders` resources found on the classpath");
+		}
+
+	}
+
+	@Test
+	public void loadBinderTypeRegistryWithSelfContainedAggregatorApp() throws Exception {
+			createBinderTestContextWithSources(
+					new Class[] { SimpleApplication.class, AggregatorParentConfiguration.class}, new String[] {},
+					"spring.cloud.stream.internal.selfContained=true");
 	}
 
 	@Test

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/BinderFactoryConfigurationTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/BinderFactoryConfigurationTests.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.cloud.stream.aggregate.AggregatorParentConfiguration;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.binder.stub1.StubBinder1;
 import org.springframework.cloud.stream.binder.stub1.StubBinder1Configuration;
@@ -43,6 +44,7 @@ import static org.junit.Assert.fail;
 
 /**
  * @author Marius Bogoevici
+ * @author Ilayaperumal Gopinathan
  */
 public class BinderFactoryConfigurationTests {
 
@@ -56,6 +58,12 @@ public class BinderFactoryConfigurationTests {
 			assertThat(e.getMessage()).contains(
 					"Cannot create binder factory, no `META-INF/spring.binders` resources found on the classpath");
 		}
+	}
+
+	@Test
+	public void loadBinderTypeRegistryWithAggregatorApp() throws Exception {
+			createBinderTestContextWithSources(
+					new Class[] { SimpleApplication.class, AggregatorParentConfiguration.class}, new String[] {});
 	}
 
 	@Test
@@ -208,7 +216,7 @@ public class BinderFactoryConfigurationTests {
 		assertThat(defaultBinder).isSameAs(binder2);
 	}
 
-	private static ConfigurableApplicationContext createBinderTestContext(String[] additionalClasspathDirectories,
+	private static ClassLoader createClassLoader(String[] additionalClasspathDirectories,
 			String... properties) throws IOException {
 		URL[] urls = ObjectUtils.isEmpty(additionalClasspathDirectories) ?
 				new URL[0] : new URL[additionalClasspathDirectories.length];
@@ -217,7 +225,12 @@ public class BinderFactoryConfigurationTests {
 				urls[i] = new URL(new ClassPathResource(additionalClasspathDirectories[i]).getURL().toString() + "/");
 			}
 		}
-		ClassLoader classLoader = new URLClassLoader(urls, BinderFactoryConfigurationTests.class.getClassLoader());
+		return new URLClassLoader(urls, BinderFactoryConfigurationTests.class.getClassLoader());
+	}
+
+	private static ConfigurableApplicationContext createBinderTestContext(String[] additionalClasspathDirectories,
+			String... properties) throws IOException {
+		ClassLoader classLoader = createClassLoader(additionalClasspathDirectories, properties);
 		return new SpringApplicationBuilder(SimpleApplication.class)
 				.resourceLoader(new DefaultResourceLoader(classLoader))
 				.properties(properties)
@@ -225,6 +238,16 @@ public class BinderFactoryConfigurationTests {
 				.run();
 	}
 
+
+	private static ConfigurableApplicationContext createBinderTestContextWithSources(Class[] sources, String[] additionalClasspathDirectories,
+			String... properties) throws IOException {
+		ClassLoader classLoader = createClassLoader(additionalClasspathDirectories, properties);
+		return new SpringApplicationBuilder(sources)
+				.resourceLoader(new DefaultResourceLoader(classLoader))
+				.properties(properties)
+				.web(false)
+				.run();
+	}
 	@Import({BinderFactoryConfiguration.class, PropertyPlaceholderAutoConfiguration.class})
 	@EnableBinding
 	public static class SimpleApplication {

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/partitioning/PartitionedProducerTest.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/partitioning/PartitionedProducerTest.java
@@ -27,6 +27,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.annotation.Bindings;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.binder.Binder;
+import org.springframework.cloud.stream.binder.BinderFactory;
 import org.springframework.cloud.stream.binder.ProducerProperties;
 import org.springframework.cloud.stream.messaging.Source;
 import org.springframework.cloud.stream.utils.MockBinderRegistryConfiguration;
@@ -41,6 +42,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 /**
  * @author Marius Bogoevici
+ * @author Ilayaperumal Gopinathan
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = PartitionedProducerTest.TestSource.class)
@@ -48,7 +50,7 @@ public class PartitionedProducerTest {
 
 	@SuppressWarnings("rawtypes")
 	@Autowired
-	private Binder binder;
+	private BinderFactory binderFactory;
 
 	@Autowired
 	@Bindings(TestSource.class)
@@ -57,12 +59,13 @@ public class PartitionedProducerTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testBindingPartitionedProducer() {
+		Binder binder = this.binderFactory.getBinder(null);
 		ArgumentCaptor<ProducerProperties> argumentCaptor = ArgumentCaptor.forClass(ProducerProperties.class);
-		verify(this.binder).bindProducer(eq("partOut"), eq(this.testSource.output()), argumentCaptor.capture());
+		verify(binder).bindProducer(eq("partOut"), eq(this.testSource.output()), argumentCaptor.capture());
 		Assert.assertThat(argumentCaptor.getValue().getPartitionCount(), equalTo(3));
 		Assert.assertThat(argumentCaptor.getValue().getPartitionKeyExpression().getExpressionString(),
 				equalTo("payload"));
-		verifyNoMoreInteractions(this.binder);
+		verifyNoMoreInteractions(binder);
 	}
 
 

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/utils/MockBinderRegistryConfiguration.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/utils/MockBinderRegistryConfiguration.java
@@ -18,14 +18,11 @@ package org.springframework.cloud.stream.utils;
 
 import java.util.Collections;
 
-import org.springframework.cloud.stream.binder.Binder;
-import org.springframework.cloud.stream.binder.BinderFactory;
 import org.springframework.cloud.stream.binder.BinderType;
 import org.springframework.cloud.stream.binder.BinderTypeRegistry;
 import org.springframework.cloud.stream.binder.DefaultBinderTypeRegistry;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.messaging.MessageChannel;
 
 /**
  * A simple configuration that creates mock {@link org.springframework.cloud.stream.binder.Binder}s.
@@ -38,10 +35,5 @@ public class MockBinderRegistryConfiguration {
 	public BinderTypeRegistry binderTypeRegistry() {
 		return new DefaultBinderTypeRegistry(
 				Collections.singletonMap("mock", new BinderType("", new Class[] { MockBinderConfiguration.class })));
-	}
-
-	@Bean
-	public Binder<?, ?, ?> defaultBinder(BinderFactory<MessageChannel> binderFactory) {
-		return binderFactory.getBinder(null);
 	}
 }


### PR DESCRIPTION
 - BinderTypeRegistry will have empty binder types for aggregate applications
  - Check if `SharedChannelRegistry` bean is in the context, then proceed with no binder type

This resolves #576