### PR TITLE
Refactor AbstractMessageChannelBinder

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
@@ -44,6 +44,10 @@ import org.springframework.util.MimeType;
  * <li>{@link #createConsumerEndpoint(String, String, CD, ConsumerProperties)}</li>
  * </ul>
  * @author Marius Bogoevici
+ * @param <C> the consumer properties type
+ * @param <P> the producer properties type
+ * @param <CD> the consumer destination type
+ * @param <PD> the producer destination type
  * @since 1.1
  */
 public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties, P extends ProducerProperties, CD, PD>


### PR DESCRIPTION
- allow the use of the destination reference returned by
`createProducerDestinationIfNecessary` when invoking `createProducerMessageHandler`