### PR TITLE
Do not start application context automatically

### DIFF
--- a/spring-cloud-stream-core-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
+++ b/spring-cloud-stream-core-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
@@ -387,6 +387,12 @@ public class SendingBean {
 }
 ----
 
+===== Spring application context for Spring Cloud Stream applications
+
+Spring cloud stream application will not start its application context automatically when the binding lifecycle beans
+are started.This is to avoid any undesirable effects on starting other beans inside the application context when those
+beans are intended to get started in a controlled manner.
+
 ==== Producing and Consuming Messages
 
 You can write a Spring Cloud Stream application using either Spring Integration annotations or Spring Cloud Stream's `@StreamListener` annotation.

--- a/spring-cloud-stream-core-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
+++ b/spring-cloud-stream-core-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
@@ -386,13 +386,6 @@ public class SendingBean {
     }
 }
 ----
-
-===== Spring application context for Spring Cloud Stream applications
-
-Spring cloud stream application will not start its application context automatically when the binding lifecycle beans
-are started.This is to avoid any undesirable effects on starting other beans inside the application context when those
-beans are intended to get started in a controlled manner.
-
 ==== Producing and Consuming Messages
 
 You can write a Spring Cloud Stream application using either Spring Integration annotations or Spring Cloud Stream's `@StreamListener` annotation.

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/OutputBindingLifecycle.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/OutputBindingLifecycle.java
@@ -62,7 +62,6 @@ public class OutputBindingLifecycle implements SmartLifecycle, ApplicationContex
 						"Cannot perform binding, no proper implementation found", e);
 			}
 			this.running = true;
-			this.applicationContext.start();
 		}
 	}
 

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/LifecycleBinderTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/LifecycleBinderTests.java
@@ -32,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Marius Bogoevici
+ * @author Ilayaperumal Gopinathan
  */
 public class LifecycleBinderTests {
 
@@ -39,9 +40,8 @@ public class LifecycleBinderTests {
 	public void testNonSmartLifecyclesStarted() {
 		ConfigurableApplicationContext applicationContext = SpringApplication.run(TestSource.class, "--server.port=-1");
 		SimpleLifecycle simpleLifecycle = applicationContext.getBean(SimpleLifecycle.class);
-		assertThat(simpleLifecycle.isRunning());
-		applicationContext.close();
 		assertThat(simpleLifecycle.isRunning()).isFalse();
+		applicationContext.close();
 	}
 
 	@EnableBinding(Source.class)


### PR DESCRIPTION
  - This will avoid other lifecycle beans inside the application context starting when
binding lifecycle beans are started.

Resolves #525