### PR TITLE
Support namespace based prefixed properties

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplicationBuilder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplicationBuilder.java
@@ -181,8 +181,14 @@ public class AggregateApplicationBuilder {
 				for (Map.Entry<String, String> entry : target.entrySet()) {
 					// only update the values with the highest precedence level.
 					if (!relaxedNameKeyExists(entry.getKey(), argKeys)) {
-						argKeys.add(entry.getKey());
-						argsToUpdate.add("--" + entry.getKey() + "=" + entry.getValue());
+						String key = entry.getKey();
+						// in case of environment variables pass the lower-case property key
+						// as we pass the properties as command line properties
+						if (key.contains("_")) {
+							key = key.replace("_", "-").toLowerCase();
+						}
+						argKeys.add(key);
+						argsToUpdate.add("--" + key + "=" + entry.getValue());
 					}
 				}
 			}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplicationBuilder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplicationBuilder.java
@@ -228,30 +228,6 @@ public class AggregateApplicationBuilder {
 		return false;
 	}
 
-	private void extractFromCommandLine(CommandLinePropertySource propertySource,
-			String namespace, Set<String> argsList) {
-		for (String propertyName : propertySource.getPropertyNames()) {
-			if (propertyName.toLowerCase().startsWith(namespace + '.')) {
-				argsList.add("--"
-						+ propertyName.toLowerCase()
-								.substring((namespace + ".").length()) + "="
-						+ propertySource.getProperty(propertyName));
-			}
-		}
-	}
-
-	private void extractFromEnvironment(SystemEnvironmentPropertySource propertySource,
-			String namespace, Set<String> argsList) {
-		for (String propertyName : propertySource.getPropertyNames()) {
-			if (propertyName.toLowerCase().startsWith(namespace + '_')) {
-				argsList.add("--"
-						+ propertyName.toLowerCase()
-						.substring((namespace + '_').length()).replace('_', '-')
-						+ "=" + propertySource.getProperty(propertyName));
-			}
-		}
-	}
-
 	private ChildContextBuilder childContext(Class<?> app,
 			ConfigurableApplicationContext parentContext, String namespace) {
 		return new ChildContextBuilder(AggregateApplication.embedApp(parentContext,

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplicationBuilder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplicationBuilder.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.stream.aggregate;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -31,6 +32,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.bind.PropertySourcesPropertyValues;
 import org.springframework.boot.bind.RelaxedDataBinder;
+import org.springframework.boot.bind.RelaxedNames;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -171,22 +173,33 @@ public class AggregateApplicationBuilder {
 			AppConfigurer appConfigurer = appConfigurerEntry.getKey();
 			String namespace = appConfigurerEntry.getValue().toLowerCase();
 			Set<String> argsToUpdate = new LinkedHashSet<>();
-			// Add the args that are set at the application level first.
-			if (appConfigurer.getArgs() != null) {
-				argsToUpdate.addAll(Arrays.asList(appConfigurer.getArgs()));
-			}
+			Set<String> argKeys = new LinkedHashSet<>();
 			final HashMap<String, String> target = new HashMap<>();
 			RelaxedDataBinder relaxedDataBinder = new RelaxedDataBinder(target, namespace);
 			relaxedDataBinder.bind(new PropertySourcesPropertyValues(propertySources));
 			if (!target.isEmpty()) {
 				for (Map.Entry<String, String> entry : target.entrySet()) {
-					argsToUpdate.add("--" + entry.getKey() + "="  + entry.getValue());
+					// only update the values with the highest precedence level.
+					if (!relaxedNameKeyExists(entry.getKey(), argKeys)) {
+						argKeys.add(entry.getKey());
+						argsToUpdate.add("--" + entry.getKey() + "=" + entry.getValue());
+					}
+				}
+			}
+			// Add the args that are set at the application level if they weren't
+			// overridden above from other property sources.
+			if (appConfigurer.getArgs() != null) {
+				for (String arg: appConfigurer.getArgs()) {
+					// use the key part left to the assignment and trimming the prefix `--`
+					String key = arg.substring(0, arg.indexOf("=")).substring(2);
+					if (!relaxedNameKeyExists(key, argKeys)) {
+						argsToUpdate.add(arg);
+					}
 				}
 			}
 			if (!argsToUpdate.isEmpty()) {
 				appConfigurer.args(argsToUpdate.toArray(new String[0]));
 			}
-
 		}
 		for (int i = apps.size() - 1; i >= 0; i--) {
 			AppConfigurer<?> appConfigurer = apps.get(i);
@@ -197,6 +210,16 @@ public class AggregateApplicationBuilder {
 
 	private boolean selfContained() {
 		return (this.sourceConfigurer != null) && (this.sinkConfigurer != null);
+	}
+
+	private boolean relaxedNameKeyExists(String key, Collection<String> collection) {
+		RelaxedNames relaxedNames = new RelaxedNames(key);
+		for (String name : relaxedNames) {
+			if (collection.contains(name)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private void extractFromCommandLine(CommandLinePropertySource propertySource,


### PR DESCRIPTION
 - In AggregateApplication, support specifying commandline and environment properties based on namespace for each containing applications using namespace as prefix
  - As usual, command line properties override the environment as well as the properties specified inside the application

Resolves spring-cloud/spring-cloud-stream#571