### PR TITLE
Support native serialization in MessageChannelBinder

### DIFF
--- a/spring-cloud-stream-binder-test/src/main/java/org/springframework/cloud/stream/binder/AbstractBinderTests.java
+++ b/spring-cloud-stream-binder-test/src/main/java/org/springframework/cloud/stream/binder/AbstractBinderTests.java
@@ -122,7 +122,7 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 		// Let the consumer actually bind to the producer before sending a msg
 		binderBindUnbindLatency();
 		moduleOutputChannel.send(message);
-		Message<?> inbound = receive(moduleInputChannel);
+		Message<?> inbound = receive(moduleInputChannel, 5);
 		assertThat(inbound).isNotNull();
 		assertThat(inbound.getPayload()).isEqualTo("foo");
 		assertThat(inbound.getHeaders().get(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE)).isNull();
@@ -164,8 +164,8 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 
 
 		Message<?>[] messages = new Message[2];
-		messages[0] = receive(moduleInputChannel);
-		messages[1] = receive(moduleInputChannel);
+		messages[0] = receive(moduleInputChannel, 5);
+		messages[1] = receive(moduleInputChannel, 5);
 
 		assertThat(messages[0]).isNotNull();
 		assertThat(messages[1]).isNotNull();
@@ -194,7 +194,7 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 
 		Message<?> message = MessageBuilder.withPayload("foo").build();
 		moduleOutputChannel.send(message);
-		Message<?> inbound = receive(moduleInputChannel);
+		Message<?> inbound = receive(moduleInputChannel, 5);
 		assertThat(inbound).isNotNull();
 		assertThat(inbound.getPayload()).isEqualTo("foo");
 		assertThat(inbound.getHeaders().get(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE)).isNull();

--- a/spring-cloud-stream-binder-test/src/main/java/org/springframework/cloud/stream/binder/AbstractBinderTests.java
+++ b/spring-cloud-stream-binder-test/src/main/java/org/springframework/cloud/stream/binder/AbstractBinderTests.java
@@ -122,7 +122,7 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 		// Let the consumer actually bind to the producer before sending a msg
 		binderBindUnbindLatency();
 		moduleOutputChannel.send(message);
-		Message<?> inbound = receive(moduleInputChannel, 5);
+		Message<?> inbound = receive(moduleInputChannel);
 		assertThat(inbound).isNotNull();
 		assertThat(inbound.getPayload()).isEqualTo("foo");
 		assertThat(inbound.getHeaders().get(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE)).isNull();
@@ -164,8 +164,8 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 
 
 		Message<?>[] messages = new Message[2];
-		messages[0] = receive(moduleInputChannel, 5);
-		messages[1] = receive(moduleInputChannel, 5);
+		messages[0] = receive(moduleInputChannel);
+		messages[1] = receive(moduleInputChannel);
 
 		assertThat(messages[0]).isNotNull();
 		assertThat(messages[1]).isNotNull();
@@ -194,7 +194,7 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 
 		Message<?> message = MessageBuilder.withPayload("foo").build();
 		moduleOutputChannel.send(message);
-		Message<?> inbound = receive(moduleInputChannel, 5);
+		Message<?> inbound = receive(moduleInputChannel);
 		assertThat(inbound).isNotNull();
 		assertThat(inbound.getPayload()).isEqualTo("foo");
 		assertThat(inbound.getHeaders().get(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE)).isNull();

--- a/spring-cloud-stream-core-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
+++ b/spring-cloud-stream-core-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
@@ -1004,7 +1004,12 @@ Effective only for messaging middleware that does not support message headers na
 Useful when producing data for non-Spring Cloud Stream applications.
 +
 Default: `embeddedHeaders`.
-
+useNativeEncoding::
+  When set to `true`, the serialization of the outbound message is handled natively using broker specific encoding (ex: Kafka producer value serializer).
+When native encoding is used, it is the responsibility of the consumer to use appropriate decoder (ex: Kafka consumer value de-serializer) to de-serialize the inbound message.
+Also, when native encoding/decoding is used the `headerMode` property is ignored as both the native encoding and embedding headers are mutually exclusive.
++
+Default: `false`.
 [[contenttypemanagement]]
 == Content Type and Transformation
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
@@ -329,8 +329,8 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 
 		@Override
 		protected void handleMessageInternal(Message<?> message) throws Exception {
-			Message<?> messageToSend = (this.useNativeEncoding) ? getMessageBuilderFactory().withPayload(message.getPayload()).build() :
-					serializeAndEmbedHeadersIfApplicable(message);
+			Message<?> messageToSend = (this.useNativeEncoding) ? getMessageBuilderFactory().withPayload(message.getPayload())
+					.copyHeaders(message.getHeaders()).build() : serializeAndEmbedHeadersIfApplicable(message);
 			this.delegate.handleMessage(messageToSend);
 		}
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ConsumerProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ConsumerProperties.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
  * Common consumer properties.
  *
  * @author Marius Bogoevici
- * @author Ilayaperumal Gopinathan
  */
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 public class ConsumerProperties {
@@ -46,8 +45,6 @@ public class ConsumerProperties {
 	private double backOffMultiplier = 2.0;
 
 	private HeaderMode headerMode = HeaderMode.embeddedHeaders;
-
-	private boolean supportDeserializationNatively = false;
 
 	@Min(value = 1, message = "Concurrency should be greater than zero.")
 	public int getConcurrency() {
@@ -126,14 +123,6 @@ public class ConsumerProperties {
 
 	public void setHeaderMode(HeaderMode headerMode) {
 		this.headerMode = headerMode;
-	}
-
-	public boolean isSupportDeserializationNatively() {
-		return this.supportDeserializationNatively;
-	}
-
-	public void setSupportDeserializationNatively(boolean supportDeserializationNatively) {
-		this.supportDeserializationNatively = supportDeserializationNatively;
 	}
 }
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ConsumerProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ConsumerProperties.java
@@ -47,6 +47,8 @@ public class ConsumerProperties {
 
 	private HeaderMode headerMode = HeaderMode.embeddedHeaders;
 
+	private boolean supportDeserializationNatively = false;
+
 	@Min(value = 1, message = "Concurrency should be greater than zero.")
 	public int getConcurrency() {
 		return concurrency;
@@ -124,6 +126,14 @@ public class ConsumerProperties {
 
 	public void setHeaderMode(HeaderMode headerMode) {
 		this.headerMode = headerMode;
+	}
+
+	public boolean isSupportDeserializationNatively() {
+		return this.supportDeserializationNatively;
+	}
+
+	public void setSupportDeserializationNatively(boolean supportDeserializationNatively) {
+		this.supportDeserializationNatively = supportDeserializationNatively;
 	}
 }
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ProducerProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ProducerProperties.java
@@ -50,7 +50,7 @@ public class ProducerProperties {
 
 	private HeaderMode headerMode = HeaderMode.embeddedHeaders;
 
-	private boolean supportSerializationNatively = false;
+	private boolean useNativeEncoding = false;
 
 	public Expression getPartitionKeyExpression() {
 		return partitionKeyExpression;
@@ -123,12 +123,12 @@ public class ProducerProperties {
 		this.headerMode = headerMode;
 	}
 
-	public boolean isSupportSerializationNatively() {
-		return this.supportSerializationNatively;
+	public boolean isUseNativeEncoding() {
+		return this.useNativeEncoding;
 	}
 
-	public void setSupportSerializationNatively(boolean supportSerializationNatively) {
-		this.supportSerializationNatively = supportSerializationNatively;
+	public void setUseNativeEncoding(boolean useNativeEncoding) {
+		this.useNativeEncoding = useNativeEncoding;
 	}
 
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ProducerProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ProducerProperties.java
@@ -50,6 +50,8 @@ public class ProducerProperties {
 
 	private HeaderMode headerMode = HeaderMode.embeddedHeaders;
 
+	private boolean supportSerializationNatively = false;
+
 	public Expression getPartitionKeyExpression() {
 		return partitionKeyExpression;
 	}
@@ -119,6 +121,14 @@ public class ProducerProperties {
 
 	public void setHeaderMode(HeaderMode headerMode) {
 		this.headerMode = headerMode;
+	}
+
+	public boolean isSupportSerializationNatively() {
+		return this.supportSerializationNatively;
+	}
+
+	public void setSupportSerializationNatively(boolean supportSerializationNatively) {
+		this.supportSerializationNatively = supportSerializationNatively;
 	}
 
 }


### PR DESCRIPTION
- If the broker supports native serialization, then the serialization of the outbound payload is not done by the binder's producer binding outbound message handler.
  Also, when native serialization is enabled, embedding of headers (if enabled) is allowed only when the outbound payload type is byte[]
- At the consumer binding's inbound message handler, the extraction of embedded headers is performed only for the byte[] payload (given the deserialization would have already occurred at the broker level)
- Add correspoinding tests in Kafka binder implementation

Resolves #691
