### PR TITLE
Fixes for GH-696 and GH-697

### DIFF
--- a/spring-cloud-stream-schema-server/pom.xml
+++ b/spring-cloud-stream-schema-server/pom.xml
@@ -27,6 +27,7 @@
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<version>1.4.192</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.avro</groupId>

--- a/spring-cloud-stream-schema-server/src/main/java/org/springframework/cloud/stream/schema/server/config/SchemaServerConfiguration.java
+++ b/spring-cloud-stream-schema-server/src/main/java/org/springframework/cloud/stream/schema/server/config/SchemaServerConfiguration.java
@@ -19,8 +19,10 @@ package org.springframework.cloud.stream.schema.server.config;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.schema.server.controllers.ServerController;
+import org.springframework.cloud.stream.schema.server.model.Schema;
 import org.springframework.cloud.stream.schema.server.repository.SchemaRepository;
 import org.springframework.cloud.stream.schema.server.support.AvroSchemaValidator;
 import org.springframework.cloud.stream.schema.server.support.SchemaValidator;
@@ -34,6 +36,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @Configuration
 @EnableJpaRepositories(basePackageClasses = SchemaRepository.class)
 @EnableConfigurationProperties(SchemaServerProperties.class)
+@EntityScan(basePackageClasses = Schema.class)
 public class SchemaServerConfiguration {
 
 	@Bean

--- a/spring-cloud-stream-schema-server/src/main/java/org/springframework/cloud/stream/schema/server/model/Schema.java
+++ b/spring-cloud-stream-schema-server/src/main/java/org/springframework/cloud/stream/schema/server/model/Schema.java
@@ -21,6 +21,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Lob;
+import javax.persistence.Table;
 
 /**
  * @author Vinicius Carvalho
@@ -28,6 +29,7 @@ import javax.persistence.Lob;
  * Represents a persisted schema entity.
  */
 @Entity
+@Table(name = "SCHEMA_REPOSITORY")
 public class Schema {
 
 	@Id

--- a/spring-cloud-stream-schema-server/src/main/java/org/springframework/cloud/stream/schema/server/repository/SchemaRepository.java
+++ b/spring-cloud-stream-schema-server/src/main/java/org/springframework/cloud/stream/schema/server/repository/SchemaRepository.java
@@ -20,15 +20,17 @@ import java.util.List;
 
 import org.springframework.cloud.stream.schema.server.model.Schema;
 import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Vinicius Carvalho
  */
 public interface SchemaRepository extends PagingAndSortingRepository<Schema, Integer> {
 
+	@Transactional
 	List<Schema> findBySubjectAndFormatOrderByVersion(String subject,
 			String format);
-
+	@Transactional
 	Schema findOneBySubjectAndFormatAndVersion(String subject, String format,
 			Integer version);
 }

--- a/spring-cloud-stream-schema-server/src/main/resources/application.yml
+++ b/spring-cloud-stream-schema-server/src/main/resources/application.yml
@@ -1,5 +1,8 @@
 spring:
   application:
     name: SchemaRegistryServer
+  jpa:
+    hibernate:
+      ddl-auto: update
 server:
   port: 8990


### PR DESCRIPTION
+ Renamed Table from Schema to SCHEMA_REPOSITORY to avoid potential reserved word clashes with some databases

+ Added `@EntityScan` annotation so managed entities can be scanned if the schema server is being used embedded inside another app and not as standalone

+ Postgresql GH-696 requires transactional semantics even for reading operations when using Lob columns

+ Removed dependency to h2 database. A database driver is now explicitly required when running the server

Resolves #696