### PR TITLE
Improve application aggregation and testability

### DIFF
--- a/spring-cloud-stream-test-support/src/test/java/org/springframework/cloud/stream/test/aggregate/AggregateTestWithBean.java
+++ b/spring-cloud-stream-test-support/src/test/java/org/springframework/cloud/stream/test/aggregate/AggregateTestWithBean.java
@@ -1,0 +1,78 @@
+package org.springframework.cloud.stream.test.aggregate;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.aggregate.AggregateApplication;
+import org.springframework.cloud.stream.aggregate.AggregateApplicationBuilder;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.messaging.Processor;
+import org.springframework.cloud.stream.test.binder.MessageCollector;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.annotation.Transformer;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Marius Bogoevici
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = AggregateTestWithBean.ChainedProcessors.class, properties = {"server.port=-1"})
+public class AggregateTestWithBean {
+
+	@Autowired
+	public MessageCollector messageCollector;
+
+	@Autowired
+	public AggregateApplication aggregateApplication;
+
+	@Test
+	public void testAggregateApplication() throws InterruptedException {
+		Processor uppercaseProcessor = aggregateApplication.getBinding(Processor.class, "upper");
+		Processor suffixProcessor = aggregateApplication.getBinding(Processor.class, "suffix");
+		uppercaseProcessor.input().send(MessageBuilder.withPayload("Hello").build());
+		Message<?> receivedMessage = messageCollector.forChannel(suffixProcessor.output()).poll(1, TimeUnit.SECONDS);
+		assertThat(receivedMessage).isNotNull();
+		assertThat(receivedMessage.getPayload()).isEqualTo("HELLO WORLD!");
+	}
+
+	@SpringBootApplication
+	@EnableBinding
+	public static class ChainedProcessors {
+
+		@Bean
+		public AggregateApplication aggregateApplication() {
+			return new AggregateApplicationBuilder().from(UppercaseProcessor.class)
+					.namespace("upper").to(SuffixProcessor.class).namespace("suffix").build();
+		}
+	}
+
+	@Configuration
+	@EnableBinding(Processor.class)
+	public static class UppercaseProcessor {
+
+		@Transformer(inputChannel = Processor.INPUT, outputChannel = Processor.OUTPUT)
+		public String transform(String in) {
+			return in.toUpperCase();
+		}
+	}
+
+	@Configuration
+	@EnableBinding(Processor.class)
+	public static class SuffixProcessor {
+
+		@Transformer(inputChannel = Processor.INPUT, outputChannel = Processor.OUTPUT)
+		public String transform(String in) {
+			return in + " WORLD!";
+		}
+	}
+}

--- a/spring-cloud-stream-test-support/src/test/java/org/springframework/cloud/stream/test/aggregate/AggregateTestWithMain.java
+++ b/spring-cloud-stream-test-support/src/test/java/org/springframework/cloud/stream/test/aggregate/AggregateTestWithMain.java
@@ -1,0 +1,61 @@
+package org.springframework.cloud.stream.test.aggregate;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import org.springframework.cloud.stream.aggregate.AggregateApplication;
+import org.springframework.cloud.stream.aggregate.AggregateApplicationBuilder;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.messaging.Processor;
+import org.springframework.cloud.stream.test.binder.MessageCollector;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.annotation.Transformer;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class AggregateTestWithMain {
+
+	@Test
+	public void testAggregateApplication() throws InterruptedException {
+		// emulate a main method
+		ConfigurableApplicationContext context = new AggregateApplicationBuilder().from(UppercaseProcessor.class)
+				.namespace("upper").to(SuffixProcessor.class).namespace("suffix").run();
+
+		AggregateApplication aggregateAccessor = context.getBean(AggregateApplication.class);
+		MessageCollector messageCollector = context.getBean(MessageCollector.class);
+		Processor uppercaseProcessor = aggregateAccessor.getBinding(Processor.class, "upper");
+		Processor suffixProcessor = aggregateAccessor.getBinding(Processor.class, "suffix");
+		uppercaseProcessor.input().send(MessageBuilder.withPayload("Hello").build());
+		Message<?> receivedMessage = messageCollector.forChannel(suffixProcessor.output()).poll(1, TimeUnit.SECONDS);
+		assertThat(receivedMessage).isNotNull();
+		assertThat(receivedMessage.getPayload()).isEqualTo("HELLO WORLD!");
+		context.close();
+	}
+
+	@Configuration
+	@EnableBinding(Processor.class)
+	public static class UppercaseProcessor {
+
+		@Transformer(inputChannel = Processor.INPUT, outputChannel = Processor.OUTPUT)
+		public String transform(String in) {
+			return in.toUpperCase();
+		}
+	}
+
+	@Configuration
+	@EnableBinding(Processor.class)
+	public static class SuffixProcessor {
+
+		@Transformer(inputChannel = Processor.INPUT, outputChannel = Processor.OUTPUT)
+		public String transform(String in) {
+			return in + " WORLD!";
+		}
+	}
+}

--- a/spring-cloud-stream-test-support/src/test/java/org/springframework/cloud/stream/test/example/ExampleTest.java
+++ b/spring-cloud-stream-test-support/src/test/java/org/springframework/cloud/stream/test/example/ExampleTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.stream.test;
+package org.springframework.cloud.stream.test.example;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplication.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplication.java
@@ -1,98 +1,23 @@
-/*
- * Copyright 2015-2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.springframework.cloud.stream.aggregate;
 
-import java.util.LinkedHashMap;
-import java.util.Map.Entry;
-
-import org.springframework.boot.Banner.Mode;
-import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.integration.channel.DirectChannel;
-import org.springframework.messaging.SubscribableChannel;
-
 /**
- * Class that is responsible for embedding apps using shared channel registry.
+ * Handle to an aggregate application, providing access to the underlying
+ * components of the aggregate (e.g. bindable instances).
  *
  * @author Marius Bogoevici
- * @author Ilayaperumal Gopinathan
- * @author Venil Noronha
  */
-abstract class AggregateApplication {
+public interface AggregateApplication {
 
-	private static final String SPRING_CLOUD_STREAM_INTERNAL_PREFIX = "spring.cloud.stream.internal";
-
-	private static final String CHANNEL_NAMESPACE_PROPERTY_NAME =
-			SPRING_CLOUD_STREAM_INTERNAL_PREFIX + ".channelNamespace";
-
-	private static final String SELF_CONTAINED_APP_PROPERTY_NAME =
-			SPRING_CLOUD_STREAM_INTERNAL_PREFIX + ".selfContained";
-
-	public static final String INPUT_CHANNEL_NAME = "input";
-
-	public static final String OUTPUT_CHANNEL_NAME = "output";
-
-	static ConfigurableApplicationContext createParentContext(Object[] sources, String[] args, final
-			boolean selfContained, boolean webEnvironment,
-			boolean headless) {
-		SpringApplicationBuilder aggregatorParentConfiguration = new SpringApplicationBuilder();
-		aggregatorParentConfiguration
-				.sources(sources)
-				.web(webEnvironment)
-				.headless(headless)
-				.properties("spring.jmx.default-domain="
-									+ AggregateApplicationBuilder.ParentConfiguration.class.getName(),
-						SELF_CONTAINED_APP_PROPERTY_NAME + "=" + selfContained);
-		return aggregatorParentConfiguration.run(args);
-	}
-
-	static String getDefaultNamespace(String appClassName, int index) {
-		return appClassName + "_" + index;
-	}
-
-
-	protected static SpringApplicationBuilder embedApp(
-			ConfigurableApplicationContext parentContext, String namespace,
-			Class<?> app) {
-		return new SpringApplicationBuilder(app)
-				.web(false)
-				.main(app)
-				.bannerMode(Mode.OFF)
-				.properties("spring.jmx.default-domain=" + namespace)
-				.properties(CHANNEL_NAMESPACE_PROPERTY_NAME + "=" + namespace)
-				.registerShutdownHook(false)
-				.parent(parentContext);
-	}
-
-	static void prepareSharedChannelRegistry(SharedChannelRegistry sharedChannelRegistry,
-			LinkedHashMap<Class<?>, String> appsWithNamespace) {
-		int i = 0;
-		SubscribableChannel sharedChannel = null;
-		for (Entry<Class<?>, String> appEntry : appsWithNamespace.entrySet()) {
-			String namespace = appEntry.getValue();
-			if (i > 0) {
-				sharedChannelRegistry.register(namespace + "." + INPUT_CHANNEL_NAME, sharedChannel);
-			}
-			sharedChannel = new DirectChannel();
-			if (i < appsWithNamespace.size() - 1) {
-				sharedChannelRegistry.register(namespace + "." + OUTPUT_CHANNEL_NAME, sharedChannel);
-			}
-			i++;
-		}
-	}
-
+	/**
+	 * Retrieves the bindable proxy instance (e.g. {@link org.springframework.cloud.stream.messaging.Processor},
+	 * {@link org.springframework.cloud.stream.messaging.Source},
+	 * {@link org.springframework.cloud.stream.messaging.Sink} or custom interface) from
+	 * the given namespace.
+	 *
+	 * @param bindableType the bindable type
+	 * @param namespace the namespace
+	 * @param <T>
+	 * @return
+	 */
+	<T> T getBinding(Class<T> bindableType, String namespace);
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplicationBuilder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplicationBuilder.java
@@ -48,7 +48,7 @@ import org.springframework.integration.monitor.IntegrationMBeanExporter;
 import org.springframework.util.StringUtils;
 
 /**
- * Application builder for {@link AggregateApplicationUtils}.
+ * Application builder for {@link AggregateApplication}.
  *
  * @author Dave Syer
  * @author Ilayaperumal Gopinathan

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplicationUtils.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplicationUtils.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.aggregate;
+
+import java.util.LinkedHashMap;
+import java.util.Map.Entry;
+
+import org.springframework.boot.Banner.Mode;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.messaging.SubscribableChannel;
+
+/**
+ * Utilities for embedding applications in aggregates.
+ *
+ * @author Marius Bogoevici
+ * @author Ilayaperumal Gopinathan
+ * @author Venil Noronha
+ */
+abstract class AggregateApplicationUtils {
+
+	private static final String SPRING_CLOUD_STREAM_INTERNAL_PREFIX = "spring.cloud.stream.internal";
+
+	private static final String CHANNEL_NAMESPACE_PROPERTY_NAME =
+			SPRING_CLOUD_STREAM_INTERNAL_PREFIX + ".channelNamespace";
+
+	private static final String SELF_CONTAINED_APP_PROPERTY_NAME =
+			SPRING_CLOUD_STREAM_INTERNAL_PREFIX + ".selfContained";
+
+	public static final String INPUT_CHANNEL_NAME = "input";
+
+	public static final String OUTPUT_CHANNEL_NAME = "output";
+
+	static ConfigurableApplicationContext createParentContext(Object[] sources, String[] args, final
+			boolean selfContained, boolean webEnvironment,
+			boolean headless) {
+		SpringApplicationBuilder aggregatorParentConfiguration = new SpringApplicationBuilder();
+		aggregatorParentConfiguration
+				.sources(sources)
+				.web(webEnvironment)
+				.headless(headless)
+				.properties("spring.jmx.default-domain="
+									+ AggregateApplicationBuilder.ParentConfiguration.class.getName(),
+						SELF_CONTAINED_APP_PROPERTY_NAME + "=" + selfContained);
+		return aggregatorParentConfiguration.run(args);
+	}
+
+	static String getDefaultNamespace(String appClassName, int index) {
+		return appClassName + "_" + index;
+	}
+
+
+	protected static SpringApplicationBuilder embedApp(
+			ConfigurableApplicationContext parentContext, String namespace,
+			Class<?> app) {
+		return new SpringApplicationBuilder(app)
+				.web(false)
+				.main(app)
+				.bannerMode(Mode.OFF)
+				.properties("spring.jmx.default-domain=" + namespace)
+				.properties(CHANNEL_NAMESPACE_PROPERTY_NAME + "=" + namespace)
+				.registerShutdownHook(false)
+				.parent(parentContext);
+	}
+
+	static void prepareSharedChannelRegistry(SharedChannelRegistry sharedChannelRegistry,
+			LinkedHashMap<Class<?>, String> appsWithNamespace) {
+		int i = 0;
+		SubscribableChannel sharedChannel = null;
+		for (Entry<Class<?>, String> appEntry : appsWithNamespace.entrySet()) {
+			String namespace = appEntry.getValue();
+			if (i > 0) {
+				sharedChannelRegistry.register(namespace + "." + INPUT_CHANNEL_NAME, sharedChannel);
+			}
+			sharedChannel = new DirectChannel();
+			if (i < appsWithNamespace.size() - 1) {
+				sharedChannelRegistry.register(namespace + "." + OUTPUT_CHANNEL_NAME, sharedChannel);
+			}
+			i++;
+		}
+	}
+
+}

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/aggregation/AggregationTest.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/aggregation/AggregationTest.java
@@ -44,7 +44,7 @@ import static org.junit.Assert.assertTrue;
  * @author Marius Bogoevici
  * @author Ilayaperumal Gopinathan
  */
-public class ModuleAggregationTest {
+public class AggregationTest {
 
 	private ConfigurableApplicationContext aggregatedApplicationContext;
 
@@ -60,10 +60,12 @@ public class ModuleAggregationTest {
 	}
 
 	@Test
-	public void testModuleAggregation() {
+	public void aggregation() {
 		aggregatedApplicationContext = new AggregateApplicationBuilder(
 				MockBinderRegistryConfiguration.class, "--server.port=0")
-				.from(TestSource.class).to(TestProcessor.class).run();
+				.from(TestSource.class)
+				.to(TestProcessor.class)
+				.run();
 		SharedChannelRegistry sharedChannelRegistry = aggregatedApplicationContext
 				.getBean(SharedChannelRegistry.class);
 		BindableChannelFactory channelFactory = aggregatedApplicationContext

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/utils/MockBinderRegistryConfiguration.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/utils/MockBinderRegistryConfiguration.java
@@ -25,7 +25,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * A simple configuration that creates mock {@link org.springframework.cloud.stream.binder.Binder}s.
+ * A simple configuration that creates mock
+ * {@link org.springframework.cloud.stream.binder.Binder}s.
  * @author Marius Bogoevici
  */
 @Configuration


### PR DESCRIPTION
Fixes #723

- Add support for registering an `AggregateApplication` bean for accessing the
  components from underlying subcontexts
- Testing support and samples

Signed-off-by: Marius Bogoevici <mbogoevici@pivotal.io>