### PR TITLE
Skip `deserializePayloadIfNecessary` only if `originalContentType` is not set

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
@@ -278,7 +278,8 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 		@Override
 		@SuppressWarnings("unchecked")
 		protected Object handleRequestMessage(Message<?> requestMessage) {
-			if (!(requestMessage.getPayload() instanceof byte[])) {
+			if (!(requestMessage.getPayload() instanceof byte[])
+					&& !requestMessage.getHeaders().containsKey(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE)) {
 				return requestMessage;
 			}
 			MessageValues messageValues;


### PR DESCRIPTION
Fixes #741

The current code will skip `deserializePayloadIfNecessary` if the
payload is a `byte[]`. There are in fact two conditions that indicate
that a message does not require postprocessing in the binder: that
the payload is not a `byte[]` which indicates that the message has
already been deserialized, and that the `originalContentType` is not
present, or else it'd need to be moved to `contentType`. This fix
adds the secondary condition to the check.

Note: this requires backporting to the 1.1.x branch.