### PR TITLE
Fix Incorrect Docs for consumer.maxAttempts

### DIFF
--- a/spring-cloud-stream-core-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
+++ b/spring-cloud-stream-core-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
@@ -974,7 +974,8 @@ Useful when inbound data is coming from outside Spring Cloud Stream applications
 +
 Default: `embeddedHeaders`.
 maxAttempts::
-  The number of attempts of re-processing an inbound message.
+  If processing fails, the number of attempts to process the message (including the first).
+  Set to 1 to disable retry.
 +
 Default: `3`.
 backOffInitialInterval::


### PR DESCRIPTION
It is an absolute number of attempts, not the number of retries.