### PR TITLE
Access aggregate's child applications' request mapping/endpoint web endpoints

### DIFF
--- a/spring-cloud-stream-core-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
+++ b/spring-cloud-stream-core-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
@@ -881,9 +881,22 @@ public class SampleAggregateApplication {
 }
 ----
 
-
+[NOTE]
+====
 The binding properties like `--spring.cloud.stream.bindings.output.destination=processor-output` need to be specified as one of the external configuration properties (cmdline arg etc.,).
+====
 
+===== Exposing Web MVC endpoints of child applications via aggregate application
+
+If the child applications inside the aggregate application have web MVC request mappings (including the Spring Boot actuator endpoints if enabled) then they can be accessed via aggregate application with the request mappings `paths` have child application's `namespace` as their prefixes.
+For instance, if a child application has a request mappings for the path `/user/info` and uses a namespace `http1` then this request mapping can be accessed via aggregate application's server endpoint using the path `/http1/user/info`.
+If no `namespace` is specified, then the prefix `child` and the index number for identifying the child application.
+For instance, if a child application doesn't have explicit `namespace` for the above request mapping, then it would use `/child_0/user/info` as the request mapping from the aggregate applicaton.
+
+[NOTE]
+====
+Since the `namespace` is used for the request mappings to uniquely distinguish from other child applications, it is important to use a valid request mapping name for the namespace (not `-` etc.,)
+====
 
 == Binders
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplicationBuilder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplicationBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,25 +16,47 @@
 
 package org.springframework.cloud.stream.aggregate;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactoryUtils;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.SmartInitializingSingleton;
-import org.springframework.boot.actuate.autoconfigure.EndpointAutoConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.EndpointCorsProperties;
+import org.springframework.boot.actuate.autoconfigure.ManagementServerProperties;
+import org.springframework.boot.actuate.autoconfigure.ManagementServerPropertiesAutoConfiguration;
+import org.springframework.boot.actuate.endpoint.AbstractEndpoint;
 import org.springframework.boot.actuate.endpoint.MetricReaderPublicMetrics;
 import org.springframework.boot.actuate.endpoint.MetricsEndpoint;
+import org.springframework.boot.actuate.endpoint.mvc.AbstractEndpointMvcAdapter;
+import org.springframework.boot.actuate.endpoint.mvc.AbstractMvcEndpoint;
+import org.springframework.boot.actuate.endpoint.mvc.EndpointHandlerMapping;
+import org.springframework.boot.actuate.endpoint.mvc.EndpointHandlerMappingCustomizer;
+import org.springframework.boot.actuate.endpoint.mvc.MvcEndpoint;
+import org.springframework.boot.actuate.endpoint.mvc.MvcEndpointSecurityInterceptor;
+import org.springframework.boot.actuate.endpoint.mvc.MvcEndpoints;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.autoconfigure.web.BasicErrorController;
+import org.springframework.boot.autoconfigure.web.DispatcherServletAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.EmbeddedServletContainerAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.HttpMessageConvertersAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.ServerPropertiesAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;
 import org.springframework.boot.bind.PropertySourcesPropertyValues;
 import org.springframework.boot.bind.RelaxedDataBinder;
 import org.springframework.boot.bind.RelaxedNames;
@@ -46,10 +68,16 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.env.PropertySources;
 import org.springframework.integration.monitor.IntegrationMBeanExporter;
 import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.handler.AbstractHandlerMethodMapping;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 
 /**
  * Application builder for {@link AggregateApplication}.
@@ -202,7 +230,9 @@ public class AggregateApplicationBuilder implements AggregateApplication, Applic
 		}
 		if (this.parentContext == null) {
 			if (Boolean.TRUE.equals(this.webEnvironment)) {
-				this.addParentSources(new Object[] { EmbeddedServletContainerAutoConfiguration.class });
+				this.addParentSources(new Object[]{EmbeddedServletContainerAutoConfiguration.class, WebMvcAutoConfiguration.class,
+						DispatcherServletAutoConfiguration.class, HttpMessageConvertersAutoConfiguration.class,
+						ManagementServerPropertiesAutoConfiguration.class, ServerPropertiesAutoConfiguration.class});
 			}
 			this.parentContext = AggregateApplicationUtils.createParentContext(
 					this.parentSources.toArray(new Object[0]),
@@ -224,7 +254,6 @@ public class AggregateApplicationBuilder implements AggregateApplication, Applic
 		PropertySources propertySources = this.parentContext.getEnvironment()
 				.getPropertySources();
 		for (Map.Entry<AppConfigurer, String> appConfigurerEntry : appConfigurers.entrySet()) {
-
 			AppConfigurer appConfigurer = appConfigurerEntry.getKey();
 			String namespace = appConfigurerEntry.getValue().toLowerCase();
 			Set<String> argsToUpdate = new LinkedHashSet<>();
@@ -264,15 +293,71 @@ public class AggregateApplicationBuilder implements AggregateApplication, Applic
 				appConfigurer.args(argsToUpdate.toArray(new String[0]));
 			}
 		}
-		for (int i = apps.size() - 1; i >= 0; i--) {
-			AppConfigurer<?> appConfigurer = apps.get(i);
-			appConfigurer.embed();
-		}
+		exposeWebEndpoints(apps);
 		if (BeanFactoryUtils.beansOfTypeIncludingAncestors(this.parentContext, AggregateApplication.class)
 				.size() == 0) {
 			this.parentContext.getBeanFactory().registerSingleton("aggregateApplicationAccessor", this);
 		}
 		return this.parentContext;
+	}
+
+	private void exposeWebEndpoints(List<AppConfigurer<?>> apps) {
+		Set<MvcEndpoint> mvcEndpointsToAdd = new HashSet<>();
+		Map<RequestMappingInfo, Map<Object, Method>> requestMappingInfo = new HashMap<>();
+		for (int i = apps.size() - 1; i >= 0; i--) {
+			AppConfigurer<?> appConfigurer = apps.get(i);
+			ConfigurableApplicationContext childContext = appConfigurer.embed();
+			// Map the Spring MVC RequestMapping into parent context
+			AbstractHandlerMethodMapping handlerMethodMapping = childContext.getBean(AbstractHandlerMethodMapping.class);
+			Map<RequestMappingInfo, HandlerMethod> mappings = handlerMethodMapping.getHandlerMethods();
+			for (Map.Entry<RequestMappingInfo, HandlerMethod> mapping : mappings.entrySet()) {
+				Map<Object, Method> handlerMethodMap = new HashMap<>();
+				HandlerMethod handlerMethod = mapping.getValue();
+				if (!BasicErrorController.class.isAssignableFrom(handlerMethod.getBeanType())) {
+					Object handlerBean = handlerMethod.getBean();
+					try {
+						this.parentContext.getBeanFactory().getBean(handlerBean.toString());
+					}
+					catch (NoSuchBeanDefinitionException e) {
+						// ChildContext is expected to have the bean as the request mapping is retrieved from the child context.
+						this.parentContext.getBeanFactory().registerSingleton(handlerBean.toString(), childContext.getBean(handlerBean.toString()));
+					}
+					handlerMethodMap.put(handlerBean, handlerMethod.getMethod());
+				}
+				requestMappingInfo.put(mapping.getKey(), handlerMethodMap);
+			}
+			// Map the actuator web endpoints
+			MvcEndpoints mvcEndpoints = new MvcEndpoints();
+			mvcEndpoints.setApplicationContext(childContext);
+			try {
+				mvcEndpoints.afterPropertiesSet();
+			}
+			catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+			for (MvcEndpoint mvcEndpoint : mvcEndpoints.getEndpoints()) {
+				String namespaceValue = Pattern.compile("\\w+").matcher(appConfigurer.getNamespace()).matches() ? appConfigurer.getNamespace() : "child_" + i;
+				if (mvcEndpoint instanceof AbstractMvcEndpoint) {
+					((AbstractMvcEndpoint) mvcEndpoint).setPath("/" + namespaceValue + "/" + mvcEndpoint.getPath());
+				}
+				else if (mvcEndpoint instanceof AbstractEndpointMvcAdapter) {
+					((AbstractEndpointMvcAdapter) mvcEndpoint).setPath("/" + namespaceValue + "/" + mvcEndpoint.getPath());
+				}
+				else if (mvcEndpoint instanceof AbstractEndpoint) {
+					((AbstractEndpoint) mvcEndpoint).setId(namespaceValue + "_" + ((AbstractEndpoint) mvcEndpoint).getId());
+				}
+			}
+			mvcEndpointsToAdd.addAll(mvcEndpoints.getEndpoints());
+		}
+		MvcEndpointsHolder mvcEndpointsHolder = new MvcEndpointsHolder(mvcEndpointsToAdd);
+		this.parentContext.getBeanFactory().registerSingleton("mvcEndpointsHolder", mvcEndpointsHolder);
+		// invoke lazy bean to get instantiated after setting mvcEndpoints
+		EndpointHandlerMapping endpointHandlerMapping = this.parentContext.getBean(EndpointHandlerMapping.class);
+		for (Map.Entry<RequestMappingInfo, Map<Object, Method>> mappingInfoMapEntry : requestMappingInfo.entrySet()) {
+			for (Map.Entry<Object, Method> handlerMethodEntry : mappingInfoMapEntry.getValue().entrySet()) {
+				endpointHandlerMapping.registerMapping(mappingInfoMapEntry.getKey(), handlerMethodEntry.getKey(), handlerMethodEntry.getValue());
+			}
+		}
 	}
 
 	private boolean selfContained() {
@@ -292,36 +377,6 @@ public class AggregateApplicationBuilder implements AggregateApplication, Applic
 	private ChildContextBuilder childContext(Class<?> app, ConfigurableApplicationContext parentContext,
 			String namespace) {
 		return new ChildContextBuilder(AggregateApplicationUtils.embedApp(parentContext, namespace, app));
-	}
-
-	private static class ChildContextHolder {
-
-		private final ConfigurableApplicationContext childContext;
-
-		ChildContextHolder(ConfigurableApplicationContext childContext) {
-			Assert.notNull(childContext, "cannot be null");
-			this.childContext = childContext;
-		}
-
-		public ConfigurableApplicationContext getChildContext() {
-			return childContext;
-		}
-	}
-
-	@ImportAutoConfiguration({ ChannelBindingAutoConfiguration.class, EndpointAutoConfiguration.class })
-	@EnableBinding
-	public static class ParentConfiguration {
-		@Bean
-		@ConditionalOnMissingBean(SharedBindingTargetRegistry.class)
-		public SharedBindingTargetRegistry sharedBindingTargetRegistry() {
-			return new SharedBindingTargetRegistry();
-		}
-
-		@Bean
-		@ConditionalOnMissingBean(SharedChannelRegistry.class)
-		public SharedChannelRegistry sharedChannelRegistry(SharedBindingTargetRegistry sharedBindingTargetRegistry) {
-			return new SharedChannelRegistry(sharedBindingTargetRegistry);
-		}
 	}
 
 	public class SourceConfigurer extends AppConfigurer<SourceConfigurer> {
@@ -412,7 +467,7 @@ public class AggregateApplicationBuilder implements AggregateApplication, Applic
 			return applicationBuilder.run(args);
 		}
 
-		void embed() {
+		ConfigurableApplicationContext embed() {
 			final ConfigurableApplicationContext childContext = childContext(this.app,
 					AggregateApplicationBuilder.this.parentContext, this.namespace).args(this.args).config(this.names)
 							.profiles(this.profiles).run();
@@ -441,6 +496,7 @@ public class AggregateApplicationBuilder implements AggregateApplication, Applic
 								new MetricReaderPublicMetrics(new NamespaceAwareSpringIntegrationMetricReader(
 										this.namespace, childContext.getBean(IntegrationMBeanExporter.class))));
 			}
+			return childContext;
 		}
 
 		public AggregateApplication build() {
@@ -500,4 +556,130 @@ public class AggregateApplicationBuilder implements AggregateApplication, Applic
 
 	}
 
+	private static class ChildContextHolder {
+
+		private final ConfigurableApplicationContext childContext;
+
+		ChildContextHolder(ConfigurableApplicationContext childContext) {
+			Assert.notNull(childContext, "cannot be null");
+			this.childContext = childContext;
+		}
+
+		public ConfigurableApplicationContext getChildContext() {
+			return childContext;
+		}
+	}
+
+	@EnableBinding
+	@ImportAutoConfiguration({ChannelBindingAutoConfiguration.class})
+	public static class ParentConfiguration {
+
+		@Autowired(required = false)
+		private ManagementServerProperties managementServerProperties;
+
+		@Autowired(required = false)
+		private List<EndpointHandlerMappingCustomizer> mappingCustomizers;
+
+		@Autowired(required = false)
+		private EndpointCorsProperties corsProperties;
+
+		@Bean
+		@ConditionalOnMissingBean(SharedBindingTargetRegistry.class)
+		public SharedBindingTargetRegistry sharedBindingTargetRegistry() {
+			return new SharedBindingTargetRegistry();
+		}
+
+		@Bean
+		@ConditionalOnMissingBean(SharedChannelRegistry.class)
+		public SharedChannelRegistry sharedChannelRegistry(SharedBindingTargetRegistry sharedBindingTargetRegistry) {
+			return new SharedChannelRegistry(sharedBindingTargetRegistry);
+		}
+
+		@Bean
+		@Lazy
+		@ConditionalOnClass(name = "org.springframework.boot.actuate.endpoint.mvc.MvcEndpointSecurityInterceptor")
+		public EndpointHandlerMapping endpointHandlerMapping(MvcEndpointsHolder mvcEndpointsHolder) {
+			EndpointHandlerMapping mapping = null;
+			if (this.corsProperties != null) {
+				CorsConfiguration corsConfiguration = getCorsConfiguration(this.corsProperties);
+				mapping = new EndpointHandlerMapping(mvcEndpointsHolder.getMvcEndpoints(), corsConfiguration);
+			}
+			else {
+				mapping = new EndpointHandlerMapping(mvcEndpointsHolder.getMvcEndpoints(), null);
+			}
+			if (managementServerProperties != null) {
+				mapping.setPrefix(this.managementServerProperties.getContextPath());
+				MvcEndpointSecurityInterceptor securityInterceptor = new MvcEndpointSecurityInterceptor(
+						this.managementServerProperties.getSecurity().isEnabled(),
+						this.managementServerProperties.getSecurity().getRoles());
+				mapping.setSecurityInterceptor(securityInterceptor);
+			}
+			if (this.mappingCustomizers != null) {
+				for (EndpointHandlerMappingCustomizer customizer : this.mappingCustomizers) {
+					customizer.customize(mapping);
+				}
+			}
+			return mapping;
+		}
+
+		@Bean
+		@Lazy
+		@ConditionalOnMissingClass("org.springframework.boot.actuate.endpoint.mvc.MvcEndpointSecurityInterceptor")
+		public EndpointHandlerMapping endpointHandlerMappingWithoutSecurityInterceptor(MvcEndpointsHolder mvcEndpointsHolder) {
+			EndpointHandlerMapping mapping = null;
+			if (this.corsProperties != null) {
+				CorsConfiguration corsConfiguration = getCorsConfiguration(this.corsProperties);
+				mapping = new EndpointHandlerMapping(mvcEndpointsHolder.getMvcEndpoints(), corsConfiguration);
+			}
+			else {
+				mapping = new EndpointHandlerMapping(mvcEndpointsHolder.getMvcEndpoints(), null);
+			}
+			if (managementServerProperties != null) {
+				mapping.setPrefix(this.managementServerProperties.getContextPath());
+			}
+			if (this.mappingCustomizers != null) {
+				for (EndpointHandlerMappingCustomizer customizer : this.mappingCustomizers) {
+					customizer.customize(mapping);
+				}
+			}
+			return mapping;
+		}
+
+		private CorsConfiguration getCorsConfiguration(EndpointCorsProperties properties) {
+			if (CollectionUtils.isEmpty(properties.getAllowedOrigins())) {
+				return null;
+			}
+			CorsConfiguration configuration = new CorsConfiguration();
+			configuration.setAllowedOrigins(properties.getAllowedOrigins());
+			if (!CollectionUtils.isEmpty(properties.getAllowedHeaders())) {
+				configuration.setAllowedHeaders(properties.getAllowedHeaders());
+			}
+			if (!CollectionUtils.isEmpty(properties.getAllowedMethods())) {
+				configuration.setAllowedMethods(properties.getAllowedMethods());
+			}
+			if (!CollectionUtils.isEmpty(properties.getExposedHeaders())) {
+				configuration.setExposedHeaders(properties.getExposedHeaders());
+			}
+			if (properties.getMaxAge() != null) {
+				configuration.setMaxAge(properties.getMaxAge());
+			}
+			if (properties.getAllowCredentials() != null) {
+				configuration.setAllowCredentials(properties.getAllowCredentials());
+			}
+			return configuration;
+		}
+	}
+
+	public static class MvcEndpointsHolder {
+
+		private final Set<MvcEndpoint> mvcEndpoints;
+
+		public MvcEndpointsHolder(Set<MvcEndpoint> mvcEndpoints) {
+			this.mvcEndpoints = mvcEndpoints;
+		}
+
+		public Set<MvcEndpoint> getMvcEndpoints() {
+			return mvcEndpoints;
+		}
+	}
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplicationUtils.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplicationUtils.java
@@ -55,9 +55,7 @@ abstract class AggregateApplicationUtils {
 						+ AggregateApplicationBuilder.ParentConfiguration.class.getName(),
 						InternalPropertyNames.SELF_CONTAINED_APP_PROPERTY_NAME + "="
 								+ selfContained)
-				.properties("management.port=-1")
-				.properties(
-						"spring.autoconfigure.exclude=org.springframework.boot.actuate.autoconfigure.EndpointAutoConfiguration");
+				.properties("management.port=-1");
 		return aggregatorParentConfiguration.run(args);
 	}
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplicationUtils.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplicationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,16 @@ import java.util.LinkedHashMap;
 import java.util.Map.Entry;
 
 import org.springframework.boot.Banner.Mode;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.SearchStrategy;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.cloud.stream.internal.InternalPropertyNames;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.messaging.SubscribableChannel;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 /**
  * Utilities for embedding applications in aggregates.
@@ -46,9 +51,11 @@ abstract class AggregateApplicationUtils {
 		aggregatorParentConfiguration.sources(sources).web(webEnvironment)
 				.headless(headless)
 				.properties("spring.jmx.default-domain="
-						+ AggregateApplicationBuilder.ParentConfiguration.class.getName(),
+								+ AggregateApplicationBuilder.ParentConfiguration.class.getName(),
 						InternalPropertyNames.SELF_CONTAINED_APP_PROPERTY_NAME + "="
-								+ selfContained);
+								+ selfContained)
+				.properties("management.port=-1")
+				.properties("spring.autoconfigure.exclude=org.springframework.boot.actuate.autoconfigure.EndpointAutoConfiguration");
 		return aggregatorParentConfiguration.run(args);
 	}
 
@@ -59,7 +66,10 @@ abstract class AggregateApplicationUtils {
 	protected static SpringApplicationBuilder embedApp(
 			ConfigurableApplicationContext parentContext, String namespace,
 			Class<?> app) {
-		return new SpringApplicationBuilder(app).web(false).main(app).bannerMode(Mode.OFF)
+		// Child context needs to enable web MVC configuration and web enabled to obtain the MVC request mapping in the child applications
+		return new SpringApplicationBuilder(new Object[]{app, RequestMappingConfiguration.class})
+				.web(false)
+				.bannerMode(Mode.OFF)
 				.properties("spring.jmx.default-domain=" + namespace)
 				.properties(
 						InternalPropertyNames.NAMESPACE_PROPERTY_NAME + "=" + namespace)
@@ -83,6 +93,16 @@ abstract class AggregateApplicationUtils {
 						sharedChannel);
 			}
 			i++;
+		}
+	}
+
+	@Configuration
+	public static class RequestMappingConfiguration {
+
+		@Bean
+		@ConditionalOnMissingBean(search = SearchStrategy.CURRENT)
+		public RequestMappingHandlerMapping requestMappingHandlerMapping() {
+			return new RequestMappingHandlerMapping();
 		}
 	}
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplicationUtils.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateApplicationUtils.java
@@ -20,6 +20,7 @@ import java.util.LinkedHashMap;
 import java.util.Map.Entry;
 
 import org.springframework.boot.Banner.Mode;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.SearchStrategy;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -51,11 +52,12 @@ abstract class AggregateApplicationUtils {
 		aggregatorParentConfiguration.sources(sources).web(webEnvironment)
 				.headless(headless)
 				.properties("spring.jmx.default-domain="
-								+ AggregateApplicationBuilder.ParentConfiguration.class.getName(),
+						+ AggregateApplicationBuilder.ParentConfiguration.class.getName(),
 						InternalPropertyNames.SELF_CONTAINED_APP_PROPERTY_NAME + "="
 								+ selfContained)
 				.properties("management.port=-1")
-				.properties("spring.autoconfigure.exclude=org.springframework.boot.actuate.autoconfigure.EndpointAutoConfiguration");
+				.properties(
+						"spring.autoconfigure.exclude=org.springframework.boot.actuate.autoconfigure.EndpointAutoConfiguration");
 		return aggregatorParentConfiguration.run(args);
 	}
 
@@ -66,8 +68,9 @@ abstract class AggregateApplicationUtils {
 	protected static SpringApplicationBuilder embedApp(
 			ConfigurableApplicationContext parentContext, String namespace,
 			Class<?> app) {
-		// Child context needs to enable web MVC configuration and web enabled to obtain the MVC request mapping in the child applications
-		return new SpringApplicationBuilder(new Object[]{app, RequestMappingConfiguration.class})
+		// Child context needs to enable web MVC configuration and web enabled to obtain
+		// the MVC request mapping in the child applications
+		return new SpringApplicationBuilder(new Object[] { app, RequestMappingConfiguration.class })
 				.web(false)
 				.bannerMode(Mode.OFF)
 				.properties("spring.jmx.default-domain=" + namespace)
@@ -97,6 +100,7 @@ abstract class AggregateApplicationUtils {
 	}
 
 	@Configuration
+	@ConditionalOnClass(name = "org.springframework.web.servlet.DispatcherServlet")
 	public static class RequestMappingConfiguration {
 
 		@Bean

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateWebConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateWebConfiguration.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.aggregate;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.EndpointCorsProperties;
+import org.springframework.boot.actuate.autoconfigure.ManagementServerProperties;
+import org.springframework.boot.actuate.endpoint.AbstractEndpoint;
+import org.springframework.boot.actuate.endpoint.mvc.AbstractEndpointMvcAdapter;
+import org.springframework.boot.actuate.endpoint.mvc.AbstractMvcEndpoint;
+import org.springframework.boot.actuate.endpoint.mvc.EndpointHandlerMapping;
+import org.springframework.boot.actuate.endpoint.mvc.EndpointHandlerMappingCustomizer;
+import org.springframework.boot.actuate.endpoint.mvc.MvcEndpoint;
+import org.springframework.boot.actuate.endpoint.mvc.MvcEndpointSecurityInterceptor;
+import org.springframework.boot.actuate.endpoint.mvc.MvcEndpoints;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.autoconfigure.web.BasicErrorController;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.handler.AbstractHandlerMethodMapping;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+
+/**
+ * Configuration class that sets up web endpoints if web enabled.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+@Configuration
+@ConditionalOnClass(name = "org.springframework.web.servlet.DispatcherServlet")
+public class AggregateWebConfiguration {
+
+	@Autowired(required = false)
+	private ManagementServerProperties managementServerProperties;
+
+	@Autowired(required = false)
+	private List<EndpointHandlerMappingCustomizer> mappingCustomizers;
+
+	@Autowired(required = false)
+	private EndpointCorsProperties corsProperties;
+
+	@Bean
+	@Lazy
+	@ConditionalOnClass(name = "org.springframework.boot.actuate.endpoint.mvc.MvcEndpointSecurityInterceptor")
+	public EndpointHandlerMapping endpointHandlerMapping(MvcEndpointsHolder mvcEndpointsHolder) {
+		EndpointHandlerMapping mapping = null;
+		if (this.corsProperties != null) {
+			CorsConfiguration corsConfiguration = getCorsConfiguration(this.corsProperties);
+			mapping = new EndpointHandlerMapping(mvcEndpointsHolder.getMvcEndpoints(), corsConfiguration);
+		}
+		else {
+			mapping = new EndpointHandlerMapping(mvcEndpointsHolder.getMvcEndpoints(), null);
+		}
+		if (managementServerProperties != null) {
+			mapping.setPrefix(this.managementServerProperties.getContextPath());
+			MvcEndpointSecurityInterceptor securityInterceptor = new MvcEndpointSecurityInterceptor(
+					this.managementServerProperties.getSecurity().isEnabled(),
+					this.managementServerProperties.getSecurity().getRoles());
+			mapping.setSecurityInterceptor(securityInterceptor);
+		}
+		if (this.mappingCustomizers != null) {
+			for (EndpointHandlerMappingCustomizer customizer : this.mappingCustomizers) {
+				customizer.customize(mapping);
+			}
+		}
+		return mapping;
+	}
+
+	@Bean
+	@Lazy
+	@ConditionalOnMissingClass("org.springframework.boot.actuate.endpoint.mvc.MvcEndpointSecurityInterceptor")
+	public EndpointHandlerMapping endpointHandlerMappingWithoutSecurityInterceptor(
+			MvcEndpointsHolder mvcEndpointsHolder) {
+		EndpointHandlerMapping mapping = null;
+		if (this.corsProperties != null) {
+			CorsConfiguration corsConfiguration = getCorsConfiguration(this.corsProperties);
+			mapping = new EndpointHandlerMapping(mvcEndpointsHolder.getMvcEndpoints(), corsConfiguration);
+		}
+		else {
+			mapping = new EndpointHandlerMapping(mvcEndpointsHolder.getMvcEndpoints(), null);
+		}
+		if (managementServerProperties != null) {
+			mapping.setPrefix(this.managementServerProperties.getContextPath());
+		}
+		if (this.mappingCustomizers != null) {
+			for (EndpointHandlerMappingCustomizer customizer : this.mappingCustomizers) {
+				customizer.customize(mapping);
+			}
+		}
+		return mapping;
+	}
+
+	private CorsConfiguration getCorsConfiguration(EndpointCorsProperties properties) {
+		if (CollectionUtils.isEmpty(properties.getAllowedOrigins())) {
+			return null;
+		}
+		CorsConfiguration configuration = new CorsConfiguration();
+		configuration.setAllowedOrigins(properties.getAllowedOrigins());
+		if (!CollectionUtils.isEmpty(properties.getAllowedHeaders())) {
+			configuration.setAllowedHeaders(properties.getAllowedHeaders());
+		}
+		if (!CollectionUtils.isEmpty(properties.getAllowedMethods())) {
+			configuration.setAllowedMethods(properties.getAllowedMethods());
+		}
+		if (!CollectionUtils.isEmpty(properties.getExposedHeaders())) {
+			configuration.setExposedHeaders(properties.getExposedHeaders());
+		}
+		if (properties.getMaxAge() != null) {
+			configuration.setMaxAge(properties.getMaxAge());
+		}
+		if (properties.getAllowCredentials() != null) {
+			configuration.setAllowCredentials(properties.getAllowCredentials());
+		}
+		return configuration;
+	}
+
+	@Bean
+	public WebEndpointConfigurer webEndpointConfigurer() {
+		return new WebEndpointConfigurer();
+	}
+
+	public class WebEndpointConfigurer implements ApplicationContextAware {
+
+		private ConfigurableApplicationContext applicationContext;
+
+		@Override
+		public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+			this.applicationContext = (ConfigurableApplicationContext) applicationContext;
+		}
+
+		void exposeWebEndpoints(List<AggregateApplicationBuilder.AppConfigurer<?>> apps) {
+			Set<MvcEndpoint> mvcEndpointsToAdd = new HashSet<>();
+			Map<RequestMappingInfo, Map<Object, Method>> requestMappingInfo = new HashMap<>();
+			for (int i = apps.size() - 1; i >= 0; i--) {
+				AggregateApplicationBuilder.AppConfigurer<?> appConfigurer = apps.get(i);
+				ConfigurableApplicationContext childContext = appConfigurer.embed();
+				// Map the Spring MVC RequestMapping into parent context
+				AbstractHandlerMethodMapping handlerMethodMapping = childContext
+						.getBean(AbstractHandlerMethodMapping.class);
+				Map<RequestMappingInfo, HandlerMethod> mappings = handlerMethodMapping.getHandlerMethods();
+				for (Map.Entry<RequestMappingInfo, HandlerMethod> mapping : mappings.entrySet()) {
+					Map<Object, Method> handlerMethodMap = new HashMap<>();
+					HandlerMethod handlerMethod = mapping.getValue();
+					if (!BasicErrorController.class.isAssignableFrom(handlerMethod.getBeanType())) {
+						Object handlerBean = handlerMethod.getBean();
+						try {
+							this.applicationContext.getBeanFactory().getBean(handlerBean.toString());
+						}
+						catch (NoSuchBeanDefinitionException e) {
+							// ChildContext is expected to have the bean as the
+							// request mapping is retrieved from the child context.
+							this.applicationContext.getBeanFactory().registerSingleton(handlerBean.toString(),
+									childContext.getBean(handlerBean.toString()));
+						}
+						handlerMethodMap.put(handlerBean, handlerMethod.getMethod());
+					}
+					requestMappingInfo.put(mapping.getKey(), handlerMethodMap);
+				}
+				// Map the actuator web endpoints
+				MvcEndpoints mvcEndpoints = new MvcEndpoints();
+				mvcEndpoints.setApplicationContext(childContext);
+				try {
+					mvcEndpoints.afterPropertiesSet();
+				}
+				catch (Exception e) {
+					throw new RuntimeException(e);
+				}
+				for (MvcEndpoint mvcEndpoint : mvcEndpoints.getEndpoints()) {
+					String namespaceValue = Pattern.compile("\\w+").matcher(appConfigurer.getNamespace()).matches()
+							? appConfigurer.getNamespace() : "child_" + i;
+					if (mvcEndpoint instanceof AbstractMvcEndpoint) {
+						((AbstractMvcEndpoint) mvcEndpoint)
+								.setPath("/" + namespaceValue + "/" + mvcEndpoint.getPath());
+					}
+					else if (mvcEndpoint instanceof AbstractEndpointMvcAdapter) {
+						((AbstractEndpointMvcAdapter) mvcEndpoint)
+								.setPath("/" + namespaceValue + "/" + mvcEndpoint.getPath());
+					}
+					else if (mvcEndpoint instanceof AbstractEndpoint) {
+						((AbstractEndpoint) mvcEndpoint)
+								.setId(namespaceValue + "_" + ((AbstractEndpoint) mvcEndpoint).getId());
+					}
+				}
+				mvcEndpointsToAdd.addAll(mvcEndpoints.getEndpoints());
+			}
+			MvcEndpointsHolder mvcEndpointsHolder = new MvcEndpointsHolder(mvcEndpointsToAdd);
+			this.applicationContext.getBeanFactory().registerSingleton("mvcEndpointsHolder", mvcEndpointsHolder);
+			// invoke lazy bean to get instantiated after setting mvcEndpoints
+			EndpointHandlerMapping endpointHandlerMapping = this.applicationContext
+					.getBean(EndpointHandlerMapping.class);
+			for (Map.Entry<RequestMappingInfo, Map<Object, Method>> mappingInfoMapEntry : requestMappingInfo
+					.entrySet()) {
+				for (Map.Entry<Object, Method> handlerMethodEntry : mappingInfoMapEntry.getValue().entrySet()) {
+					endpointHandlerMapping.registerMapping(mappingInfoMapEntry.getKey(),
+							handlerMethodEntry.getKey(), handlerMethodEntry.getValue());
+				}
+			}
+		}
+	}
+
+	public class MvcEndpointsHolder {
+
+		private final Set<MvcEndpoint> mvcEndpoints;
+
+		public MvcEndpointsHolder(Set<MvcEndpoint> mvcEndpoints) {
+			this.mvcEndpoints = mvcEndpoints;
+		}
+
+		public Set<MvcEndpoint> getMvcEndpoints() {
+			return mvcEndpoints;
+		}
+	}
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateWebConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aggregate/AggregateWebConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.autoconfigure.EndpointCorsProperties;
 import org.springframework.boot.actuate.autoconfigure.ManagementServerProperties;
+import org.springframework.boot.actuate.autoconfigure.ManagementServerPropertiesAutoConfiguration;
 import org.springframework.boot.actuate.endpoint.AbstractEndpoint;
 import org.springframework.boot.actuate.endpoint.mvc.AbstractEndpointMvcAdapter;
 import org.springframework.boot.actuate.endpoint.mvc.AbstractMvcEndpoint;
@@ -37,9 +38,16 @@ import org.springframework.boot.actuate.endpoint.mvc.EndpointHandlerMappingCusto
 import org.springframework.boot.actuate.endpoint.mvc.MvcEndpoint;
 import org.springframework.boot.actuate.endpoint.mvc.MvcEndpointSecurityInterceptor;
 import org.springframework.boot.actuate.endpoint.mvc.MvcEndpoints;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.autoconfigure.validation.ValidationAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.BasicErrorController;
+import org.springframework.boot.autoconfigure.web.DispatcherServletAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.EmbeddedServletContainerAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.HttpMessageConvertersAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.ServerPropertiesAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -59,6 +67,11 @@ import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
  */
 @Configuration
 @ConditionalOnClass(name = "org.springframework.web.servlet.DispatcherServlet")
+@ImportAutoConfiguration({ ValidationAutoConfiguration.class,
+		EmbeddedServletContainerAutoConfiguration.class, WebMvcAutoConfiguration.class,
+		DispatcherServletAutoConfiguration.class, HttpMessageConvertersAutoConfiguration.class,
+		ManagementServerPropertiesAutoConfiguration.class,
+		ServerPropertiesAutoConfiguration.class })
 public class AggregateWebConfiguration {
 
 	@Autowired(required = false)

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/aggregation/AggregationTest.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/aggregation/AggregationTest.java
@@ -35,6 +35,7 @@ import org.springframework.boot.actuate.endpoint.mvc.AbstractMvcEndpoint;
 import org.springframework.boot.actuate.endpoint.mvc.EndpointHandlerMapping;
 import org.springframework.boot.actuate.endpoint.mvc.MvcEndpoint;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.validation.ValidationAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.DispatcherServletAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.EmbeddedServletContainerAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.HttpMessageConvertersAutoConfiguration;
@@ -190,31 +191,12 @@ public class AggregationTest {
 	}
 
 	@Test
-	public void testParentArgsAndSourcesWithWebEnabled() {
+	public void testParentArgsAndSources() {
 		AggregateApplicationBuilder aggregateApplicationBuilder = new AggregateApplicationBuilder(
 				MockBinderRegistryConfiguration.class);
 		final ConfigurableApplicationContext context = aggregateApplicationBuilder.parent(DummyConfig.class)
 				.from(TestSource.class)
 				.to(TestProcessor.class)
-				.run("--server.port=0");
-		DirectFieldAccessor aggregateApplicationBuilderAccessor = new DirectFieldAccessor(aggregateApplicationBuilder);
-		List<Object> sources = (List<Object>) aggregateApplicationBuilderAccessor.getPropertyValue("parentSources");
-		assertThat(sources).containsExactlyInAnyOrder(AggregateApplicationBuilder.ParentConfiguration.class,
-				MockBinderRegistryConfiguration.class, DummyConfig.class,
-				EmbeddedServletContainerAutoConfiguration.class, WebMvcAutoConfiguration.class,
-				DispatcherServletAutoConfiguration.class, HttpMessageConvertersAutoConfiguration.class,
-				ManagementServerPropertiesAutoConfiguration.class, ServerPropertiesAutoConfiguration.class);
-		context.close();
-	}
-
-	@Test
-	public void testParentArgsAndSourcesWithWebDisabled() {
-		AggregateApplicationBuilder aggregateApplicationBuilder = new AggregateApplicationBuilder(
-				MockBinderRegistryConfiguration.class, "--foo1=bar1");
-		final ConfigurableApplicationContext context = aggregateApplicationBuilder
-				.parent(DummyConfig.class, "--foo2=bar2").web(false)
-				.from(TestSource.class)
-				.namespace("foo").to(TestProcessor.class).namespace("bar")
 				.run("--server.port=0");
 		DirectFieldAccessor aggregateApplicationBuilderAccessor = new DirectFieldAccessor(aggregateApplicationBuilder);
 		List<Object> sources = (List<Object>) aggregateApplicationBuilderAccessor.getPropertyValue("parentSources");

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/aggregation/AggregationTest.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/aggregation/AggregationTest.java
@@ -21,14 +21,25 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
 import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.boot.actuate.autoconfigure.ManagementServerPropertiesAutoConfiguration;
+import org.springframework.boot.actuate.endpoint.AbstractEndpoint;
+import org.springframework.boot.actuate.endpoint.mvc.AbstractEndpointMvcAdapter;
+import org.springframework.boot.actuate.endpoint.mvc.AbstractMvcEndpoint;
+import org.springframework.boot.actuate.endpoint.mvc.EndpointHandlerMapping;
+import org.springframework.boot.actuate.endpoint.mvc.MvcEndpoint;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.DispatcherServletAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.EmbeddedServletContainerAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.HttpMessageConvertersAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.ServerPropertiesAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;
 import org.springframework.cloud.stream.aggregate.AggregateApplicationBuilder;
 import org.springframework.cloud.stream.aggregate.AggregateApplicationBuilder.SourceConfigurer;
 import org.springframework.cloud.stream.aggregate.SharedBindingTargetRegistry;
@@ -42,11 +53,23 @@ import org.springframework.cloud.stream.utils.MockBinderRegistryConfiguration;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.stereotype.Controller;
 import org.springframework.util.ReflectionUtils;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.mvc.condition.MediaTypeExpression;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.springframework.web.bind.annotation.RequestMethod.POST;
 
 /**
  * @author Marius Bogoevici
@@ -84,6 +107,49 @@ public class AggregationTest {
 	}
 
 	@Test
+	public void aggregationWebEndpoints() {
+		aggregatedApplicationContext = new AggregateApplicationBuilder(
+				MockBinderRegistryConfiguration.class, "--server.port=0")
+						.from(TestSource.class).namespace("source")
+						.to(TestProcessor.class).namespace("processor")
+						.run();
+		SharedBindingTargetRegistry sharedBindingTargetRegistry = aggregatedApplicationContext
+				.getBean(SharedBindingTargetRegistry.class);
+		BindingTargetFactory channelFactory = aggregatedApplicationContext
+				.getBean(BindingTargetFactory.class);
+		Map<RequestMappingInfo, HandlerMethod> mappings = aggregatedApplicationContext
+				.getBean(RequestMappingHandlerMapping.class).getHandlerMethods();
+		for (Map.Entry<RequestMappingInfo, HandlerMethod> entry : mappings.entrySet()) {
+			if (!entry.getKey().getPatternsCondition().getPatterns().contains("/error")) {
+				RequestMappingInfo mappingInfo = entry.getKey();
+				assertTrue(mappingInfo.getPatternsCondition().getPatterns().size() == 1);
+				assertTrue(mappingInfo.getPatternsCondition().getPatterns().contains("/"));
+				assertTrue(mappingInfo.getMethodsCondition().getMethods().size() == 1);
+				assertTrue(mappingInfo.getMethodsCondition().getMethods().iterator().next().toString().equals("POST"));
+				for (MediaTypeExpression expression : mappingInfo.getConsumesCondition().getExpressions()) {
+					String mediaType = expression.getMediaType().toString();
+					assertTrue(mediaType.equals("text/*") || mediaType.equals("application/json")
+							|| mediaType.equals("*/*"));
+				}
+			}
+		}
+		Set<MvcEndpoint> endpoints = aggregatedApplicationContext.getBean(EndpointHandlerMapping.class).getEndpoints();
+		for (MvcEndpoint mvcEndpoint : endpoints) {
+			if (mvcEndpoint instanceof AbstractMvcEndpoint || mvcEndpoint instanceof AbstractEndpointMvcAdapter) {
+				String path = mvcEndpoint.getPath();
+				assertTrue(path.startsWith("/source") || path.startsWith("/processor"));
+			}
+			else {
+				String id = ((AbstractEndpoint) mvcEndpoint).getId();
+				assertTrue(id.startsWith("source_") || id.startsWith("processor_"));
+			}
+		}
+		assertThat(channelFactory).isNotNull();
+		assertThat(sharedBindingTargetRegistry.getAll().keySet()).hasSize(2);
+		aggregatedApplicationContext.close();
+	}
+
+	@Test
 	public void testModuleAggregationUsingSharedChannelRegistry() {
 		// test backward compatibility
 		aggregatedApplicationContext = new AggregateApplicationBuilder(
@@ -99,7 +165,7 @@ public class AggregationTest {
 	}
 
 	@Test
-	public void testParentArgsAndSources() {
+	public void testParentArgsAndSourcesWithoutWebDisabled() {
 		List<String> argsToVerify = new ArrayList<>();
 		argsToVerify.add("--foo1=bar1");
 		argsToVerify.add("--foo2=bar2");
@@ -107,7 +173,7 @@ public class AggregationTest {
 		argsToVerify.add("--server.port=0");
 		AggregateApplicationBuilder aggregateApplicationBuilder = new AggregateApplicationBuilder(
 				MockBinderRegistryConfiguration.class, "--foo1=bar1");
-		final ConfigurableApplicationContext context = aggregateApplicationBuilder
+		final ConfigurableApplicationContext context = aggregateApplicationBuilder.web(false)
 				.parent(DummyConfig.class, "--foo2=bar2")
 				.from(TestSource.class)
 				.namespace("foo").to(TestProcessor.class).namespace("bar")
@@ -119,14 +185,30 @@ public class AggregationTest {
 		assertThat(parentArgs).containsExactlyInAnyOrder(argsToVerify.toArray(new String[argsToVerify.size()]));
 		List<Object> sources = (List<Object>) aggregateApplicationBuilderAccessor.getPropertyValue("parentSources");
 		assertThat(sources).containsExactlyInAnyOrder(AggregateApplicationBuilder.ParentConfiguration.class,
+				MockBinderRegistryConfiguration.class, DummyConfig.class);
+		context.close();
+	}
+
+	@Test
+	public void testParentArgsAndSourcesWithWebEnabled() {
+		AggregateApplicationBuilder aggregateApplicationBuilder = new AggregateApplicationBuilder(
+				MockBinderRegistryConfiguration.class);
+		final ConfigurableApplicationContext context = aggregateApplicationBuilder.parent(DummyConfig.class)
+				.from(TestSource.class)
+				.to(TestProcessor.class)
+				.run("--server.port=0");
+		DirectFieldAccessor aggregateApplicationBuilderAccessor = new DirectFieldAccessor(aggregateApplicationBuilder);
+		List<Object> sources = (List<Object>) aggregateApplicationBuilderAccessor.getPropertyValue("parentSources");
+		assertThat(sources).containsExactlyInAnyOrder(AggregateApplicationBuilder.ParentConfiguration.class,
 				MockBinderRegistryConfiguration.class, DummyConfig.class,
-				EmbeddedServletContainerAutoConfiguration.class);
+				EmbeddedServletContainerAutoConfiguration.class, WebMvcAutoConfiguration.class,
+				DispatcherServletAutoConfiguration.class, HttpMessageConvertersAutoConfiguration.class,
+				ManagementServerPropertiesAutoConfiguration.class, ServerPropertiesAutoConfiguration.class);
 		context.close();
 	}
 
 	@Test
 	public void testParentArgsAndSourcesWithWebDisabled() {
-		List<String> argsToVerify = new ArrayList<>();
 		AggregateApplicationBuilder aggregateApplicationBuilder = new AggregateApplicationBuilder(
 				MockBinderRegistryConfiguration.class, "--foo1=bar1");
 		final ConfigurableApplicationContext context = aggregateApplicationBuilder
@@ -389,7 +471,20 @@ public class AggregationTest {
 
 	@EnableBinding(Source.class)
 	@EnableAutoConfiguration
+	@Controller
 	public static class TestSource {
+
+		@RequestMapping(path = "${http.pathPattern:/}", method = POST, consumes = { "text/*", "application/json" })
+		@ResponseStatus(HttpStatus.ACCEPTED)
+		public void handleRequest(@RequestBody String body,
+				@RequestHeader(HttpHeaders.CONTENT_TYPE) Object contentType) {
+		}
+
+		@RequestMapping(path = "${http.pathPattern:/}", method = POST, consumes = "*/*")
+		@ResponseStatus(HttpStatus.ACCEPTED)
+		public void handleRequest(@RequestBody byte[] body,
+				@RequestHeader(HttpHeaders.CONTENT_TYPE) Object contentType) {
+		}
 
 	}
 


### PR DESCRIPTION
 - Use namespace to prefix the endpoints' paths
 - Lazy initialize EndpointHandlerMapping once child application context is updated with its actuator endpoints
 - Disable actuator endpoints for aggregator parent context

Resolves #702