### PR TITLE
Obvious Fix - Fix typo for transforming a String message to uppercase.

### DIFF
--- a/spring-cloud-stream-core-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
+++ b/spring-cloud-stream-core-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
@@ -420,7 +420,7 @@ Or you can use a processor's channels in a transformer:
 public class TransformProcessor {
   @Transformer(inputChannel = Processor.INPUT, outputChannel = Processor.OUTPUT)
   public Object transform(String message) {
-    return message.toUpper();
+    return message.toUpperCase();
   }
 }
 ----


### PR DESCRIPTION
Resolves issue https://github.com/spring-cloud/spring-cloud-stream/issues/777.