### PR TITLE
"spring.cloud.stream.default" prefix is not used by BindingServiceProperties

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/EnvironmentEntryInitializingTreeMap.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/EnvironmentEntryInitializingTreeMap.java
@@ -90,4 +90,8 @@ public class EnvironmentEntryInitializingTreeMap<T> extends AbstractMap<String, 
 		return delegate.entrySet();
 	}
 
+	@Override
+	public boolean containsKey(Object key) {
+		return get(key) != null;
+	}
 }


### PR DESCRIPTION
Fix #782 