### PR TITLE
Add dispatching capabilities to `@StreamListener`

### DIFF
--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerAnnotationBeanPostProcessorOverrideTest.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerAnnotationBeanPostProcessorOverrideTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerAnnotationBeanPostProcessorOverrideTest.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerAnnotationBeanPostProcessorOverrideTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.config;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.Test;
+
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.annotation.StreamListener;
+import org.springframework.cloud.stream.binding.StreamListenerAnnotationBeanPostProcessor;
+import org.springframework.cloud.stream.messaging.Sink;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.handler.annotation.Payload;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.cloud.stream.config.BindingServiceConfiguration.STREAM_LISTENER_ANNOTATION_BEAN_POST_PROCESSOR_NAME;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class StreamListenerAnnotationBeanPostProcessorOverrideTest {
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testOverrideStreamListenerAnnotationBeanPostProcessor() throws Exception {
+		ConfigurableApplicationContext context = SpringApplication.run(TestPojoWithAnnotatedArguments.class,
+				"--server.port=0");
+
+		TestPojoWithAnnotatedArguments testPojoWithAnnotatedArguments = context
+				.getBean(TestPojoWithAnnotatedArguments.class);
+		Sink sink = context.getBean(Sink.class);
+		String id = UUID.randomUUID().toString();
+		sink.input().send(MessageBuilder.withPayload("{\"foo\":\"barbar" + id + "\"}")
+				.setHeader("contentType", "application/json").setHeader("testHeader", "testValue")
+				.setHeader("type", "foo").build());
+		sink.input().send(MessageBuilder.withPayload("{\"bar\":\"foofoo" + id + "\"}")
+				.setHeader("contentType", "application/json").setHeader("testHeader", "testValue")
+				.setHeader("type", "bar").build());
+		assertThat(testPojoWithAnnotatedArguments.receivedFoo).hasSize(1);
+		assertThat(testPojoWithAnnotatedArguments.receivedFoo.get(0)).hasFieldOrPropertyWithValue("foo",
+				"barbar" + id);
+		context.close();
+	}
+
+	@EnableBinding(Sink.class)
+	@EnableAutoConfiguration
+	public static class TestPojoWithAnnotatedArguments {
+
+		List<StreamListenerTestUtils.FooPojo> receivedFoo = new ArrayList<>();
+
+		List<StreamListenerTestUtils.BarPojo> receivedBar = new ArrayList<>();
+
+		@StreamListener(value = Sink.INPUT, condition = "foo")
+		public void receive(@Payload StreamListenerTestUtils.FooPojo fooPojo) {
+			this.receivedFoo.add(fooPojo);
+		}
+
+		/**
+		 * Overrides the default {@link StreamListenerAnnotationBeanPostProcessor}.
+		 */
+		@Bean(name = STREAM_LISTENER_ANNOTATION_BEAN_POST_PROCESSOR_NAME)
+		public static BeanPostProcessor streamListenerAnnotationBeanPostProcessor() {
+			return new StreamListenerAnnotationBeanPostProcessor() {
+				@Override
+				protected StreamListener postProcessAnnotation(StreamListener originalAnnotation, Method annotatedMethod) {
+					Map<String,Object> attributes = new HashMap<>(AnnotationUtils.getAnnotationAttributes(originalAnnotation));
+					attributes.put("condition", "headers['type']=='" + originalAnnotation.condition() + "'");
+					return AnnotationUtils.synthesizeAnnotation(attributes, StreamListener.class, annotatedMethod);
+				}
+			};
+		}
+	}
+}

--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerAnnotationBeanPostProcessorOverrideTest.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerAnnotationBeanPostProcessorOverrideTest.java
@@ -73,9 +73,7 @@ public class StreamListenerAnnotationBeanPostProcessorOverrideTest {
 	public static class TestPojoWithAnnotatedArguments {
 
 		List<StreamListenerTestUtils.FooPojo> receivedFoo = new ArrayList<>();
-
-		List<StreamListenerTestUtils.BarPojo> receivedBar = new ArrayList<>();
-
+		
 		@StreamListener(value = Sink.INPUT, condition = "foo")
 		public void receive(@Payload StreamListenerTestUtils.FooPojo fooPojo) {
 			this.receivedFoo.add(fooPojo);

--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerDuplicateMappingTests.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerDuplicateMappingTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.stream.config;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.springframework.beans.factory.BeanCreationException;
@@ -24,9 +23,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.annotation.StreamListener;
+import org.springframework.cloud.stream.binding.StreamListenerErrorMessages;
+import org.springframework.cloud.stream.messaging.Processor;
 import org.springframework.cloud.stream.messaging.Sink;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.annotation.SendTo;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
@@ -39,15 +41,14 @@ public class StreamListenerDuplicateMappingTests {
 
 	@Test
 	@SuppressWarnings("unchecked")
-	@Ignore
-	public void testDuplicateMapping() {
+	public void testMultipleMappingsWithReturnValue() {
 		ConfigurableApplicationContext context = null;
 		try {
-			context = SpringApplication.run(TestDuplicateMapping.class, "--server.port=0");
+			context = SpringApplication.run(TestMultipleMappingsWithReturnValue.class, "--server.port=0");
 			fail("Exception expected on duplicate mapping");
 		}
-		catch (BeanCreationException e) {
-			assertThat(e.getCause().getMessage()).startsWith("Duplicate @StreamListener mapping");
+		catch (IllegalArgumentException e) {
+			assertThat(e.getMessage()).startsWith(StreamListenerErrorMessages.MULTIPLE_VALUE_RETURNING_METHODS);
 		}
 		finally {
 			if (context != null) {
@@ -74,16 +75,20 @@ public class StreamListenerDuplicateMappingTests {
 		}
 	}
 
-	@EnableBinding(Sink.class)
+	@EnableBinding(Processor.class)
 	@EnableAutoConfiguration
-	public static class TestDuplicateMapping {
+	public static class TestMultipleMappingsWithReturnValue {
 
-		@StreamListener(Sink.INPUT)
-		public void receive(Message<String> fooMessage) {
+		@StreamListener(Processor.INPUT)
+		@SendTo(Processor.OUTPUT)
+		public String receive(Message<String> fooMessage) {
+			return null;
 		}
 
-		@StreamListener(Sink.INPUT)
-		public void receiveDuplicateMapping(Message<String> fooMessage) {
+		@StreamListener(Processor.INPUT)
+		@SendTo(Processor.OUTPUT)
+		public String receiveDuplicateMapping(Message<String> fooMessage) {
+			return null;
 		}
 	}
 

--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerDuplicateMappingTests.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerDuplicateMappingTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.stream.config;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.springframework.beans.factory.BeanCreationException;
@@ -38,6 +39,7 @@ public class StreamListenerDuplicateMappingTests {
 
 	@Test
 	@SuppressWarnings("unchecked")
+	@Ignore
 	public void testDuplicateMapping() {
 		ConfigurableApplicationContext context = null;
 		try {

--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerWithConditionsTest.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerWithConditionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerWithConditionsTest.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerWithConditionsTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.config;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.Test;
+
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.annotation.Input;
+import org.springframework.cloud.stream.annotation.StreamListener;
+import org.springframework.cloud.stream.messaging.Sink;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.handler.annotation.Payload;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class StreamListenerWithConditionsTest {
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testAnnotatedArgumentsWithConditionalClass() throws Exception {
+		ConfigurableApplicationContext context = SpringApplication.run(TestPojoWithAnnotatedArguments.class,
+				"--server.port=0");
+
+		TestPojoWithAnnotatedArguments testPojoWithAnnotatedArguments = context
+				.getBean(TestPojoWithAnnotatedArguments.class);
+		Sink sink = context.getBean(Sink.class);
+		String id = UUID.randomUUID().toString();
+		sink.input().send(MessageBuilder.withPayload("{\"foo\":\"barbar" + id + "\"}")
+				.setHeader("contentType", "application/json").setHeader("testHeader", "testValue")
+				.setHeader("type", "foo").build());
+		sink.input().send(MessageBuilder.withPayload("{\"bar\":\"foofoo" + id + "\"}")
+				.setHeader("contentType", "application/json").setHeader("testHeader", "testValue")
+				.setHeader("type", "bar").build());
+		sink.input().send(MessageBuilder.withPayload("{\"bar\":\"foofoo" + id + "\"}")
+				.setHeader("contentType", "application/json").setHeader("testHeader", "testValue")
+				.setHeader("type", "qux").build());
+		assertThat(testPojoWithAnnotatedArguments.receivedFoo).hasSize(1);
+		assertThat(testPojoWithAnnotatedArguments.receivedFoo.get(0)).hasFieldOrPropertyWithValue("foo",
+				"barbar" + id);
+		assertThat(testPojoWithAnnotatedArguments.receivedBar).hasSize(1);
+		assertThat(testPojoWithAnnotatedArguments.receivedBar.get(0)).hasFieldOrPropertyWithValue("bar",
+				"foofoo" + id);
+		context.close();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testConditionalFailsWithDeclarativeMethod() throws Exception {
+		try {
+			ConfigurableApplicationContext context = SpringApplication.run(TestConditionalOnDeclarativeMethodFails.class,
+					"--server.port=0");
+			context.close();
+			fail("Context creation failure expected");
+		} catch (BeanCreationException e) {
+			assertThat(e).hasRootCauseInstanceOf(IllegalArgumentException.class);
+			assertThat(e.getCause()).hasMessageContaining("Cannot set a condition when using @StreamListener in declarative mode");
+		}
+	}
+
+	@EnableBinding(Sink.class)
+	@EnableAutoConfiguration
+	public static class TestPojoWithAnnotatedArguments {
+
+		List<StreamListenerTestUtils.FooPojo> receivedFoo = new ArrayList<>();
+
+		List<StreamListenerTestUtils.BarPojo> receivedBar = new ArrayList<>();
+
+		@StreamListener(value = Sink.INPUT, condition = "headers['type']=='foo'")
+		public void receive(@Payload StreamListenerTestUtils.FooPojo fooPojo) {
+			this.receivedFoo.add(fooPojo);
+		}
+
+		@StreamListener(target = Sink.INPUT, condition = "headers['type']=='bar'")
+		public void receive(@Payload StreamListenerTestUtils.BarPojo barPojo) {
+			this.receivedBar.add(barPojo);
+		}
+
+	}
+
+	@EnableBinding(Sink.class)
+	@EnableAutoConfiguration
+	public static class TestConditionalOnDeclarativeMethodFails {
+
+		List<StreamListenerTestUtils.FooPojo> receivedFoo = new ArrayList<>();
+
+		List<StreamListenerTestUtils.BarPojo> receivedBar = new ArrayList<>();
+
+		@StreamListener(condition = "headers['type']=='foo'")
+		public void receive(@Input("input") MessageChannel input) {
+			// do nothing
+		}
+	}
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/annotation/StreamListener.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/annotation/StreamListener.java
@@ -23,6 +23,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.springframework.cloud.stream.binding.StreamListenerParameterAdapter;
+import org.springframework.core.annotation.AliasFor;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 
 /**
@@ -131,6 +132,18 @@ public @interface StreamListener {
 	/**
 	 * The name of the binding target (e.g. channel) that the method subscribes to.
 	 */
+	@AliasFor("target")
 	String value() default "";
 
+	/**
+	 * The name of the binding target (e.g. channel) that the method subscribes to.
+	 * @return
+	 */
+	@AliasFor("value")
+	String target()  default "";
+
+	/**
+	 * A condition that must be met by all items that are dispatched to this method.
+	 */
+	String condition() default "";
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/annotation/StreamListener.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/annotation/StreamListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -131,19 +131,21 @@ public @interface StreamListener {
 
 	/**
 	 * The name of the binding target (e.g. channel) that the method subscribes to.
+	 * @return the name of the binding target.
 	 */
 	@AliasFor("target")
 	String value() default "";
 
 	/**
 	 * The name of the binding target (e.g. channel) that the method subscribes to.
-	 * @return
+	 * @return the name of the binding target.
 	 */
 	@AliasFor("value")
 	String target()  default "";
 
 	/**
 	 * A condition that must be met by all items that are dispatched to this method.
+	 * @return a SpEL expression that must evaluate to a {@code boolean} value.
 	 */
 	String condition() default "";
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/DispatchingStreamListenerMessageHandler.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/DispatchingStreamListenerMessageHandler.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binding;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.Expression;
+import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.MessagingException;
+import org.springframework.util.Assert;
+
+/**
+ * An {@link AbstractReplyProducingMessageHandler} that delegates
+ * @author Marius Bogoevici
+ */
+final class DispatchingStreamListenerMessageHandler extends AbstractReplyProducingMessageHandler {
+
+	private final Collection<ConditionalStreamListenerHandler> handlerMethods;
+
+	private final EvaluationContext evaluationContext;
+
+	DispatchingStreamListenerMessageHandler(Collection<ConditionalStreamListenerHandler> handlerMethods,
+			EvaluationContext evaluationContext) {
+		Assert.notEmpty(handlerMethods, "'handlerMethods' cannot be empty");
+		Assert.notNull(evaluationContext, "'evaluationContext' cannot be empty");
+		this.handlerMethods = handlerMethods;
+		this.evaluationContext = evaluationContext;
+	}
+
+	@Override
+	protected boolean shouldCopyRequestHeaders() {
+		return false;
+	}
+
+	@Override
+	protected Object handleRequestMessage(Message<?> requestMessage) {
+		Collection<ConditionalStreamListenerHandler> matchingHandlers = findMatchingHandlers(requestMessage);
+		if (matchingHandlers.size() == 0) {
+			if (logger.isWarnEnabled()) {
+				logger.warn("Cannot find a @StreamListener matching " + requestMessage);
+			}
+			return null;
+		}
+		else if (matchingHandlers.size() > 1) {
+			for (ConditionalStreamListenerHandler matchingHandler : matchingHandlers) {
+				if (!matchingHandler.isVoid()) {
+					throw new MessagingException(
+							"Multiple matching methods cannot return values for " + requestMessage);
+				}
+			}
+			for (ConditionalStreamListenerHandler matchingMethod : matchingHandlers) {
+				matchingMethod.handleMessage(requestMessage);
+			}
+			return null;
+		}
+		else {
+			final ConditionalStreamListenerHandler singleMatchingHandler = matchingHandlers.iterator().next();
+			singleMatchingHandler.handleMessage(requestMessage);
+			return null;
+		}
+	}
+
+	private Collection<ConditionalStreamListenerHandler> findMatchingHandlers(Message<?> message) {
+		ArrayList<ConditionalStreamListenerHandler> matchingMethods = new ArrayList<>();
+		for (ConditionalStreamListenerHandler conditionalStreamListenerHandlerMethod : this.handlerMethods) {
+			if (conditionalStreamListenerHandlerMethod.getCondition() == null) {
+				matchingMethods.add(conditionalStreamListenerHandlerMethod);
+			}
+			else {
+				Object value = conditionalStreamListenerHandlerMethod.getCondition().getValue(this.evaluationContext, message);
+				if (Boolean.class.isAssignableFrom(value.getClass())) {
+					if ((Boolean) value) {
+						matchingMethods.add(conditionalStreamListenerHandlerMethod);
+					}
+				}
+				else if (Boolean.valueOf(String.valueOf(value))) {
+					matchingMethods.add(conditionalStreamListenerHandlerMethod);
+				}
+			}
+		}
+		return matchingMethods;
+	}
+
+	static class ConditionalStreamListenerHandler implements MessageHandler {
+
+		private Expression condition;
+
+		private StreamListenerMessageHandler streamListenerMessageHandler;
+
+		ConditionalStreamListenerHandler(Expression condition, StreamListenerMessageHandler streamListenerMessageHandler) {
+			this.condition = condition;
+			this.streamListenerMessageHandler = streamListenerMessageHandler;
+		}
+
+		public Expression getCondition() {
+			return condition;
+		}
+
+		public boolean isVoid() {
+			return this.streamListenerMessageHandler.isVoid();
+		}
+
+		@Override
+		public void handleMessage(Message<?> message) throws MessagingException {
+			this.streamListenerMessageHandler.handleMessage(message);
+		}
+	}
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/DispatchingStreamListenerMessageHandler.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/DispatchingStreamListenerMessageHandler.java
@@ -59,17 +59,12 @@ final class DispatchingStreamListenerMessageHandler extends AbstractReplyProduci
 		Collection<ConditionalStreamListenerHandler> matchingHandlers = findMatchingHandlers(requestMessage);
 		if (matchingHandlers.size() == 0) {
 			if (logger.isWarnEnabled()) {
-				logger.warn("Cannot find a @StreamListener matching " + requestMessage.toString());
+				logger.warn("Cannot find a @StreamListener matching for message with id: "
+						+ requestMessage.getHeaders().getId());
 			}
 			return null;
 		}
 		else if (matchingHandlers.size() > 1) {
-			for (ConditionalStreamListenerHandler matchingHandler : matchingHandlers) {
-				if (!matchingHandler.isVoid()) {
-					throw new MessagingException(
-							"Multiple matching methods cannot return values for " + requestMessage);
-				}
-			}
 			for (ConditionalStreamListenerHandler matchingMethod : matchingHandlers) {
 				matchingMethod.handleMessage(requestMessage);
 			}
@@ -107,6 +102,9 @@ final class DispatchingStreamListenerMessageHandler extends AbstractReplyProduci
 
 		ConditionalStreamListenerHandler(Expression condition,
 				StreamListenerMessageHandler streamListenerMessageHandler) {
+			Assert.notNull(streamListenerMessageHandler, "the message handler cannot be null");
+			Assert.isTrue(condition == null || streamListenerMessageHandler.isVoid(),
+					"cannot specify a condition and a return value at the same time");
 			this.condition = condition;
 			this.streamListenerMessageHandler = streamListenerMessageHandler;
 		}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerErrorMessages.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerErrorMessages.java
@@ -62,4 +62,8 @@ public abstract class StreamListenerErrorMessages {
 			+ " and @Output annotation as a method parameter";
 
 	public static final String CONDITION_ON_DECLARATIVE_METHOD = "Cannot set a condition when using @StreamListener in declarative mode";
+
+	public static final String CONDITION_ON_METHOD_RETURNING_VALUE = "Cannot set a condition for methods that return a value";
+
+	public static final String MULTIPLE_VALUE_RETURNING_METHODS = "If multiple @StreamListener methods are listening to the same binding target, none of them may return a value";
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerErrorMessages.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerErrorMessages.java
@@ -60,4 +60,6 @@ public abstract class StreamListenerErrorMessages {
 
 	public static final String INVALID_OUTPUT_VALUES = "Cannot set both output (@Output/@SendTo) method annotation value"
 			+ " and @Output annotation as a method parameter";
+
+	public static final String CONDITION_ON_DECLARATIVE_METHOD = "Cannot set a condition when using @StreamListener in declarative mode";
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerMessageHandler.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerMessageHandler.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binding;
+
+import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class StreamListenerMessageHandler extends AbstractReplyProducingMessageHandler {
+
+	private final InvocableHandlerMethod invocableHandlerMethod;
+
+	StreamListenerMessageHandler(InvocableHandlerMethod invocableHandlerMethod) {
+		this.invocableHandlerMethod = invocableHandlerMethod;
+	}
+
+	@Override
+	protected boolean shouldCopyRequestHeaders() {
+		return false;
+	}
+
+	public boolean isVoid() {
+		return invocableHandlerMethod.isVoid();
+	}
+
+	@Override
+	protected Object handleRequestMessage(Message<?> requestMessage) {
+		try {
+			return this.invocableHandlerMethod.invoke(requestMessage);
+		} catch (Exception e) {
+			if (e instanceof MessagingException) {
+				throw (MessagingException) e;
+			} else {
+				throw new MessagingException(requestMessage,
+						"Exception thrown while invoking " + this.invocableHandlerMethod.getShortLogMessage(), e);
+			}
+		}
+	}
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerMessageHandler.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerMessageHandler.java
@@ -23,6 +23,7 @@ import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
 
 /**
  * @author Marius Bogoevici
+ * @since 1.2
  */
 public class StreamListenerMessageHandler extends AbstractReplyProducingMessageHandler {
 
@@ -45,10 +46,12 @@ public class StreamListenerMessageHandler extends AbstractReplyProducingMessageH
 	protected Object handleRequestMessage(Message<?> requestMessage) {
 		try {
 			return this.invocableHandlerMethod.invoke(requestMessage);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			if (e instanceof MessagingException) {
 				throw (MessagingException) e;
-			} else {
+			}
+			else {
 				throw new MessagingException(requestMessage,
 						"Exception thrown while invoking " + this.invocableHandlerMethod.getShortLogMessage(), e);
 			}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerMethodUtils.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerMethodUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerMethodUtils.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerMethodUtils.java
@@ -61,7 +61,7 @@ public class StreamListenerMethodUtils {
 
 	protected static void validateStreamListenerMethod(Method method, int inputAnnotationCount,
 			int outputAnnotationCount, String methodAnnotatedInboundName, String methodAnnotatedOutboundName,
-			boolean isDeclarative) {
+			boolean isDeclarative, StreamListener streamListener) {
 		int methodArgumentsLength = method.getParameterTypes().length;
 		if (!isDeclarative) {
 			Assert.isTrue(inputAnnotationCount == 0 && outputAnnotationCount == 0,
@@ -83,6 +83,8 @@ public class StreamListenerMethodUtils {
 			Assert.isTrue(outputAnnotationCount == 0, StreamListenerErrorMessages.INVALID_OUTPUT_VALUES);
 		}
 		if (isDeclarative) {
+			Assert.isTrue(!StringUtils.hasText(streamListener.condition()),
+					StreamListenerErrorMessages.CONDITION_ON_DECLARATIVE_METHOD);
 			for (int parameterIndex = 0; parameterIndex < methodArgumentsLength; parameterIndex++) {
 				MethodParameter methodParameter = MethodParameter.forMethodOrConstructor(method, parameterIndex);
 				if (methodParameter.hasParameterAnnotation(Input.class)) {

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerMethodUtils.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerMethodUtils.java
@@ -61,7 +61,7 @@ public class StreamListenerMethodUtils {
 
 	protected static void validateStreamListenerMethod(Method method, int inputAnnotationCount,
 			int outputAnnotationCount, String methodAnnotatedInboundName, String methodAnnotatedOutboundName,
-			boolean isDeclarative, StreamListener streamListener) {
+			boolean isDeclarative, String condition) {
 		int methodArgumentsLength = method.getParameterTypes().length;
 		if (!isDeclarative) {
 			Assert.isTrue(inputAnnotationCount == 0 && outputAnnotationCount == 0,
@@ -82,8 +82,12 @@ public class StreamListenerMethodUtils {
 		if (StringUtils.hasText(methodAnnotatedOutboundName)) {
 			Assert.isTrue(outputAnnotationCount == 0, StreamListenerErrorMessages.INVALID_OUTPUT_VALUES);
 		}
+		if (!Void.TYPE.equals(method.getReturnType())) {
+			Assert.isTrue(!StringUtils.hasText(condition),
+					StreamListenerErrorMessages.CONDITION_ON_METHOD_RETURNING_VALUE);
+		}
 		if (isDeclarative) {
-			Assert.isTrue(!StringUtils.hasText(streamListener.condition()),
+			Assert.isTrue(!StringUtils.hasText(condition),
 					StreamListenerErrorMessages.CONDITION_ON_DECLARATIVE_METHOD);
 			for (int parameterIndex = 0; parameterIndex < methodArgumentsLength; parameterIndex++) {
 				MethodParameter methodParameter = MethodParameter.forMethodOrConstructor(method, parameterIndex);

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -193,7 +193,6 @@ public class BindingServiceConfiguration {
 	@Configuration
 	protected static class PostProcessorConfiguration {
 
-		public static final String DEFAULT_STREAM_LISTENER_ANNOTATION_BEAN_POST_PROCESSOR_NAME = "streamListenerAnnotationBeanPostProcessor";
 		private BinderAwareChannelResolver binderAwareChannelResolver;
 
 		@Bean

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceConfiguration.java
@@ -52,7 +52,6 @@ import org.springframework.cloud.stream.converter.CompositeMessageConverterFacto
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.expression.PropertyAccessor;
 import org.springframework.integration.channel.PublishSubscribeChannel;
 import org.springframework.integration.config.IntegrationEvaluationContextFactoryBean;
@@ -80,6 +79,8 @@ import org.springframework.util.CollectionUtils;
 public class BindingServiceConfiguration {
 
 	private static final String ERROR_CHANNEL_NAME = "error";
+
+	public static final String STREAM_LISTENER_ANNOTATION_BEAN_POST_PROCESSOR_NAME = "streamListenerAnnotationBeanPostProcessor";
 
 	@Autowired(required = false)
 	private ObjectMapper objectMapper;
@@ -175,12 +176,6 @@ public class BindingServiceConfiguration {
 		return messageHandlerMethodFactory;
 	}
 
-	@Bean
-	public static StreamListenerAnnotationBeanPostProcessor bindToAnnotationBeanPostProcessor(
-			@Lazy BinderAwareChannelResolver binderAwareChannelResolver,
-			@Lazy MessageHandlerMethodFactory messageHandlerMethodFactory) {
-		return new StreamListenerAnnotationBeanPostProcessor(binderAwareChannelResolver, messageHandlerMethodFactory);
-	}
 
 	@Bean
 	// provided for backwards compatibility scenarios
@@ -189,10 +184,16 @@ public class BindingServiceConfiguration {
 		return new ChannelBindingServiceProperties(bindingServiceProperties);
 	}
 
+	@Bean(name = STREAM_LISTENER_ANNOTATION_BEAN_POST_PROCESSOR_NAME)
+	public static StreamListenerAnnotationBeanPostProcessor streamListenerAnnotationBeanPostProcessor() {
+		return new StreamListenerAnnotationBeanPostProcessor();
+	}
+
 	// IMPORTANT: Nested class to avoid instantiating all of the above early
 	@Configuration
 	protected static class PostProcessorConfiguration {
 
+		public static final String DEFAULT_STREAM_LISTENER_ANNOTATION_BEAN_POST_PROCESSOR_NAME = "streamListenerAnnotationBeanPostProcessor";
 		private BinderAwareChannelResolver binderAwareChannelResolver;
 
 		@Bean


### PR DESCRIPTION
`@StreamListener` has support for a `condition` parameter,
that contains a SpEL expression that is evaluated before the
method is invoked.

Fix #682

Move StreamListenerMessageHandler as a top level class

Use dispatching and add test

Refactor dispatching mechanism

Throw error when conditions are used in declarative mode

Make StreamListenerAnnotationBeanPostProcessor overridable