### PR TITLE
Copy existing `BindingProperties` values when replacing bound map

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceProperties.java
@@ -127,9 +127,10 @@ public class BindingServiceProperties implements ApplicationContextAware, Enviro
 		if (environment instanceof ConfigurableEnvironment) {
 			// override the bindings store with the environment-initializing version if in
 			// a Spring context
+			Map<String, BindingProperties> delegate = new TreeMap<String, BindingProperties>(String.CASE_INSENSITIVE_ORDER);
+			delegate.putAll(this.bindings);
 			this.bindings = new EnvironmentEntryInitializingTreeMap<>((ConfigurableEnvironment) environment,
-					BindingProperties.class, "spring.cloud.stream.default",
-					new TreeMap<String, BindingProperties>(String.CASE_INSENSITIVE_ORDER));
+					BindingProperties.class, "spring.cloud.stream.default", delegate);
 		}
 	}
 


### PR DESCRIPTION
Fix #810

(backport to 1.1.x)