### PR TITLE
AbstractMessageChannelBinder can have a `null` headers list

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
@@ -82,7 +82,7 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 	public AbstractMessageChannelBinder(boolean supportsHeadersNatively, String[] headersToEmbed,
 										PP provisioningProvider) {
 		this.supportsHeadersNatively = supportsHeadersNatively;
-		this.headersToEmbed = headersToEmbed;
+		this.headersToEmbed = headersToEmbed == null ? new String[0] : headersToEmbed;
 		this.provisioningProvider = provisioningProvider;
 	}
 


### PR DESCRIPTION
Fix #812