### PR TITLE
Incorrect Confluent Schema Registry URL & Automatic Registration

### DIFF
--- a/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/AvroSchemaRegistryClientMessageConverter.java
+++ b/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/AvroSchemaRegistryClientMessageConverter.java
@@ -194,8 +194,8 @@ public class AvroSchemaRegistryClientMessageConverter extends AbstractAvroMessag
 				String schemaContents = this.schemaRegistryClient.fetch(schemaReference);
 				schema = parser.parse(schemaContents);
 			} catch (SchemaNotFoundException e) {
-				if (isDynamicSchemaGenerationEnabled()) {
-					schema = extractSchemaForWriting(payload);
+				schema = extractSchemaForWriting(payload);
+				if (schema != null) {
 					SchemaRegistrationResponse schemaRegistrationResponse = this.schemaRegistryClient.register(
 							toSubject(schema), AVRO_FORMAT, schema.toString(true));
 				}

--- a/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/AvroSchemaRegistryClientMessageConverter.java
+++ b/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/AvroSchemaRegistryClientMessageConverter.java
@@ -193,7 +193,8 @@ public class AvroSchemaRegistryClientMessageConverter extends AbstractAvroMessag
 			try {
 				String schemaContents = this.schemaRegistryClient.fetch(schemaReference);
 				schema = parser.parse(schemaContents);
-			} catch (SchemaNotFoundException e) {
+			}
+			catch (SchemaNotFoundException e) {
 				schema = extractSchemaForWriting(payload);
 				if (schema != null) {
 					SchemaRegistrationResponse schemaRegistrationResponse = this.schemaRegistryClient.register(

--- a/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/client/ConfluentSchemaRegistryClient.java
+++ b/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/client/ConfluentSchemaRegistryClient.java
@@ -23,8 +23,6 @@ import java.util.Map;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.springframework.cache.annotation.CacheConfig;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cloud.stream.schema.SchemaNotFoundException;
 import org.springframework.cloud.stream.schema.SchemaReference;
 import org.springframework.cloud.stream.schema.SchemaRegistrationResponse;
@@ -41,7 +39,6 @@ import org.springframework.web.client.RestTemplate;
  * @author Vinicius Carvalho
  * @author Marius Bogoevici
  */
-@CacheConfig(cacheNames = "schemas")
 public class ConfluentSchemaRegistryClient implements SchemaRegistryClient {
 
 	private RestTemplate template;
@@ -86,7 +83,6 @@ public class ConfluentSchemaRegistryClient implements SchemaRegistryClient {
 	}
 
 	@Override
-	@Cacheable
 	public String fetch(SchemaReference schemaReference) {
 		String path = String.format("/subjects/%s/versions/%d",
 				schemaReference.getSubject(), schemaReference.getVersion());
@@ -113,7 +109,6 @@ public class ConfluentSchemaRegistryClient implements SchemaRegistryClient {
 	}
 
 	@Override
-	@Cacheable
 	public String fetch(int id) {
 		String path = String.format("/schemas/ids/%d", id);
 		HttpHeaders headers = new HttpHeaders();

--- a/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/client/ConfluentSchemaRegistryClient.java
+++ b/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/client/ConfluentSchemaRegistryClient.java
@@ -23,19 +23,25 @@ import java.util.Map;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cloud.stream.schema.SchemaNotFoundException;
 import org.springframework.cloud.stream.schema.SchemaReference;
 import org.springframework.cloud.stream.schema.SchemaRegistrationResponse;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.Assert;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 /**
  * @author Vinicius Carvalho
  * @author Marius Bogoevici
  */
+@CacheConfig(cacheNames = "schemas")
 public class ConfluentSchemaRegistryClient implements SchemaRegistryClient {
 
 	private RestTemplate template;
@@ -80,20 +86,34 @@ public class ConfluentSchemaRegistryClient implements SchemaRegistryClient {
 	}
 
 	@Override
+	@Cacheable
 	public String fetch(SchemaReference schemaReference) {
-		String path = String.format("/schemas/ids/%d", schemaReference.getVersion());
+		String path = String.format("/subjects/%s/versions/%d",
+				schemaReference.getSubject(), schemaReference.getVersion());
 		HttpHeaders headers = new HttpHeaders();
 		headers.put("Accept",
 				Arrays.asList("application/vnd.schemaregistry.v1+json", "application/vnd.schemaregistry+json",
 						"application/json"));
 		headers.add("Content-Type", "application/vnd.schemaregistry.v1+json");
 		HttpEntity<String> request = new HttpEntity<>("", headers);
-		ResponseEntity<Map> response = this.template.exchange(this.endpoint + path, HttpMethod.GET, request, Map
-				.class);
-		return (String) response.getBody().get("schema");
+		try {
+			ResponseEntity<Map> response = this.template.exchange(this.endpoint + path, HttpMethod.GET, request,
+					Map.class);
+			return (String) response.getBody().get("schema");
+		}
+		catch (HttpClientErrorException e) {
+			if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
+				throw new SchemaNotFoundException(
+						String.format("Could not find schema for reference: %s", schemaReference));
+			}
+			else {
+				throw e;
+			}
+		}
 	}
 
 	@Override
+	@Cacheable
 	public String fetch(int id) {
 		String path = String.format("/schemas/ids/%d", id);
 		HttpHeaders headers = new HttpHeaders();
@@ -102,8 +122,19 @@ public class ConfluentSchemaRegistryClient implements SchemaRegistryClient {
 						"application/json"));
 		headers.add("Content-Type", "application/vnd.schemaregistry.v1+json");
 		HttpEntity<String> request = new HttpEntity<>("", headers);
-		ResponseEntity<Map> response = this.template.exchange(this.endpoint + path, HttpMethod.GET, request, Map
-				.class);
-		return (String) response.getBody().get("schema");
+		try {
+			ResponseEntity<Map> response = this.template.exchange(this.endpoint + path, HttpMethod.GET, request,
+					Map.class);
+			return (String) response.getBody().get("schema");
+		}
+		catch (HttpClientErrorException e) {
+			if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
+				throw new SchemaNotFoundException(
+						String.format("Could not find schema with id: %s", id));
+			}
+			else {
+				throw e;
+			}
+		}
 	}
 }


### PR DESCRIPTION
We encountered two problems while trying to get Spring Cloud Stream Schema running with the Confluent Platform:

1. When trying to fetch Schemas from the registry by extracting the Schema reference from the MIME type, the _ConfluentSchemaRegistryClient_ tries to get the Schema by its Id (which is unknown) instead of getting it by its _subject_ and _version_
1. Schemas that can be extracted from the payload are only registered automatically if the Schema reference can not be extracted from the MIME type. They should also be registered automatically if they can not be found in the registry, but can be extracted from the payload.