### PR TITLE
Fix StreamListener method with no explicit declarative method params

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerAnnotationBeanPostProcessor.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerAnnotationBeanPostProcessor.java
@@ -71,7 +71,7 @@ import org.springframework.util.StringUtils;
  */
 public class StreamListenerAnnotationBeanPostProcessor
 		implements BeanPostProcessor, ApplicationContextAware, BeanFactoryAware, SmartInitializingSingleton,
-				InitializingBean {
+		InitializingBean {
 
 	private static final SpelExpressionParser SPEL_EXPRESSION_PARSER = new SpelExpressionParser();
 
@@ -100,7 +100,7 @@ public class StreamListenerAnnotationBeanPostProcessor
 	private BeanExpressionContext expressionContext;
 
 	@Override
-	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@SuppressWarnings({"rawtypes", "unchecked"})
 	public final void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
 		this.applicationContext = (ConfigurableApplicationContext) applicationContext;
 	}
@@ -182,7 +182,7 @@ public class StreamListenerAnnotationBeanPostProcessor
 	 * the postprocessor.
 	 *
 	 * @param originalAnnotation the original annotation
-	 * @param annotatedMethod the method on which the annotation has been found
+	 * @param annotatedMethod    the method on which the annotation has been found
 	 * @return the postprocessed {@link StreamListener} annotation
 	 */
 	protected StreamListener postProcessAnnotation(StreamListener originalAnnotation, Method annotatedMethod) {
@@ -199,7 +199,7 @@ public class StreamListenerAnnotationBeanPostProcessor
 						.getValue(methodParameter.getParameterAnnotation(Input.class));
 				Assert.isTrue(StringUtils.hasText(inboundName), StreamListenerErrorMessages.INVALID_INBOUND_NAME);
 				Assert.isTrue(
-						isDeclarativeMethodParameter(this.applicationContext.getBean(inboundName), methodParameter, true),
+						isDeclarativeMethodParameter(this.applicationContext.getBean(inboundName), methodParameter),
 						StreamListenerErrorMessages.INVALID_DECLARATIVE_METHOD_PARAMETERS);
 				return true;
 			}
@@ -208,25 +208,26 @@ public class StreamListenerAnnotationBeanPostProcessor
 						.getValue(methodParameter.getParameterAnnotation(Output.class));
 				Assert.isTrue(StringUtils.hasText(outboundName), StreamListenerErrorMessages.INVALID_OUTBOUND_NAME);
 				Assert.isTrue(
-						isDeclarativeMethodParameter(this.applicationContext.getBean(outboundName), methodParameter, true),
+						isDeclarativeMethodParameter(this.applicationContext.getBean(outboundName), methodParameter),
 						StreamListenerErrorMessages.INVALID_DECLARATIVE_METHOD_PARAMETERS);
 				return true;
 			}
 			if (StringUtils.hasText(methodAnnotatedOutboundName)) {
 				return isDeclarativeMethodParameter(this.applicationContext.getBean(methodAnnotatedOutboundName),
-						methodParameter, false);
+						methodParameter);
 			}
 			if (StringUtils.hasText(methodAnnotatedInboundName)) {
 				return isDeclarativeMethodParameter(this.applicationContext.getBean(methodAnnotatedInboundName),
-						methodParameter, false);
+						methodParameter);
 			}
 		}
 		return false;
 	}
 
-	private boolean isDeclarativeMethodParameter(Object targetBean, MethodParameter methodParameter, boolean hasParameterAnnoation) {
+	private boolean isDeclarativeMethodParameter(Object targetBean, MethodParameter methodParameter) {
 		if (targetBean != null) {
-			if (hasParameterAnnoation && methodParameter.getParameterType().isAssignableFrom(targetBean.getClass())) {
+			if (!methodParameter.getParameterType().equals(Object.class)
+					&& methodParameter.getParameterType().isAssignableFrom(targetBean.getClass())) {
 				return true;
 			}
 			for (StreamListenerParameterAdapter<?, Object> streamListenerParameterAdapter : this.streamListenerParameterAdapters) {
@@ -238,7 +239,7 @@ public class StreamListenerAnnotationBeanPostProcessor
 		return false;
 	}
 
-	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@SuppressWarnings({"rawtypes", "unchecked"})
 	private void invokeSetupMethodOnListenedChannel(Method method, Object bean, String inboundName,
 			String outboundName) {
 		Object[] arguments = new Object[method.getParameterTypes().length];

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerAnnotationBeanPostProcessor.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerAnnotationBeanPostProcessor.java
@@ -199,7 +199,7 @@ public class StreamListenerAnnotationBeanPostProcessor
 						.getValue(methodParameter.getParameterAnnotation(Input.class));
 				Assert.isTrue(StringUtils.hasText(inboundName), StreamListenerErrorMessages.INVALID_INBOUND_NAME);
 				Assert.isTrue(
-						isDeclarativeMethodParameter(this.applicationContext.getBean(inboundName), methodParameter),
+						isDeclarativeMethodParameter(this.applicationContext.getBean(inboundName), methodParameter, true),
 						StreamListenerErrorMessages.INVALID_DECLARATIVE_METHOD_PARAMETERS);
 				return true;
 			}
@@ -208,25 +208,25 @@ public class StreamListenerAnnotationBeanPostProcessor
 						.getValue(methodParameter.getParameterAnnotation(Output.class));
 				Assert.isTrue(StringUtils.hasText(outboundName), StreamListenerErrorMessages.INVALID_OUTBOUND_NAME);
 				Assert.isTrue(
-						isDeclarativeMethodParameter(this.applicationContext.getBean(outboundName), methodParameter),
+						isDeclarativeMethodParameter(this.applicationContext.getBean(outboundName), methodParameter, true),
 						StreamListenerErrorMessages.INVALID_DECLARATIVE_METHOD_PARAMETERS);
 				return true;
 			}
 			if (StringUtils.hasText(methodAnnotatedOutboundName)) {
 				return isDeclarativeMethodParameter(this.applicationContext.getBean(methodAnnotatedOutboundName),
-						methodParameter);
+						methodParameter, false);
 			}
 			if (StringUtils.hasText(methodAnnotatedInboundName)) {
 				return isDeclarativeMethodParameter(this.applicationContext.getBean(methodAnnotatedInboundName),
-						methodParameter);
+						methodParameter, false);
 			}
 		}
 		return false;
 	}
 
-	private boolean isDeclarativeMethodParameter(Object targetBean, MethodParameter methodParameter) {
+	private boolean isDeclarativeMethodParameter(Object targetBean, MethodParameter methodParameter, boolean hasParameterAnnoation) {
 		if (targetBean != null) {
-			if (methodParameter.getParameterType().isAssignableFrom(targetBean.getClass())) {
+			if (hasParameterAnnoation && methodParameter.getParameterType().isAssignableFrom(targetBean.getClass())) {
 				return true;
 			}
 			for (StreamListenerParameterAdapter<?, Object> streamListenerParameterAdapter : this.streamListenerParameterAdapters) {


### PR DESCRIPTION
 - Make sure to check if the method parameters have annotation specified to conclude the method as `declarative` otherwise, it is `handler` method.
 - Add test

Resolves #844