### PR TITLE
Kafka GH-21: Don't Override User Partition

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/MessageConverterConfigurer.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/MessageConverterConfigurer.java
@@ -275,12 +275,16 @@ public class MessageConverterConfigurer implements MessageChannelConfigurer, Bea
 
 		@Override
 		public Message<?> preSend(Message<?> message, MessageChannel channel) {
-			int partition = this.partitionHandler.determinePartition(message);
-			return MessageConverterConfigurer.this.messageBuilderFactory
-					.fromMessage(message)
-					.setHeader(BinderHeaders.PARTITION_HEADER, partition)
-					.build();
-
+			if (!message.getHeaders().containsKey(BinderHeaders.PARTITION_HEADER)) {
+				int partition = this.partitionHandler.determinePartition(message);
+				return MessageConverterConfigurer.this.messageBuilderFactory
+						.fromMessage(message)
+						.setHeader(BinderHeaders.PARTITION_HEADER, partition)
+						.build();
+			}
+			else {
+				return message;
+			}
 		}
 	}
 


### PR DESCRIPTION
See spring-cloud/spring-cloud-stream-binder-kafka#109

If the user app sets the `BinderHeader.PARTITION_HEADER`, don't override it in the binder.