### PR TITLE
Avoid eager creation of bound target beans

### DIFF
--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerHandlerMethodTests.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerHandlerMethodTests.java
@@ -30,10 +30,14 @@ import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.annotation.Input;
 import org.springframework.cloud.stream.annotation.Output;
 import org.springframework.cloud.stream.annotation.StreamListener;
+import org.springframework.cloud.stream.binding.StreamListenerErrorMessages;
 import org.springframework.cloud.stream.messaging.Processor;
 import org.springframework.cloud.stream.messaging.Sink;
 import org.springframework.cloud.stream.test.binder.MessageCollector;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.integration.annotation.Router;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -48,7 +52,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 import static org.springframework.cloud.stream.binding.StreamListenerErrorMessages.AMBIGUOUS_MESSAGE_HANDLER_METHOD_ARGUMENTS;
 import static org.springframework.cloud.stream.binding.StreamListenerErrorMessages.INPUT_AT_STREAM_LISTENER;
-import static org.springframework.cloud.stream.binding.StreamListenerErrorMessages.INVALID_BOUND_TARGET_NAME;
 import static org.springframework.cloud.stream.binding.StreamListenerErrorMessages.INVALID_DECLARATIVE_METHOD_PARAMETERS;
 import static org.springframework.cloud.stream.binding.StreamListenerErrorMessages.INVALID_INBOUND_NAME;
 import static org.springframework.cloud.stream.binding.StreamListenerErrorMessages.INVALID_OUTBOUND_NAME;
@@ -85,7 +88,22 @@ public class StreamListenerHandlerMethodTests {
 		MessageCollector messageCollector = context.getBean(MessageCollector.class);
 		Message<?> result = messageCollector.forChannel(processor.output()).poll(1000, TimeUnit.MILLISECONDS);
 		assertThat(result).isNotNull();
-		assertThat(result.getPayload()).isEqualTo(result.getPayload().toString().toUpperCase());
+		assertThat(result.getPayload()).isEqualTo(testMessage.toUpperCase());
+		context.close();
+	}
+
+	@Test
+	public void testStreamListenerMethodWithTargetBeanFromOutside() throws Exception {
+		ConfigurableApplicationContext context = SpringApplication.run(TestStreamListenerMethodWithTargetBeanFromOutside.class, "--server.port=0");
+		Sink sink = context.getBean(Sink.class);
+		final String testMessageToSend = "testing";
+		sink.input().send(MessageBuilder.withPayload(testMessageToSend).build());
+		DirectChannel directChannel = (DirectChannel) context.getBean(testMessageToSend.toUpperCase(), MessageChannel.class);
+		MessageCollector messageCollector = context.getBean(MessageCollector.class);
+		Message<?> result = messageCollector.forChannel(directChannel).poll(1000, TimeUnit.MILLISECONDS);
+		sink.input().send(MessageBuilder.withPayload(testMessageToSend).build());
+		assertThat(result).isNotNull();
+		assertThat(result.getPayload()).isEqualTo(testMessageToSend.toUpperCase());
 		context.close();
 	}
 
@@ -139,9 +157,9 @@ public class StreamListenerHandlerMethodTests {
 			SpringApplication.run(TestMethodInvalidInboundName.class, "--server.port=0");
 			fail("Exception expected on using invalid inbound name");
 		}
-		catch (Exception e) {
-			assertThat(e.getCause()).isInstanceOf(IllegalStateException.class);
-			assertThat(e.getCause()).hasMessageContaining(INVALID_BOUND_TARGET_NAME);
+		catch (BeanCreationException e) {
+			assertThat(e.getCause()).isInstanceOf(IllegalArgumentException.class);
+			assertThat(e.getCause()).hasMessageContaining(StreamListenerErrorMessages.INVALID_DECLARATIVE_METHOD_PARAMETERS);
 		}
 	}
 
@@ -301,6 +319,24 @@ public class StreamListenerHandlerMethodTests {
 		@SendTo(Processor.OUTPUT)
 		public String receive(Object received) {
 			return received.toString().toUpperCase();
+		}
+	}
+
+	@EnableBinding(Sink.class)
+	@EnableAutoConfiguration
+	public static class TestStreamListenerMethodWithTargetBeanFromOutside {
+
+		private static final String ROUTER_QUEUE = "routeInstruction";
+
+		@StreamListener(Sink.INPUT)
+		@SendTo(ROUTER_QUEUE)
+		public Message<String> convertMessageBody(Message<String> message) {
+			return new DefaultMessageBuilderFactory().withPayload(message.getPayload().toUpperCase()).build();
+		}
+
+		@Router(inputChannel = ROUTER_QUEUE)
+		public String route(String message) {
+			return message.toUpperCase();
 		}
 	}
 

--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerHandlerMethodTests.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerHandlerMethodTests.java
@@ -48,6 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 import static org.springframework.cloud.stream.binding.StreamListenerErrorMessages.AMBIGUOUS_MESSAGE_HANDLER_METHOD_ARGUMENTS;
 import static org.springframework.cloud.stream.binding.StreamListenerErrorMessages.INPUT_AT_STREAM_LISTENER;
+import static org.springframework.cloud.stream.binding.StreamListenerErrorMessages.INVALID_BOUND_TARGET_NAME;
 import static org.springframework.cloud.stream.binding.StreamListenerErrorMessages.INVALID_DECLARATIVE_METHOD_PARAMETERS;
 import static org.springframework.cloud.stream.binding.StreamListenerErrorMessages.INVALID_INBOUND_NAME;
 import static org.springframework.cloud.stream.binding.StreamListenerErrorMessages.INVALID_OUTBOUND_NAME;
@@ -138,9 +139,9 @@ public class StreamListenerHandlerMethodTests {
 			SpringApplication.run(TestMethodInvalidInboundName.class, "--server.port=0");
 			fail("Exception expected on using invalid inbound name");
 		}
-		catch (BeanCreationException e) {
-			assertThat(e.getCause()).isInstanceOf(NoSuchBeanDefinitionException.class);
-			assertThat(e.getCause()).hasMessageContaining("'invalid'");
+		catch (Exception e) {
+			assertThat(e.getCause()).isInstanceOf(IllegalStateException.class);
+			assertThat(e.getCause()).hasMessageContaining(INVALID_BOUND_TARGET_NAME);
 		}
 	}
 

--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerWithAnnotatedInputOutputArgsTests.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerWithAnnotatedInputOutputArgsTests.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
+import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.cloud.stream.annotation.EnableBinding;
@@ -57,9 +58,9 @@ public class StreamListenerWithAnnotatedInputOutputArgsTests {
 	public void testInputOutputArgsWithMoreParameters() {
 		try {
 			SpringApplication.run(TestInputOutputArgsWithMoreParameters.class, "--server.port=0");
-			fail("Expected exception: "+ INVALID_DECLARATIVE_METHOD_PARAMETERS);
+			fail("Expected exception: " + INVALID_DECLARATIVE_METHOD_PARAMETERS);
 		}
-		catch (Exception e) {
+		catch (BeanCreationException e) {
 			assertThat(e.getMessage()).contains(INVALID_DECLARATIVE_METHOD_PARAMETERS);
 		}
 	}
@@ -70,9 +71,9 @@ public class StreamListenerWithAnnotatedInputOutputArgsTests {
 			SpringApplication.run(TestInputOutputArgsWithInvalidBindableTarget.class, "--server.port=0");
 			fail("Exception expected on using invalid bindable target as method parameter");
 		}
-		catch (Exception e) {
-			assertThat(e.getCause()).isInstanceOf(IllegalStateException.class);
-			assertThat(e.getCause()).hasMessageContaining(StreamListenerErrorMessages.INVALID_BOUND_TARGET_NAME);
+		catch (BeanCreationException e) {
+			assertThat(e.getCause()).isInstanceOf(IllegalArgumentException.class);
+			assertThat(e.getCause()).hasMessageContaining(StreamListenerErrorMessages.INVALID_DECLARATIVE_METHOD_PARAMETERS);
 		}
 	}
 

--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerWithAnnotatedInputOutputArgsTests.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerWithAnnotatedInputOutputArgsTests.java
@@ -20,13 +20,13 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
-import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.annotation.Input;
 import org.springframework.cloud.stream.annotation.Output;
 import org.springframework.cloud.stream.annotation.StreamListener;
+import org.springframework.cloud.stream.binding.StreamListenerErrorMessages;
 import org.springframework.cloud.stream.messaging.Processor;
 import org.springframework.cloud.stream.test.binder.MessageCollector;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -71,8 +71,8 @@ public class StreamListenerWithAnnotatedInputOutputArgsTests {
 			fail("Exception expected on using invalid bindable target as method parameter");
 		}
 		catch (Exception e) {
-			assertThat(e.getCause()).isInstanceOf(NoSuchBeanDefinitionException.class);
-			assertThat(e.getCause()).hasMessageContaining("'invalid'");
+			assertThat(e.getCause()).isInstanceOf(IllegalStateException.class);
+			assertThat(e.getCause()).hasMessageContaining(StreamListenerErrorMessages.INVALID_BOUND_TARGET_NAME);
 		}
 	}
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerAnnotationBeanPostProcessor.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerAnnotationBeanPostProcessor.java
@@ -226,24 +226,27 @@ public class StreamListenerAnnotationBeanPostProcessor
 	private boolean isDeclarativeMethodParameter(String targetBeanName, MethodParameter methodParameter) {
 		try {
 			Class targetBeanClass = this.applicationContext.getType(targetBeanName);
-			if (targetBeanClass != null) {
-				if (!methodParameter.getParameterType().equals(Object.class)
-						&& (targetBeanClass.isAssignableFrom(methodParameter.getParameterType()) ||
-						methodParameter.getParameterType().isAssignableFrom(targetBeanClass))) {
-					return true;
-				}
-				if (!this.streamListenerParameterAdapters.isEmpty()) {
-					Object targetBean = this.applicationContext.getBean(targetBeanName);
-					for (StreamListenerParameterAdapter<?, Object> streamListenerParameterAdapter : this.streamListenerParameterAdapters) {
-						if (streamListenerParameterAdapter.supports(targetBean.getClass(), methodParameter)) {
-							return true;
-						}
-					}
-				}
+			if (!methodParameter.getParameterType().equals(Object.class)
+					&& (targetBeanClass.isAssignableFrom(methodParameter.getParameterType()) ||
+					methodParameter.getParameterType().isAssignableFrom(targetBeanClass))) {
+				return true;
 			}
 		}
 		catch (NoSuchBeanDefinitionException e) {
-			throw new IllegalStateException(String.format("%s: %s: ", targetBeanName, StreamListenerErrorMessages.INVALID_BOUND_TARGET_NAME, targetBeanName),  e);
+			// ignore as the bean definition might not exist yet.
+		}
+		if (!this.streamListenerParameterAdapters.isEmpty()) {
+			try {
+				Object targetBean = this.applicationContext.getBean(targetBeanName);
+				for (StreamListenerParameterAdapter<?, Object> streamListenerParameterAdapter : this.streamListenerParameterAdapters) {
+					if (streamListenerParameterAdapter.supports(targetBean.getClass(), methodParameter)) {
+						return true;
+					}
+				}
+			}
+			catch (BeansException e) {
+				// ignore as the bean definition might not exist yet.
+			}
 		}
 		return false;
 	}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerErrorMessages.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerErrorMessages.java
@@ -37,8 +37,6 @@ public abstract class StreamListenerErrorMessages {
 
 	public static final String INVALID_OUTBOUND_NAME = "The @Output annotation must have the name of an input as value";
 
-	public static final String INVALID_BOUND_TARGET_NAME = "The bound target name is not valid";
-
 	public static final String ATLEAST_ONE_OUTPUT = "At least one output must be specified";
 
 	public static final String SEND_TO_MULTIPLE_DESTINATIONS = "Multiple destinations cannot be specified";

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerErrorMessages.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerErrorMessages.java
@@ -37,6 +37,8 @@ public abstract class StreamListenerErrorMessages {
 
 	public static final String INVALID_OUTBOUND_NAME = "The @Output annotation must have the name of an input as value";
 
+	public static final String INVALID_BOUND_TARGET_NAME = "The bound target name is not valid";
+
 	public static final String ATLEAST_ONE_OUTPUT = "At least one output must be specified";
 
 	public static final String SEND_TO_MULTIPLE_DESTINATIONS = "Multiple destinations cannot be specified";


### PR DESCRIPTION
 - At StreamListenerBeanPostProcessor, avoid eager creation of inbound/outbound target beans whenever possible
  - Use `applicationContext.getType(targetName)` instead of `applicationContext.getBean(targetName)` which checks the type of target beans from bean factory instead of creating the bean eagerly.
  - For declarative method invocation, `applicationContext.getBean` is needed as it requires the actual bean as its argument

Resolves #767