### PR TITLE
Leniently support treating input Strings as JSON when converting to POJO

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/ObjectStringMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/ObjectStringMessageConverter.java
@@ -44,6 +44,12 @@ public class ObjectStringMessageConverter extends AbstractMessageConverter {
 		return true;
 	}
 
+	@Override
+	protected boolean canConvertFrom(Message<?> message, Class<?> targetClass) {
+		// only supports the conversion to String
+		return supportsMimeType(message.getHeaders()) && String.class == targetClass;
+	}
+
 	protected Object convertFromInternal(Message<?> message, Class<?> targetClass, Object conversionHint) {
 		if (message.getPayload() != null) {
 			if (message.getPayload() instanceof byte[]) {


### PR DESCRIPTION
Fixes #871

* Only support conversion based on `text/plain` header if target type is String;

(Note: requires backport to 1.1.x)