### PR TITLE
Make spring-boot actuator as optional dependency

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderFactoryWithHealthIndicator.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderFactoryWithHealthIndicator.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder;
+
+import java.util.Map;
+
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.CompositeHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.health.OrderedHealthAggregator;
+import org.springframework.context.ConfigurableApplicationContext;
+
+/**
+ * {@link BinderFactory} that extends {@link DefaultBinderFactory} and provides {@link HealthIndicator} support.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+public class BinderFactoryWithHealthIndicator extends DefaultBinderFactory {
+
+	private volatile CompositeHealthIndicator bindersHealthIndicator;
+
+	public BinderFactoryWithHealthIndicator(Map<String, BinderConfiguration> binderConfigurations) {
+		super(binderConfigurations);
+	}
+
+	public void setBindersHealthIndicator(CompositeHealthIndicator bindersHealthIndicator) {
+		this.bindersHealthIndicator = bindersHealthIndicator;
+	}
+
+	@Override
+	protected <T> Binder<T, ?, ?> getBinderInstance(String binderConfigurationName) {
+		Binder<T, ?, ?> binder = super.getBinderInstance(binderConfigurationName);
+		if (this.bindersHealthIndicator != null) {
+			OrderedHealthAggregator healthAggregator = new OrderedHealthAggregator();
+			ConfigurableApplicationContext binderProducingContext = this.getBinderInstanceCache().get(binderConfigurationName).getBinderContext();
+			Map<String, HealthIndicator> indicators = binderProducingContext.getBeansOfType(HealthIndicator.class);
+			// if there are no health indicators in the child context, we just mark the binder's health as unknown
+			// this can happen due to the fact that configuration is inherited
+			HealthIndicator binderHealthIndicator =
+					indicators.isEmpty() ? new DefaultHealthIndicator() : new CompositeHealthIndicator(
+							healthAggregator, indicators);
+			this.bindersHealthIndicator.addHealthIndicator(binderConfigurationName, binderHealthIndicator);
+		}
+		return binder;
+	}
+
+	private static class DefaultHealthIndicator extends AbstractHealthIndicator {
+
+		@Override
+		protected void doHealthCheck(Health.Builder builder) throws Exception {
+			builder.unknown();
+		}
+	}
+}
+

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindingService.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindingService.java
@@ -152,12 +152,13 @@ public class BindingService {
 
 	@SuppressWarnings("unchecked")
 	private <T> Binder<T, ?, ?> getBinder(String channelName, Class<T> bindableType) {
-		String transport = this.bindingServiceProperties.getBinder(channelName);
-		return binderFactory.getBinder(transport, bindableType);
+		String binderConfigurationName = this.bindingServiceProperties.getBinder(channelName);
+		return binderFactory.getBinder(binderConfigurationName, bindableType);
 	}
 
 	/**
 	 * Provided for backwards compatibility. Will be removed in a future version.
+	 *
 	 * @return
 	 */
 	@Deprecated

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceConfiguration.java
@@ -68,6 +68,7 @@ import org.springframework.util.CollectionUtils;
 
 /**
  * Configuration class that provides necessary beans for {@link MessageChannel} binding.
+ *
  * @author Dave Syer
  * @author David Turanski
  * @author Marius Bogoevici

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingAutoConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelBindingAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,22 +16,14 @@
 
 package org.springframework.cloud.stream.config;
 
-import java.util.List;
-
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.actuate.autoconfigure.ConditionalOnEnabledHealthIndicator;
-import org.springframework.boot.actuate.autoconfigure.EndpointAutoConfiguration;
-import org.springframework.boot.actuate.health.CompositeHealthIndicator;
-import org.springframework.boot.actuate.health.OrderedHealthAggregator;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cloud.stream.binding.Bindable;
 import org.springframework.cloud.stream.binding.BindingService;
-import org.springframework.cloud.stream.endpoint.ChannelsEndpoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.integration.scheduling.PollerMetadata;
 import org.springframework.messaging.MessageChannel;
 
@@ -41,34 +33,20 @@ import org.springframework.messaging.MessageChannel;
  *
  * @author Dave Syer
  * @author Marius Bogoevici
+ * @author Ilayaperumal Gopinathan
  */
 @Configuration
 @ConditionalOnBean(BindingService.class)
 @EnableConfigurationProperties(DefaultPollerProperties.class)
-@AutoConfigureBefore(EndpointAutoConfiguration.class)
+@Import(ChannelsEndpointConfiguration.class)
 public class ChannelBindingAutoConfiguration {
 
 	@Autowired
 	private DefaultPollerProperties poller;
 
-	@Autowired(required = false)
-	private List<Bindable> adapters;
-
 	@Bean(name = PollerMetadata.DEFAULT_POLLER)
 	@ConditionalOnMissingBean(PollerMetadata.class)
 	public PollerMetadata defaultPoller() {
 		return this.poller.getPollerMetadata();
-	}
-
-	@Bean
-	public ChannelsEndpoint channelsEndpoint(BindingServiceProperties properties) {
-		return new ChannelsEndpoint(this.adapters, properties);
-	}
-
-	@Bean
-	@ConditionalOnEnabledHealthIndicator("binders")
-	@ConditionalOnMissingBean(name = "bindersHealthIndicator")
-	public CompositeHealthIndicator bindersHealthIndicator() {
-		return new CompositeHealthIndicator(new OrderedHealthAggregator());
 	}
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelsEndpointConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ChannelsEndpointConfiguration.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.config;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.EndpointAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.cloud.stream.binding.Bindable;
+import org.springframework.cloud.stream.endpoint.ChannelsEndpoint;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Dave Syer
+ * @author Marius Bogoevici
+ * @author Ilayaperumal Gopinathan
+ */
+@Configuration
+@ConditionalOnClass(name = "org.springframework.boot.actuate.health.HealthIndicator")
+@AutoConfigureAfter(EndpointAutoConfiguration.class)
+public class ChannelsEndpointConfiguration {
+
+	@Autowired(required = false)
+	private List<Bindable> adapters;
+
+	@Bean
+	public ChannelsEndpoint channelsEndpoint(BindingServiceProperties properties) {
+		return new ChannelsEndpoint(this.adapters, properties);
+	}
+}


### PR DESCRIPTION
 - BinderFactoryConfiguration has a conditional configuration that creates `BinderFactory` with binder health indicators only if the spring-boot `actuator` is in classpath
 - Move Channels endpoint configuration into a separate conditional configuration class

Resolves #869