### PR TITLE
Internal refactoring - expose header embedding and serialization

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
@@ -165,7 +165,7 @@ public abstract class AbstractBinder<T, C extends ConsumerProperties, P extends 
 		return name + GROUP_INDEX_DELIMITER + (StringUtils.hasText(group) ? group : "default");
 	}
 
-	final MessageValues serializePayloadIfNecessary(Message<?> message) {
+	protected final MessageValues serializePayloadIfNecessary(Message<?> message) {
 		Object originalPayload = message.getPayload();
 		Object originalContentType = message.getHeaders().get(MessageHeaders.CONTENT_TYPE);
 
@@ -183,7 +183,7 @@ public abstract class AbstractBinder<T, C extends ConsumerProperties, P extends 
 		return messageValues;
 	}
 
-	private byte[] serializePayloadIfNecessary(Object originalPayload) {
+	protected final byte[] serializePayloadIfNecessary(Object originalPayload) {
 		if (originalPayload instanceof byte[]) {
 			return (byte[]) originalPayload;
 		}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
@@ -57,9 +57,6 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 
 	protected static final ExpressionParser EXPRESSION_PARSER = new SpelExpressionParser();
 
-	private final EmbeddedHeadersMessageConverter embeddedHeadersMessageConverter = new
-			EmbeddedHeadersMessageConverter();
-
 	/**
 	 * Indicates whether the implementation and the message broker have
 	 * native support for message headers. If false, headers will be
@@ -279,12 +276,12 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 			MessageValues messageValues;
 			if (this.extractEmbeddedHeaders) {
 				try {
-					messageValues = AbstractMessageChannelBinder.this.embeddedHeadersMessageConverter.extractHeaders(
-							(Message<byte[]>) requestMessage, true);
+					messageValues = EmbeddedHeaderUtils.extractHeaders((Message<byte[]>) requestMessage,
+							true);
 				}
 				catch (Exception e) {
 					AbstractMessageChannelBinder.this.logger.error(
-							EmbeddedHeadersMessageConverter.decodeExceptionMessage(
+							EmbeddedHeaderUtils.decodeExceptionMessage(
 									requestMessage), e);
 					messageValues = new MessageValues(requestMessage);
 				}
@@ -342,8 +339,7 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 				if (originalContentType instanceof MimeType) {
 					transformed.put(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE, originalContentType.toString());
 				}
-				payload = AbstractMessageChannelBinder.this.embeddedHeadersMessageConverter.embedHeaders(transformed,
-						this.embeddedHeaders);
+				payload = EmbeddedHeaderUtils.embedHeaders(transformed, this.embeddedHeaders);
 			}
 			else {
 				payload = (byte[]) transformed.getPayload();


### PR DESCRIPTION
Fix #888

- Rename `EmbeddedHeaderMessageConverter` to `EmbeddedHeaderUtils`;
- Add method to populate default header set;
- Make `serializePayloadIfNecessary` protected so it can be accessed by subclasses;