### PR TITLE
Allow `StreamListenerParameterAdapter` to be applied more broadly

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerAnnotationBeanPostProcessor.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerAnnotationBeanPostProcessor.java
@@ -271,16 +271,16 @@ public class StreamListenerAnnotationBeanPostProcessor
 			if (targetReferenceValue != null) {
 				Assert.isInstanceOf(String.class, targetReferenceValue, "Annotation value must be a String");
 				Object targetBean = this.applicationContext.getBean((String) targetReferenceValue);
-				if (parameterType.isAssignableFrom(targetBean.getClass())) {
-					arguments[parameterIndex] = targetBean;
+				// Iterate existing parameter adapters first
+				for (StreamListenerParameterAdapter<?, Object> streamListenerParameterAdapter : this.streamListenerParameterAdapters) {
+					if (streamListenerParameterAdapter.supports(targetBean.getClass(), methodParameter)) {
+						arguments[parameterIndex] = streamListenerParameterAdapter.adapt(targetBean, methodParameter);
+						break;
+					}
 				}
-				else {
-					for (StreamListenerParameterAdapter<?, Object> streamListenerParameterAdapter : this.streamListenerParameterAdapters) {
-						if (streamListenerParameterAdapter.supports(targetBean.getClass(), methodParameter)) {
-							arguments[parameterIndex] = streamListenerParameterAdapter.adapt(targetBean,
-									methodParameter);
-							break;
-						}
+				if (arguments[parameterIndex] == null) {
+					if (parameterType.isAssignableFrom(targetBean.getClass())) {
+						arguments[parameterIndex] = targetBean;
 					}
 				}
 				Assert.notNull(arguments[parameterIndex], "Cannot convert argument " + parameterIndex + " of " + method


### PR DESCRIPTION
Fix #890