### PR TITLE
Convert `byte[]` via `text/plain` to String

### DIFF
--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/TextPlainConversionTest.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/TextPlainConversionTest.java
@@ -64,6 +64,16 @@ public class TextPlainConversionTest {
 	}
 
 	@Test
+	public void testByteArrayConversionOnOutput() throws Exception {
+		testProcessor.output().send(MessageBuilder.withPayload("Bar".getBytes()).build());
+		@SuppressWarnings("unchecked")
+		Message<?> received = ((TestSupportBinder) binderFactory.getBinder(null, MessageChannel.class))
+				.messageCollector().forChannel(testProcessor.output()).poll(1, TimeUnit.SECONDS);
+		assertThat(received).isNotNull();
+		assertThat(received.getPayload()).isEqualTo("Bar");
+	}
+
+	@Test
 	public void testTextPlainConversionOnInputAndOutput() throws Exception {
 		testProcessor.input().send(MessageBuilder.withPayload(new Foo("Bar")).build());
 		@SuppressWarnings("unchecked")

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/ObjectStringMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/ObjectStringMessageConverter.java
@@ -64,7 +64,11 @@ public class ObjectStringMessageConverter extends AbstractMessageConverter {
 
 	protected Object convertToInternal(Object payload, MessageHeaders headers, Object conversionHint) {
 		if (payload != null) {
-			return payload.toString();
+			if ((payload instanceof byte[])) {
+				return new String((byte[]) payload, Charset.forName("UTF-8"));
+			} else {
+				return payload.toString();
+			}
 		}
 		else {
 			return null;


### PR DESCRIPTION
Fix #898

When the payload is `byte[]` ensure that the
String is the String representation, not the
toString() conversion result.