### PR TITLE
Handle placeholders and SpEL in metrics properties

### DIFF
--- a/spring-cloud-stream-metrics/src/test/java/org/springframework/cloud/stream/metrics/ApplicationMetricsExporterTests.java
+++ b/spring-cloud-stream-metrics/src/test/java/org/springframework/cloud/stream/metrics/ApplicationMetricsExporterTests.java
@@ -214,6 +214,8 @@ public class ApplicationMetricsExporterTests {
 				"--PLATFORM_APP_ID=123-id-bar",
 				"--spring.cloud.application.guid=${PLATFORM_APP_NAME}.${PLATFORM_APP_ID}",
 				"--spring.cloud.application.guid.expression=#{'${PLATFORM_APP_NAME}' + '..' + '${PLATFORM_APP_ID}'}",
+				"--spring.cloud.application.guid.default.prop=${app.name.not.found:time-source}",
+				"--spring.cloud.application.guid.default.env=${APP_NAME_NOT_FOUND:time-source}",
 				"--spring.metrics.export.delay-millis=500",
 				"--spring.cloud.stream.bindings." + Emitter.APPLICATION_METRICS + ".destination=foo",
 				"--spring.metrics.export.includes=integration**",
@@ -231,6 +233,10 @@ public class ApplicationMetricsExporterTests {
 				.isEqualTo("123-name-foo.123-id-bar");
 		Assertions.assertThat(applicationMetrics.getProperties().get("spring.cloud.application.guid.expression"))
 				.isEqualTo("123-name-foo..123-id-bar");
+		Assertions.assertThat(applicationMetrics.getProperties().get("spring.cloud.application.guid.default.prop"))
+				.isEqualTo("time-source");
+		Assertions.assertThat(applicationMetrics.getProperties().get("spring.cloud.application.guid.default.env"))
+				.isEqualTo("time-source");
 		Assert.assertFalse(CollectionUtils.isEmpty(applicationMetrics.getProperties()));
 		Assert.assertTrue(applicationMetrics.getProperties().get("spring.test.env.syntax").equals("testing"));
 		applicationContext.close();

--- a/spring-cloud-stream-metrics/src/test/java/org/springframework/cloud/stream/metrics/ApplicationMetricsExporterTests.java
+++ b/spring-cloud-stream-metrics/src/test/java/org/springframework/cloud/stream/metrics/ApplicationMetricsExporterTests.java
@@ -20,7 +20,7 @@ import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
+import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -201,6 +201,38 @@ public class ApplicationMetricsExporterTests {
 		Assert.assertFalse(CollectionUtils.isEmpty(applicationMetrics.getProperties()));
 		Assert.assertTrue(applicationMetrics.getProperties().get("spring.test.env.syntax")
 				.equals("testing"));
+		applicationContext.close();
+	}
+
+	@Test
+	public void propertiesWithPlaceholdersAndExpressions() throws Exception {
+		ConfigurableApplicationContext applicationContext = SpringApplication.run(
+				BinderExporterApplication.class,
+				"--server.port=0",
+				"--spring.jmx.enabled=false",
+				"--PLATFORM_APP_NAME=123-name-foo",
+				"--PLATFORM_APP_ID=123-id-bar",
+				"--spring.cloud.application.guid=${PLATFORM_APP_NAME}.${PLATFORM_APP_ID}",
+				"--spring.cloud.application.guid.expression=#{'${PLATFORM_APP_NAME}' + '..' + '${PLATFORM_APP_ID}'}",
+				"--spring.metrics.export.delay-millis=500",
+				"--spring.cloud.stream.bindings." + Emitter.APPLICATION_METRICS + ".destination=foo",
+				"--spring.metrics.export.includes=integration**",
+				"--spring.cloud.stream.metrics.properties=spring**");
+		Emitter emitterSource = applicationContext.getBean(Emitter.class);
+		MessageCollector collector = applicationContext.getBean(MessageCollector.class);
+		Message<?> message = collector.forChannel(emitterSource.applicationMetrics()).poll(1000,
+				TimeUnit.MILLISECONDS);
+		Assert.assertNotNull(message);
+		ObjectMapper mapper = applicationContext.getBean(ObjectMapper.class);
+		ApplicationMetrics applicationMetrics = mapper.readValue((String) message.getPayload(), ApplicationMetrics.class);
+		Assert.assertTrue(contains("integration.channel.errorChannel.errorRate.mean",
+				applicationMetrics.getMetrics()));
+		Assertions.assertThat(applicationMetrics.getProperties().get("spring.cloud.application.guid"))
+				.isEqualTo("123-name-foo.123-id-bar");
+		Assertions.assertThat(applicationMetrics.getProperties().get("spring.cloud.application.guid.expression"))
+				.isEqualTo("123-name-foo..123-id-bar");
+		Assert.assertFalse(CollectionUtils.isEmpty(applicationMetrics.getProperties()));
+		Assert.assertTrue(applicationMetrics.getProperties().get("spring.test.env.syntax").equals("testing"));
 		applicationContext.close();
 	}
 


### PR DESCRIPTION
Fix #907

- Placeholders are replaced and expressions are evaluated
  before on attached properties