### PR TITLE
GH-931: Fix BinderAwareChannelResolver Concurrency

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BinderAwareChannelResolver.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BinderAwareChannelResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,6 @@ public class BinderAwareChannelResolver extends BeanFactoryMessageChannelDestina
 
 	private ConfigurableListableBeanFactory beanFactory;
 
-	@SuppressWarnings("unchecked")
 	public BinderAwareChannelResolver(BindingService bindingService,
 			AbstractBindingTargetFactory<? extends MessageChannel> bindingTargetFactory,
 			DynamicDestinationsBindable dynamicDestinationsBindable) {
@@ -66,15 +65,21 @@ public class BinderAwareChannelResolver extends BeanFactoryMessageChannelDestina
 
 	@Override
 	public MessageChannel resolveDestination(String channelName) {
-		MessageChannel channel = null;
-		DestinationResolutionException destinationResolutionException;
 		try {
 			return super.resolveDestination(channelName);
 		}
 		catch (DestinationResolutionException e) {
-			destinationResolutionException = e;
+			// intentionally empty; will check again while holding the monitor
 		}
 		synchronized (this) {
+			DestinationResolutionException destinationResolutionException;
+			try {
+				return super.resolveDestination(channelName);
+			}
+			catch (DestinationResolutionException e) {
+				destinationResolutionException = e;
+			}
+			MessageChannel channel = null;
 			if (this.beanFactory != null) {
 				String[] dynamicDestinations = null;
 				BindingServiceProperties bindingServiceProperties = this.bindingService


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-stream/issues/931

While the resolver binds the channel and registers the bean in a synchronized block,
it does not re-check that another thread has already done the work.

Add a second `super.resolveDestination()` to the synchronized block.