### PR TITLE
Fix JSON contentType handling in payload serialization

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
@@ -306,7 +306,7 @@ public abstract class AbstractBinder<T, C extends ConsumerProperties, P extends 
 				return MimeTypeUtils.APPLICATION_OCTET_STREAM;
 			}
 			if (payload instanceof String) {
-				return MimeTypeUtils.APPLICATION_JSON_VALUE.equals(originalContentType) ? MimeTypeUtils.APPLICATION_JSON
+				return (originalContentType.startsWith(MimeTypeUtils.APPLICATION_JSON_VALUE)) ? MimeTypeUtils.APPLICATION_JSON
 						: MimeTypeUtils.TEXT_PLAIN;
 			}
 			String className = payload.getClass().getName();


### PR DESCRIPTION
 - Check if the original contentType starts with `application/json` and this way any original contentType with parameters such as `charset` can also be considered correctly

Resolves #941