### PR TITLE
Extract schema version not id in ConfluentSchemaRegistry register method.

### DIFF
--- a/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/client/ConfluentSchemaRegistryClient.java
+++ b/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/client/ConfluentSchemaRegistryClient.java
@@ -59,26 +59,26 @@ public class ConfluentSchemaRegistryClient implements SchemaRegistryClient {
 	@Override
 	public SchemaRegistrationResponse register(String subject, String format, String schema) {
 		Assert.isTrue("avro".equals(format), "Only Avro is supported");
-		String path = String.format("/subjects/%s/versions", subject);
+		String path = String.format("/subjects/%s", subject);
 		HttpHeaders headers = new HttpHeaders();
 		headers.put("Accept",
 				Arrays.asList("application/vnd.schemaregistry.v1+json", "application/vnd.schemaregistry+json",
 						"application/json"));
 		headers.add("Content-Type", "application/json");
-		Integer id = null;
+		Integer version = null;
 		try {
 			String payload = this.mapper.writeValueAsString(Collections.singletonMap("schema", schema));
 			HttpEntity<String> request = new HttpEntity<>(payload, headers);
 			ResponseEntity<Map> response = this.template.exchange(this.endpoint + path, HttpMethod.POST, request,
 					Map.class);
-			id = (Integer) response.getBody().get("id");
+			version = (Integer) response.getBody().get("version");
 		}
 		catch (JsonProcessingException e) {
 			e.printStackTrace();
 		}
 		SchemaRegistrationResponse schemaRegistrationResponse = new SchemaRegistrationResponse();
-		schemaRegistrationResponse.setId(id);
-		schemaRegistrationResponse.setSchemaReference(new SchemaReference(subject, id, "avro"));
+		schemaRegistrationResponse.setId(version);
+		schemaRegistrationResponse.setSchemaReference(new SchemaReference(subject, version, "avro"));
 		return schemaRegistrationResponse;
 	}
 


### PR DESCRIPTION
Original implementation was getting the schema id and using it as the
version. This made deserialization fail since it would endeavor to
retrieve the schema by version using the id value.

Fix #947 