### PR TITLE
Ignore unknown binder types if not used

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderConfiguration.java
@@ -28,7 +28,7 @@ import java.util.Properties;
  */
 public class BinderConfiguration {
 
-	private final BinderType binderType;
+	private final String binderType;
 
 	private final Properties properties;
 
@@ -44,7 +44,7 @@ public class BinderConfiguration {
 	 * @param defaultCandidate whether the binder should be considered as a candidate when
 	 * determining a default
 	 */
-	public BinderConfiguration(BinderType binderType, Properties properties, boolean inheritEnvironment,
+	public BinderConfiguration(String binderType, Properties properties, boolean inheritEnvironment,
 			boolean defaultCandidate) {
 		this.binderType = binderType;
 		this.properties = properties;
@@ -52,7 +52,7 @@ public class BinderConfiguration {
 		this.defaultCandidate = defaultCandidate;
 	}
 
-	public BinderType getBinderType() {
+	public String getBinderType() {
 		return binderType;
 	}
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderTypeRegistry.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderTypeRegistry.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Defult implementation of a {@link BinderTypeRegistry}.
+ * Default implementation of a {@link BinderTypeRegistry}.
  *
  * @author Marius Bogoevici
  */

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BinderFactoryConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BinderFactoryConfiguration.java
@@ -64,12 +64,6 @@ public class BinderFactoryConfiguration {
 	@Value("${" + SELF_CONTAINED_APP_PROPERTY_NAME + ":}")
 	private String selfContained;
 
-	@Autowired
-	private BinderTypeRegistry binderTypeRegistry;
-
-	@Autowired
-	private BindingServiceProperties bindingServiceProperties;
-
 	@Autowired(required = false)
 	private Collection<DefaultBinderFactory.Listener> binderFactoryListeners;
 
@@ -93,16 +87,19 @@ public class BinderFactoryConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(BinderFactory.class)
-	public DefaultBinderFactory binderFactory() {
-		DefaultBinderFactory binderFactory = new DefaultBinderFactory(getBinderConfigurations());
+	public DefaultBinderFactory binderFactory(BinderTypeRegistry binderTypeRegistry,
+			BindingServiceProperties bindingServiceProperties) {
+		DefaultBinderFactory binderFactory = new DefaultBinderFactory(
+				getBinderConfigurations(binderTypeRegistry, bindingServiceProperties), binderTypeRegistry);
 		binderFactory.setDefaultBinder(bindingServiceProperties.getDefaultBinder());
 		binderFactory.setListeners(binderFactoryListeners);
 		return binderFactory;
 	}
 
-	public Map<String, BinderConfiguration> getBinderConfigurations() {
+	public Map<String, BinderConfiguration> getBinderConfigurations(BinderTypeRegistry binderTypeRegistry,
+			BindingServiceProperties bindingServiceProperties) {
 		Map<String, BinderConfiguration> binderConfigurations = new HashMap<>();
-		Map<String, BinderProperties> declaredBinders = this.bindingServiceProperties.getBinders();
+		Map<String, BinderProperties> declaredBinders = bindingServiceProperties.getBinders();
 		boolean defaultCandidatesExist = false;
 		Iterator<Map.Entry<String, BinderProperties>> binderPropertiesIterator = declaredBinders.entrySet().iterator();
 		while (!defaultCandidatesExist && binderPropertiesIterator.hasNext()) {
@@ -111,9 +108,9 @@ public class BinderFactoryConfiguration {
 		List<String> existingBinderConfigurations = new ArrayList<>();
 		for (Map.Entry<String, BinderProperties> binderEntry : declaredBinders.entrySet()) {
 			BinderProperties binderProperties = binderEntry.getValue();
-			if (this.binderTypeRegistry.get(binderEntry.getKey()) != null) {
+			if (binderTypeRegistry.get(binderEntry.getKey()) != null) {
 				binderConfigurations.put(binderEntry.getKey(),
-						new BinderConfiguration(this.binderTypeRegistry.get(binderEntry.getKey()),
+						new BinderConfiguration(binderEntry.getKey(),
 								binderProperties.getEnvironment(), binderProperties.isInheritEnvironment(),
 								binderProperties.isDefaultCandidate()));
 				existingBinderConfigurations.add(binderEntry.getKey());
@@ -121,10 +118,8 @@ public class BinderFactoryConfiguration {
 			else {
 				Assert.hasText(binderProperties.getType(),
 						"No 'type' property present for custom binder " + binderEntry.getKey());
-				BinderType binderType = this.binderTypeRegistry.get(binderProperties.getType());
-				Assert.notNull(binderType, "Binder type " + binderProperties.getType() + " is not defined");
 				binderConfigurations.put(binderEntry.getKey(),
-						new BinderConfiguration(binderType, binderProperties.getEnvironment(),
+						new BinderConfiguration(binderProperties.getType(), binderProperties.getEnvironment(),
 								binderProperties.isInheritEnvironment(), binderProperties.isDefaultCandidate()));
 				existingBinderConfigurations.add(binderEntry.getKey());
 			}
@@ -135,9 +130,9 @@ public class BinderFactoryConfiguration {
 			}
 		}
 		if (!defaultCandidatesExist) {
-			for (Map.Entry<String, BinderType> binderEntry : this.binderTypeRegistry.getAll().entrySet()) {
+			for (Map.Entry<String, BinderType> binderEntry : binderTypeRegistry.getAll().entrySet()) {
 				if (!existingBinderConfigurations.contains(binderEntry.getKey())) {
-					binderConfigurations.put(binderEntry.getKey(), new BinderConfiguration(binderEntry.getValue(),
+					binderConfigurations.put(binderEntry.getKey(), new BinderConfiguration(binderEntry.getKey(),
 							new Properties(), true, true));
 				}
 			}


### PR DESCRIPTION
Fix #972

Do not throw an error when binder configurations are
processed, unless a binder configuration that references
an unknown binder type (i.e. not found on the classpath)
is actually used by an application.

This allows supporting scenarios like
http://docs.spring.io/spring-cloud-dataflow/docs/1.2.0.RELEASE/reference/htmlsingle/#dataflow-multiple-brokers
where a set of binder configurations is passed to a number
of applications that might or might not have a specific
binder type on the classpath. If a specific binder configuration
is not used by the application, it can be ignored.

Backport to 1.2.x branch. 