### PR TITLE
Option to suppress header propagation with SI message handlers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,20 @@
         <rxjava-reactive-streams.version>1.2.1</rxjava-reactive-streams.version>
         <spring.tuple.version>1.0.0.RELEASE</spring.tuple.version>
         <spring.integration.tuple.version>1.0.0.RELEASE</spring.integration.tuple.version>
+        <spring-integration.version>4.3.10.BUILD-SNAPSHOT</spring-integration.version>
         <reactor.version>3.0.5.RELEASE</reactor.version>
         <kryo-shaded.version>3.0.3</kryo-shaded.version>
         <objenesis.version>2.1</objenesis.version>
     </properties>
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.springframework.integration</groupId>
+                <artifactId>spring-integration-bom</artifactId>
+                <version>${spring-integration.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-stream</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,20 +24,12 @@
         <rxjava-reactive-streams.version>1.2.1</rxjava-reactive-streams.version>
         <spring.tuple.version>1.0.0.RELEASE</spring.tuple.version>
         <spring.integration.tuple.version>1.0.0.RELEASE</spring.integration.tuple.version>
-        <spring-integration.version>4.3.10.BUILD-SNAPSHOT</spring-integration.version>
         <reactor.version>3.0.5.RELEASE</reactor.version>
         <kryo-shaded.version>3.0.3</kryo-shaded.version>
         <objenesis.version>2.1</objenesis.version>
     </properties>
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.springframework.integration</groupId>
-                <artifactId>spring-integration-bom</artifactId>
-                <version>${spring-integration.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-stream</artifactId>

--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/CustomHeaderPropagationTests.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/CustomHeaderPropagationTests.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.config;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.binder.BinderFactory;
+import org.springframework.cloud.stream.messaging.Processor;
+import org.springframework.cloud.stream.test.binder.TestSupportBinder;
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Marius Bogoevici
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = CustomHeaderPropagationTests.HeaderPropagationProcessor.class, webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = "spring.cloud.stream.integration.messageHandlerNotPropagatedHeaders=bar,contentType")
+public class CustomHeaderPropagationTests {
+
+	@Autowired
+	private Processor testProcessor;
+
+	@Autowired
+	private BinderFactory binderFactory;
+
+	@Test
+	public void testCustomHeaderPropagation() throws Exception {
+		testProcessor.input().send(MessageBuilder.withPayload("{'name':'foo'}")
+				.setHeader(MessageHeaders.CONTENT_TYPE, "application/json")
+				.setHeader("foo", "fooValue")
+				.setHeader("bar", "barValue")
+				.build());
+		@SuppressWarnings("unchecked")
+		Message<?> received = ((TestSupportBinder) binderFactory.getBinder(null, MessageChannel.class))
+				.messageCollector().forChannel(testProcessor.output()).poll(1, TimeUnit.SECONDS);
+		assertThat(received.getHeaders()).containsEntry("foo", "fooValue");
+		assertThat(received.getHeaders()).doesNotContainKey("bar");
+		assertThat(received.getHeaders()).doesNotContainKey(MessageHeaders.CONTENT_TYPE);
+		assertThat(received).isNotNull();
+		assertThat(received.getPayload()).isEqualTo("{'name':'foo'}");
+	}
+
+	@EnableBinding(Processor.class)
+	@EnableAutoConfiguration
+	public static class HeaderPropagationProcessor {
+
+		@ServiceActivator(inputChannel = "input", outputChannel = "output")
+		public String consume(String data) {
+			return data;
+		}
+
+	}
+}

--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/DefaultHeaderPropagationTests.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/DefaultHeaderPropagationTests.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.config;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.binder.BinderFactory;
+import org.springframework.cloud.stream.messaging.Processor;
+import org.springframework.cloud.stream.test.binder.TestSupportBinder;
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Marius Bogoevici
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = DefaultHeaderPropagationTests.HeaderPropagationProcessor.class, webEnvironment = SpringBootTest.WebEnvironment.NONE)
+public class DefaultHeaderPropagationTests {
+
+	@Autowired
+	private Processor testProcessor;
+
+	@Autowired
+	private BinderFactory binderFactory;
+
+	@Test
+	public void testDefaultHeaderPropagation() throws Exception {
+		testProcessor.input().send(MessageBuilder.withPayload("{'name':'foo'}")
+				.setHeader(MessageHeaders.CONTENT_TYPE, "application/json")
+				.setHeader("foo", "fooValue")
+				.setHeader("bar", "barValue")
+				.build());
+		@SuppressWarnings("unchecked")
+		Message<?> received = ((TestSupportBinder) binderFactory.getBinder(null, MessageChannel.class))
+				.messageCollector().forChannel(testProcessor.output()).poll(1, TimeUnit.SECONDS);
+		assertThat(received.getHeaders()).containsEntry("foo", "fooValue");
+		assertThat(received.getHeaders()).containsEntry("bar", "barValue");
+		assertThat(received.getHeaders()).doesNotContainKey(MessageHeaders.CONTENT_TYPE);
+		assertThat(received).isNotNull();
+		assertThat(received.getPayload()).isEqualTo("{'name':'foo'}");
+	}
+
+	@EnableBinding(Processor.class)
+	@EnableAutoConfiguration
+	public static class HeaderPropagationProcessor {
+
+		@ServiceActivator(inputChannel = "input", outputChannel = "output")
+		public String consume(String data) {
+			return data;
+		}
+
+	}
+}

--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/DefaultHeaderPropagationWithApplicationProvidedHeaderTests.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/DefaultHeaderPropagationWithApplicationProvidedHeaderTests.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.config;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.binder.BinderFactory;
+import org.springframework.cloud.stream.messaging.Processor;
+import org.springframework.cloud.stream.test.binder.TestSupportBinder;
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Marius Bogoevici
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = DefaultHeaderPropagationWithApplicationProvidedHeaderTests.HeaderPropagationProcessor.class, webEnvironment = SpringBootTest.WebEnvironment.NONE)
+public class DefaultHeaderPropagationWithApplicationProvidedHeaderTests {
+
+	@Autowired
+	private Processor testProcessor;
+
+	@Autowired
+	private BinderFactory binderFactory;
+
+	@Test
+	public void testHeaderPropagationIfSetByApplication() throws Exception {
+		testProcessor.input().send(MessageBuilder.withPayload("{'name':'foo'}")
+				.setHeader(MessageHeaders.CONTENT_TYPE, "application/json")
+				.setHeader("foo", "fooValue")
+				.setHeader("bar", "barValue")
+				.build());
+		@SuppressWarnings("unchecked")
+		Message<?> received = ((TestSupportBinder) binderFactory.getBinder(null, MessageChannel.class))
+				.messageCollector().forChannel(testProcessor.output()).poll(1, TimeUnit.SECONDS);
+		assertThat(received.getHeaders()).containsEntry("foo", "fooValue");
+		assertThat(received.getHeaders()).containsEntry("bar", "barValue");
+		assertThat(received.getHeaders()).containsEntry(MessageHeaders.CONTENT_TYPE, "custom/header");
+		assertThat(received).isNotNull();
+		assertThat(received.getPayload()).isEqualTo("{'name':'foo'}");
+	}
+
+	@EnableBinding(Processor.class)
+	@EnableAutoConfiguration
+	public static class HeaderPropagationProcessor {
+
+		@ServiceActivator(inputChannel = "input", outputChannel = "output")
+		public Message<?> consume(String data) {
+			return MessageBuilder.withPayload(data).setHeader(MessageHeaders.CONTENT_TYPE, "custom/header").build();
+		}
+
+	}
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceConfiguration.java
@@ -56,6 +56,7 @@ import org.springframework.expression.PropertyAccessor;
 import org.springframework.integration.channel.PublishSubscribeChannel;
 import org.springframework.integration.config.IntegrationEvaluationContextFactoryBean;
 import org.springframework.integration.context.IntegrationContextUtils;
+import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.json.JsonPropertyAccessor;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.converter.MessageConverter;
@@ -76,7 +77,7 @@ import org.springframework.util.CollectionUtils;
  * @author Gary Russell
  */
 @Configuration
-@EnableConfigurationProperties(BindingServiceProperties.class)
+@EnableConfigurationProperties({BindingServiceProperties.class, SpringIntegrationProperties.class})
 public class BindingServiceConfiguration {
 
 	public static final String STREAM_LISTENER_ANNOTATION_BEAN_POST_PROCESSOR_NAME = "streamListenerAnnotationBeanPostProcessor";
@@ -244,6 +245,28 @@ public class BindingServiceConfiguration {
 				}
 
 			});
+		}
+
+		@Bean
+		public static BeanPostProcessor messageHandlerHeaderPropagationBeanPostProcessor(
+				final SpringIntegrationProperties springIntegrationProperties) {
+			return new BeanPostProcessor() {
+				@Override
+				public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+					// TODO: Filter out beans created by SCSt (not currently necessary)
+					if (bean instanceof AbstractReplyProducingMessageHandler) {
+						AbstractReplyProducingMessageHandler messageHandler = (AbstractReplyProducingMessageHandler) bean;
+						messageHandler.addNotPropagatedHeaders(
+								springIntegrationProperties.getMessageHandlerNotPropagatedHeaders());
+					}
+					return bean;
+				}
+
+				@Override
+				public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+					return bean;
+				}
+			};
 		}
 	}
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceConfiguration.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -254,7 +255,8 @@ public class BindingServiceConfiguration {
 				@Override
 				public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
 					// TODO: Filter out beans created by SCSt (not currently necessary)
-					if (bean instanceof AbstractReplyProducingMessageHandler) {
+					Class<?> beanClass = AopUtils.isAopProxy(bean) ? AopUtils.getTargetClass(bean) : bean.getClass();
+					if (AbstractReplyProducingMessageHandler.class.isAssignableFrom(beanClass)) {
 						AbstractReplyProducingMessageHandler messageHandler = (AbstractReplyProducingMessageHandler) bean;
 						messageHandler.addNotPropagatedHeaders(
 								springIntegrationProperties.getMessageHandlerNotPropagatedHeaders());

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/SpringIntegrationProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/SpringIntegrationProperties.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.messaging.MessageHeaders;
+
+/**
+ * Contains properties for Spring Integration settings.
+ */
+@ConfigurationProperties("spring.cloud.stream.integration")
+public class SpringIntegrationProperties {
+
+	private String[] messageHandlerNotPropagatedHeaders = new String[] { MessageHeaders.CONTENT_TYPE };
+
+	public String[] getMessageHandlerNotPropagatedHeaders() {
+		return messageHandlerNotPropagatedHeaders;
+	}
+
+	public void setMessageHandlerNotPropagatedHeaders(String[] messageHandlerNotPropagatedHeaders) {
+		this.messageHandlerNotPropagatedHeaders = messageHandlerNotPropagatedHeaders;
+	}
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/SpringIntegrationProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/SpringIntegrationProperties.java
@@ -21,6 +21,8 @@ import org.springframework.messaging.MessageHeaders;
 
 /**
  * Contains properties for Spring Integration settings.
+ * @author Marius Bogoevici
+ * @since 1.2.3
  */
 @ConfigurationProperties("spring.cloud.stream.integration")
 public class SpringIntegrationProperties {


### PR DESCRIPTION
Add `SpringIntegrationProperties` class with
`spring.cloud.stream.integration` prefix for managing
Spring Integration properties.

Add `spring.cloud.stream.integration.messageHandlerNotPropagatedHeaders`
for controlling headers propagated by reply producing handlers.

Fix #943 

Merge in `master` and `1.2.x` - once Boot 1.5.4 is available. 