### PR TITLE
Allow custom JSON types to be handled properly

### DIFF
--- a/spring-cloud-stream-binder-test/src/test/java/org/springframework/cloud/stream/binder/MessageChannelBinderSupportTests.java
+++ b/spring-cloud-stream-binder-test/src/test/java/org/springframework/cloud/stream/binder/MessageChannelBinderSupportTests.java
@@ -132,6 +132,20 @@ public class MessageChannelBinderSupportTests {
 	}
 
 	@Test
+	public void testContentTypePreservedForCustomJson() throws IOException {
+		Message<String> inbound = MessageBuilder.withPayload("{\"foo\":\"foo\"}")
+				.copyHeaders(Collections.singletonMap(MessageHeaders.CONTENT_TYPE, MimeType.valueOf("application/vnd.spring.cloud.stream.user.v1+json")))
+				.build();
+		MessageValues convertedValues = binder.serializePayloadIfNecessary(inbound);
+		Message<?> converted = convertedValues.toMessage();
+		assertThat(contentTypeResolver.resolve(converted.getHeaders())).isEqualTo(MimeType.valueOf("application/vnd.spring.cloud.stream.user.v1+json"));
+		assertThat(converted.getHeaders().get(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE)).isNull();
+		MessageValues reconstructed = binder.deserializePayloadIfNecessary(converted);
+		assertThat(reconstructed.getPayload()).isEqualTo("{\"foo\":\"foo\"}");
+		assertThat(reconstructed.get(MessageHeaders.CONTENT_TYPE)).isEqualTo(MimeType.valueOf("application/vnd.spring.cloud.stream.user.v1+json").toString());
+	}
+
+	@Test
 	public void testContentTypePreservedForNonSCStApp() {
 		Message<String> inbound = MessageBuilder.withPayload("{\"foo\":\"bar\"}")
 				.copyHeaders(Collections.singletonMap(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.APPLICATION_JSON))

--- a/spring-cloud-stream-binder-test/src/test/java/org/springframework/cloud/stream/binder/MessageChannelBinderSupportTests.java
+++ b/spring-cloud-stream-binder-test/src/test/java/org/springframework/cloud/stream/binder/MessageChannelBinderSupportTests.java
@@ -47,6 +47,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gary Russell
  * @author David Turanski
  * @author Ilayaperumal Gopinathan
+ * @author Vinicius Carvalho
  */
 public class MessageChannelBinderSupportTests {
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
@@ -56,6 +56,7 @@ import org.springframework.util.StringUtils;
  * @author Ilayaperumal Gopinathan
  * @author Mark Fisher
  * @author Marius Bogoevici
+ * @author Vinicius Carvalho
  */
 public abstract class AbstractBinder<T, C extends ConsumerProperties, P extends ProducerProperties>
 		implements ApplicationContextAware, InitializingBean, Binder<T, C, P> {
@@ -238,7 +239,7 @@ public abstract class AbstractBinder<T, C extends ConsumerProperties, P extends 
 	}
 
 	private Object deserializePayload(byte[] bytes, MimeType contentType) {
-		if ("text".equalsIgnoreCase(contentType.getType()) || MimeTypeUtils.APPLICATION_JSON.equals(contentType)) {
+		if ("text".equalsIgnoreCase(contentType.getType()) || contentType.getSubtype().toLowerCase().contains(MimeTypeUtils.APPLICATION_JSON.getSubtype())) {
 			try {
 				return new String(bytes, "UTF-8");
 			}
@@ -303,13 +304,13 @@ public abstract class AbstractBinder<T, C extends ConsumerProperties, P extends 
 		private static ConcurrentMap<String, MimeType> mimeTypesCache = new ConcurrentHashMap<>();
 
 		static MimeType mimeTypeFromObject(Object payload, String originalContentType) {
+
 			Assert.notNull(payload, "payload object cannot be null.");
 			if (payload instanceof byte[]) {
 				return MimeTypeUtils.APPLICATION_OCTET_STREAM;
 			}
 			if (payload instanceof String) {
-				return MimeTypeUtils.APPLICATION_JSON_VALUE.equals(originalContentType) ? MimeTypeUtils.APPLICATION_JSON
-						: MimeTypeUtils.TEXT_PLAIN;
+				return originalContentType.toLowerCase().contains(MimeTypeUtils.APPLICATION_JSON.getSubtype()) ? MimeType.valueOf(originalContentType) : MimeTypeUtils.TEXT_PLAIN;
 			}
 			String className = payload.getClass().getName();
 			MimeType mimeType = mimeTypesCache.get(className);

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/CompositeMessageConverterFactory.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/CompositeMessageConverterFactory.java
@@ -27,7 +27,6 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.messaging.converter.AbstractMessageConverter;
 import org.springframework.messaging.converter.ByteArrayMessageConverter;
 import org.springframework.messaging.converter.CompositeMessageConverter;
-import org.springframework.messaging.converter.MappingJackson2MessageConverter;
 import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.MimeType;
@@ -38,6 +37,7 @@ import org.springframework.util.MimeType;
  * @author David Turanski
  * @author Ilayaperumal Gopinathan
  * @author Marius Bogoevici
+ * @author Vinicius Carvalho
  */
 public class CompositeMessageConverterFactory {
 
@@ -68,8 +68,7 @@ public class CompositeMessageConverterFactory {
 
 	private void initDefaultConverters() {
 		this.converters.add(new TupleJsonMessageConverter(this.objectMapper));
-
-		MappingJackson2MessageConverter jsonMessageConverter = new MappingJackson2MessageConverter();
+		CustomJackson2MessageConverter jsonMessageConverter = new CustomJackson2MessageConverter();
 		jsonMessageConverter.setSerializedPayloadClass(String.class);
 		if (this.objectMapper != null) {
 			jsonMessageConverter.setObjectMapper(this.objectMapper);

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/CustomJackson2MessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/CustomJackson2MessageConverter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.converter;
+
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.util.MimeType;
+import org.springframework.util.MimeTypeUtils;
+
+/**
+ * Custom implementation of {@link MappingJackson2MessageConverter} that is more flexible on accepting json contentTypes.
+ * Instead of strict matching for application/json this implemntation will accept any contentType that contains the keyword json on it.
+ * This will allow custom types such as application/vnd.spring.cloud.stream.metric.v1+json to be supported for example.
+ *
+ * @author Vinicius Carvalho
+ */
+public class CustomJackson2MessageConverter extends MappingJackson2MessageConverter {
+
+	@Override
+	protected boolean supportsMimeType(MessageHeaders headers) {
+		if (getSupportedMimeTypes().isEmpty()) {
+			return true;
+		}
+		MimeType mimeType = getMimeType(headers);
+		if (mimeType == null) {
+			return !isStrictContentTypeMatch();
+		}
+		return mimeType.getSubtype().toLowerCase().contains(MimeTypeUtils.APPLICATION_JSON.getSubtype());
+
+	}
+
+}


### PR DESCRIPTION
Fixes #940 

Changed logic to instead of strict comparison of contentType using
application/json we would only search for subtype json.

This allow us to support vnd.vendor.type.version+json types