### PR TITLE
Performance optimizations for basic use cases

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
@@ -68,7 +68,7 @@ public abstract class AbstractBinder<T, C extends ConsumerProperties, P extends 
 
 	protected final Log logger = LogFactory.getLog(getClass());
 
-	private final StringConvertingContentTypeResolver contentTypeResolver = new StringConvertingContentTypeResolver();
+	protected final StringConvertingContentTypeResolver contentTypeResolver = new StringConvertingContentTypeResolver();
 
 	private volatile AbstractApplicationContext applicationContext;
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
@@ -44,6 +44,7 @@ import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.SubscribableChannel;
 import org.springframework.util.Assert;
 import org.springframework.util.MimeType;
+import org.springframework.util.MimeTypeUtils;
 
 /**
  * {@link AbstractBinder} that serves as base class for {@link MessageChannel} binders.
@@ -480,7 +481,13 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 				messageValues = deserializePayloadIfNecessary(messageValues);
 			}
 			else {
-				messageValues = deserializePayloadIfNecessary(requestMessage);
+				MimeType contentType = AbstractMessageChannelBinder.this.contentTypeResolver.resolve(requestMessage.getHeaders());
+				if (contentType != null && !MimeTypeUtils.APPLICATION_OCTET_STREAM.equals(contentType)) {
+					messageValues = deserializePayloadIfNecessary(requestMessage);
+				}
+				else {
+					return requestMessage;
+				}
 			}
 			return messageValues.toMessage();
 		}


### PR DESCRIPTION
Fixes #1013

- Do not recreate MessageValues if content is byte[]

- Optimize StreamListener dispatching

   - avoid expression evaluation if not necessary
   - use `StreamListenerMessageHandler` directly if there is only one method