### PR TITLE
GH-1010: @StreamListener: Fix Header Propagation

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/annotation/StreamListener.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/annotation/StreamListener.java
@@ -39,10 +39,10 @@ import org.springframework.messaging.handler.annotation.MessageMapping;
  * A method is considered declarative if all its method parameter types and return type
  * (if not void) are binding targets or conversion targets from binding targets via a
  * registered {@link StreamListenerParameterAdapter}.
- * 
+ *
  * Only declarative methods can have binding targets or conversion targets as arguments
  * and return type.
- * 
+ *
  * Declarative methods must specify what inputs and outputs correspond to their arguments
  * and return type, and can do this in one of the following ways.
  *
@@ -118,6 +118,7 @@ import org.springframework.messaging.handler.annotation.MessageMapping;
  *
  * @author Marius Bogoevici
  * @author Ilayaperumal Gopinathan
+ * @author Gary Russell
  * @see MessageMapping
  * @see EnableBinding
  * @see org.springframework.messaging.handler.annotation.SendTo
@@ -147,4 +148,15 @@ public @interface StreamListener {
 	 * @return a SpEL expression that must evaluate to a {@code boolean} value.
 	 */
 	String condition() default "";
+
+	/**
+	 * When "true" (default), and a {@code @SendTo} annotation is present, copy the
+	 * inbound headers to the outbound message (if the header is absent on the outbound
+	 * message). Can be an expression ({@code #{...}}) or property placeholder. Must
+	 * resolve to a boolean or a string that is parsed by {@code Boolean.parseBoolean()}.
+	 * An expression that resolves to {@code null} is interpreted to mean {@code false}.
+	 * @since 1.2.3
+	 */
+	String copyHeaders() default "true";
+
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerAnnotationBeanPostProcessor.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerAnnotationBeanPostProcessor.java
@@ -101,7 +101,6 @@ public class StreamListenerAnnotationBeanPostProcessor
 	private BeanExpressionContext expressionContext;
 
 	@Override
-	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public final void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
 		this.applicationContext = (ConfigurableApplicationContext) applicationContext;
 	}
@@ -115,6 +114,7 @@ public class StreamListenerAnnotationBeanPostProcessor
 		}
 	}
 
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		Map<String, StreamListenerParameterAdapter> parameterAdapterMap = BeanFactoryUtils
@@ -226,7 +226,7 @@ public class StreamListenerAnnotationBeanPostProcessor
 
 	private boolean isDeclarativeMethodParameter(String targetBeanName, MethodParameter methodParameter) {
 		try {
-			Class targetBeanClass = this.applicationContext.getType(targetBeanName);
+			Class<?> targetBeanClass = this.applicationContext.getType(targetBeanName);
 			if (!methodParameter.getParameterType().equals(Object.class)
 					&& (targetBeanClass.isAssignableFrom(methodParameter.getParameterType()) ||
 							methodParameter.getParameterType().isAssignableFrom(targetBeanClass))) {
@@ -335,7 +335,8 @@ public class StreamListenerAnnotationBeanPostProcessor
 		}
 		StreamListenerMethodUtils.validateStreamListenerMessageHandler(method);
 		mappedListenerMethods.add(streamListener.value(),
-				new StreamListenerHandlerMethodMapping(bean, method, streamListener.condition(), defaultOutputChannel));
+				new StreamListenerHandlerMethodMapping(bean, method, streamListener.condition(), defaultOutputChannel,
+						streamListener.copyHeaders()));
 	}
 
 	@Override
@@ -349,7 +350,7 @@ public class StreamListenerAnnotationBeanPostProcessor
 						.createInvocableHandlerMethod(mapping.getTargetBean(),
 								checkProxy(mapping.getMethod(), mapping.getTargetBean()));
 				StreamListenerMessageHandler streamListenerMessageHandler = new StreamListenerMessageHandler(
-						invocableHandlerMethod);
+						invocableHandlerMethod, resolveExpressionAsBoolean(mapping.getCopyHeaders(), "copyHeaders"));
 				streamListenerMessageHandler.setApplicationContext(this.applicationContext);
 				streamListenerMessageHandler.setBeanFactory(this.applicationContext.getBeanFactory());
 				if (StringUtils.hasText(mapping.getDefaultOutputChannel())) {
@@ -357,7 +358,7 @@ public class StreamListenerAnnotationBeanPostProcessor
 				}
 				streamListenerMessageHandler.afterPropertiesSet();
 				if (StringUtils.hasText(mapping.getCondition())) {
-					String conditionAsString = resolveExpressionAsString(mapping.getCondition());
+					String conditionAsString = resolveExpressionAsString(mapping.getCondition(), "condition");
 					Expression condition = SPEL_EXPRESSION_PARSER.parseExpression(conditionAsString);
 					handlers.add(new DispatchingStreamListenerMessageHandler.ConditionalStreamListenerHandler(
 							condition, streamListenerMessageHandler));
@@ -415,13 +416,31 @@ public class StreamListenerAnnotationBeanPostProcessor
 		return method;
 	}
 
-	private String resolveExpressionAsString(String value) {
+	private String resolveExpressionAsString(String value, String property) {
 		Object resolved = resolveExpression(value);
 		if (resolved instanceof String) {
 			return (String) resolved;
 		}
 		else {
-			throw new IllegalStateException("Resolved to [" + resolved.getClass() + "] for [" + value + "]");
+			throw new IllegalStateException(
+					"Resolved " + property + " to [" + resolved.getClass() + "] instead of String for [" + value + "]");
+		}
+	}
+
+	private boolean resolveExpressionAsBoolean(String value, String property) {
+		Object resolved = resolveExpression(value);
+		if (resolved == null) {
+			return false;
+		}
+		else if (resolved instanceof String) {
+			return Boolean.parseBoolean((String) resolved);
+		}
+		else if (resolved instanceof Boolean) {
+			return (Boolean) resolved;
+		}
+		else {
+			throw new IllegalStateException("Resolved " + property + " to [" + resolved.getClass()
+					+ "] instead of String or Boolean for [" + value + "]");
 		}
 	}
 
@@ -449,20 +468,23 @@ public class StreamListenerAnnotationBeanPostProcessor
 
 	private class StreamListenerHandlerMethodMapping {
 
-		private Object targetBean;
+		private final Object targetBean;
 
-		private Method method;
+		private final Method method;
 
-		private String condition;
+		private final String condition;
 
-		private String defaultOutputChannel;
+		private final String defaultOutputChannel;
+
+		private final String copyHeaders;
 
 		StreamListenerHandlerMethodMapping(Object targetBean, Method method, String condition,
-				String defaultOutputChannel) {
+				String defaultOutputChannel, String copyHeaders) {
 			this.targetBean = targetBean;
 			this.method = method;
 			this.condition = condition;
 			this.defaultOutputChannel = defaultOutputChannel;
+			this.copyHeaders = copyHeaders;
 		}
 
 		Object getTargetBean() {
@@ -480,6 +502,11 @@ public class StreamListenerAnnotationBeanPostProcessor
 		String getDefaultOutputChannel() {
 			return defaultOutputChannel;
 		}
+
+		public String getCopyHeaders() {
+			return this.copyHeaders;
+		}
+
 	}
 
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerMessageHandler.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerMessageHandler.java
@@ -23,19 +23,23 @@ import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
 
 /**
  * @author Marius Bogoevici
+ * @author Gary Russell
  * @since 1.2
  */
 public class StreamListenerMessageHandler extends AbstractReplyProducingMessageHandler {
 
 	private final InvocableHandlerMethod invocableHandlerMethod;
 
-	StreamListenerMessageHandler(InvocableHandlerMethod invocableHandlerMethod) {
+	private final boolean copyHeaders;
+
+	StreamListenerMessageHandler(InvocableHandlerMethod invocableHandlerMethod, boolean copyHeaders) {
 		this.invocableHandlerMethod = invocableHandlerMethod;
+		this.copyHeaders = copyHeaders;
 	}
 
 	@Override
 	protected boolean shouldCopyRequestHeaders() {
-		return false;
+		return this.copyHeaders;
 	}
 
 	public boolean isVoid() {


### PR DESCRIPTION
Fixes #1010

Propagate headers by default.

Add a `copyHeaders` property to `@StreamListener` to allow suppression of header propagation.

__cherry-pick to 1.2.x__