### PR TITLE
Force dedicated VM for travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 cache:
   directories:
     - $HOME/.m2


### PR DESCRIPTION
This change is similar to what we have done in SCDF to resolve the Travis build issues. More details about the build environments [here](https://docs.travis-ci.com/user/ci-environment/).

Resolves spring-cloud/spring-cloud-stream#771