### PR TITLE
Add @ErrorListener to consumer error messages

### DIFF
--- a/spring-cloud-stream-core-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
+++ b/spring-cloud-stream-core-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
@@ -433,6 +433,42 @@ at the broker by configuring a binding for the outbound target named `error`. Fo
 publish error messages to a broker destination named "myErrors", provide the following property:
 `spring.cloud.stream.bindings.error.destination=myErrors`
 
+===== Using @ErrorListener for handling error messages
+
+The error messages sent to the global Spring Integration `errorChannel` can be consumed via explicit methods annotated with `@ErrorListener`.
+Since the `errorChannel` is a pub-sub message channel, there can be multiple `@ErrorListener` methods consuming the error messages and process them based on the requirements.
+
+[NOTE]
+====
+
+Since the error messages received from the `errorChannel` is always of the type `ErrorMessage`, the `@ErrorListener` annotated method should have parameter argument type `ErrorMessage`.
+
+[source,java]
+----
+
+@EnableBinding(Sink.class)
+public class MySink {
+
+	@Autowired
+    VotingService votingService;
+
+    @StreamListener(Sink.INPUT)
+    public void handle(Vote vote) {
+      votingService.record(vote);
+    }
+
+	@ErrorListener
+	public void errorHandler1(ErrorMessage errorMessage) {
+	  // do something with the errorMessage
+	}
+
+	@ErrorListener
+	public void errorHandler1(ErrorMessage errorMessage) {
+	  // do something with the errorMessage
+	}
+----
+====
+
 ===== Using @StreamListener for Automatic Content Type Handling
 
 Complementary to its Spring Integration support, Spring Cloud Stream provides its own `@StreamListener` annotation, modeled after other Spring Messaging annotations (e.g. `@MessageMapping`, `@JmsListener`, `@RabbitListener`, etc.).

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/annotation/ErrorListener.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/annotation/ErrorListener.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.support.ErrorMessage;
+
+/**
+ * Annotation that marks a method to consume {@link ErrorMessage}s from global Spring Integration errorChannel.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@MessageMapping
+@Documented
+public @interface ErrorListener {
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/DispatchingStreamListenerMessageHandler.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/DispatchingStreamListenerMessageHandler.java
@@ -110,10 +110,10 @@ final class DispatchingStreamListenerMessageHandler extends AbstractReplyProduci
 
 		private final Expression condition;
 
-		private final StreamListenerMessageHandler streamListenerMessageHandler;
+		private final ListenerMethodMessageHandler streamListenerMessageHandler;
 
 		ConditionalStreamListenerMessageHandlerWrapper(Expression condition,
-				StreamListenerMessageHandler streamListenerMessageHandler) {
+				ListenerMethodMessageHandler streamListenerMessageHandler) {
 			Assert.notNull(streamListenerMessageHandler, "the message handler cannot be null");
 			Assert.isTrue(condition == null || streamListenerMessageHandler.isVoid(),
 					"cannot specify a condition and a return value at the same time");
@@ -129,7 +129,7 @@ final class DispatchingStreamListenerMessageHandler extends AbstractReplyProduci
 			return this.streamListenerMessageHandler.isVoid();
 		}
 
-		public StreamListenerMessageHandler getStreamListenerMessageHandler() {
+		public ListenerMethodMessageHandler getStreamListenerMessageHandler() {
 			return streamListenerMessageHandler;
 		}
 	}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/ErrorListenerAnnotationBeanPostProcessor.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/ErrorListenerAnnotationBeanPostProcessor.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binding;
+
+import java.lang.reflect.Method;
+
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.cloud.stream.annotation.ErrorListener;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.integration.channel.PublishSubscribeChannel;
+import org.springframework.integration.context.IntegrationContextUtils;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.core.DestinationResolver;
+import org.springframework.messaging.handler.annotation.support.MessageHandlerMethodFactory;
+import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * A {@link BeanPostProcessor} that handles {@link ErrorListener} annotations found on bean methods.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+public class ErrorListenerAnnotationBeanPostProcessor implements BeanPostProcessor, ApplicationContextAware {
+
+	@Autowired
+	@Lazy
+	private DestinationResolver<MessageChannel> binderAwareChannelResolver;
+
+	@Autowired
+	@Lazy
+	private MessageHandlerMethodFactory messageHandlerMethodFactory;
+
+	private ConfigurableApplicationContext applicationContext;
+
+	@Override
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public final void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = (ConfigurableApplicationContext) applicationContext;
+	}
+
+	@Override
+	public final Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+		return bean;
+	}
+
+	@Override
+	public final Object postProcessAfterInitialization(final Object bean, final String beanName) throws BeansException {
+		Class<?> targetClass = AopUtils.isAopProxy(bean) ? AopUtils.getTargetClass(bean) : bean.getClass();
+		ReflectionUtils.doWithMethods(targetClass, new ReflectionUtils.MethodCallback() {
+			@Override
+			public void doWith(final Method method) throws IllegalArgumentException, IllegalAccessException {
+				ErrorListener errorListener = AnnotatedElementUtils.findMergedAnnotation(method,
+						ErrorListener.class);
+				if (errorListener != null && !method.isBridge()) {
+					registerHandlerMethodOnListenedChannel(method, errorListener, bean);
+				}
+			}
+		});
+		return bean;
+	}
+
+	protected final void registerHandlerMethodOnListenedChannel(Method method, ErrorListener errorListener,
+			Object bean) {
+		Method targetMethod = StreamListenerMethodUtils.checkProxy(method, bean);
+		final InvocableHandlerMethod invocableHandlerMethod = this.messageHandlerMethodFactory
+				.createInvocableHandlerMethod(bean, targetMethod);
+		PublishSubscribeChannel channel = this.applicationContext.getBean(
+				IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME, PublishSubscribeChannel.class);
+		ListenerMethodMessageHandler handler = new ListenerMethodMessageHandler(invocableHandlerMethod);
+		handler.setApplicationContext(this.applicationContext);
+		handler.setChannelResolver(this.binderAwareChannelResolver);
+		handler.afterPropertiesSet();
+		channel.subscribe(handler);
+	}
+
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/ListenerMethodMessageHandler.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/ListenerMethodMessageHandler.java
@@ -25,11 +25,11 @@ import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
  * @author Marius Bogoevici
  * @since 1.2
  */
-public class StreamListenerMessageHandler extends AbstractReplyProducingMessageHandler {
+public class ListenerMethodMessageHandler extends AbstractReplyProducingMessageHandler {
 
 	private final InvocableHandlerMethod invocableHandlerMethod;
 
-	StreamListenerMessageHandler(InvocableHandlerMethod invocableHandlerMethod) {
+	ListenerMethodMessageHandler(InvocableHandlerMethod invocableHandlerMethod) {
 		this.invocableHandlerMethod = invocableHandlerMethod;
 	}
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerAnnotationBeanPostProcessor.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerAnnotationBeanPostProcessor.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.springframework.aop.framework.Advised;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
@@ -347,8 +346,8 @@ public class StreamListenerAnnotationBeanPostProcessor
 			for (StreamListenerHandlerMethodMapping mapping : mappedBindingEntry.getValue()) {
 				final InvocableHandlerMethod invocableHandlerMethod = this.messageHandlerMethodFactory
 						.createInvocableHandlerMethod(mapping.getTargetBean(),
-								checkProxy(mapping.getMethod(), mapping.getTargetBean()));
-				StreamListenerMessageHandler streamListenerMessageHandler = new StreamListenerMessageHandler(
+								StreamListenerMethodUtils.checkProxy(mapping.getMethod(), mapping.getTargetBean()));
+				ListenerMethodMessageHandler streamListenerMessageHandler = new ListenerMethodMessageHandler(
 						invocableHandlerMethod);
 				streamListenerMessageHandler.setApplicationContext(this.applicationContext);
 				streamListenerMessageHandler.setBeanFactory(this.applicationContext.getBeanFactory());
@@ -388,39 +387,6 @@ public class StreamListenerAnnotationBeanPostProcessor
 			applicationContext.getBean(mappedBindingEntry.getKey(), SubscribableChannel.class).subscribe(handler);
 		}
 		this.mappedListenerMethods.clear();
-	}
-
-	private Method checkProxy(Method methodArg, Object bean) {
-		Method method = methodArg;
-		if (AopUtils.isJdkDynamicProxy(bean)) {
-			try {
-				// Found a @StreamListener method on the target class for this JDK proxy
-				// ->
-				// is it also present on the proxy itself?
-				method = bean.getClass().getMethod(method.getName(), method.getParameterTypes());
-				Class<?>[] proxiedInterfaces = ((Advised) bean).getProxiedInterfaces();
-				for (Class<?> iface : proxiedInterfaces) {
-					try {
-						method = iface.getMethod(method.getName(), method.getParameterTypes());
-						break;
-					}
-					catch (NoSuchMethodException noMethod) {
-					}
-				}
-			}
-			catch (SecurityException ex) {
-				ReflectionUtils.handleReflectionException(ex);
-			}
-			catch (NoSuchMethodException ex) {
-				throw new IllegalStateException(String.format(
-						"@StreamListener method '%s' found on bean target class '%s', "
-								+ "but not found in any interface(s) for bean JDK proxy. Either "
-								+ "pull the method up to an interface or switch to subclass (CGLIB) "
-								+ "proxies by setting proxy-target-class/proxyTargetClass attribute to 'true'",
-						method.getName(), method.getDeclaringClass().getSimpleName()), ex);
-			}
-		}
-		return method;
 	}
 
 	private String resolveExpressionAsString(String value) {

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceConfiguration.java
@@ -42,6 +42,7 @@ import org.springframework.cloud.stream.binding.BindingService;
 import org.springframework.cloud.stream.binding.CompositeMessageChannelConfigurer;
 import org.springframework.cloud.stream.binding.ContextStartAfterRefreshListener;
 import org.springframework.cloud.stream.binding.DynamicDestinationsBindable;
+import org.springframework.cloud.stream.binding.ErrorListenerAnnotationBeanPostProcessor;
 import org.springframework.cloud.stream.binding.InputBindingLifecycle;
 import org.springframework.cloud.stream.binding.MessageChannelConfigurer;
 import org.springframework.cloud.stream.binding.MessageConverterConfigurer;
@@ -106,6 +107,11 @@ public class BindingServiceConfiguration {
 	@Bean(name = STREAM_LISTENER_ANNOTATION_BEAN_POST_PROCESSOR_NAME)
 	public static StreamListenerAnnotationBeanPostProcessor streamListenerAnnotationBeanPostProcessor() {
 		return new StreamListenerAnnotationBeanPostProcessor();
+	}
+
+	@Bean
+	public static ErrorListenerAnnotationBeanPostProcessor errorListenerAnnotationBeanPostProcessor() {
+		return new ErrorListenerAnnotationBeanPostProcessor();
 	}
 
 	@Bean


### PR DESCRIPTION
 - Add @ErrorListener to consumer error messages from global Spring Integration `errorChannel`
 - Add ErrorListener annotation bean post processor that maps the listener method to subscribe to the errorChannel
 - Reuse some existing util method from StreamListener annotation bean post processor
 - Add tests
 - Update docs

Resolves #914