### PR TITLE
Adding custom interceptors during error channel binding

### DIFF
--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/ErrorChannelTests.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/ErrorChannelTests.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.annotation.EnableBinding;
@@ -32,7 +33,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.integration.annotation.InboundChannelAdapter;
 import org.springframework.integration.annotation.Poller;
-import org.springframework.integration.channel.PublishSubscribeChannel;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -49,7 +49,8 @@ import org.springframework.util.Assert;
 public class ErrorChannelTests {
 
 	@Autowired
-	private PublishSubscribeChannel errorChannel;
+	@Qualifier(BindingServiceConfiguration.ERROR_BRIDGE_CHANNEL)
+	private MessageChannel errorBridgeChannel;
 
 	@Autowired
 	private BinderFactory binderFactory;
@@ -57,7 +58,7 @@ public class ErrorChannelTests {
 	@Test
 	public void testErrorChannelBinding() throws Exception {
 		Message<?> message = ((TestSupportBinder) binderFactory.getBinder(null, MessageChannel.class))
-				.messageCollector().forChannel(errorChannel).poll(10, TimeUnit.SECONDS);
+				.messageCollector().forChannel(errorBridgeChannel).poll(10, TimeUnit.SECONDS);
 		Assert.isTrue(message instanceof ErrorMessage, "Message should be an instance of ErrorMessage");
 		Assert.isTrue(message.getPayload() instanceof MessagingException, "Message payload should be an instance" +
 				"of MessagingException");

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceConfiguration.java
@@ -166,7 +166,9 @@ public class BindingServiceConfiguration {
 	@Bean
 	@ConditionalOnProperty("spring.cloud.stream.bindings." + ERROR_CHANNEL_NAME + ".destination")
 	public SingleBindingTargetBindable<MessageChannel> errorChannelBindable(
-			@Qualifier(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME) PublishSubscribeChannel errorChannel) {
+			@Qualifier(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME) PublishSubscribeChannel errorChannel,
+			CompositeMessageChannelConfigurer compositeMessageChannelConfigurer) {
+		compositeMessageChannelConfigurer.configureOutputChannel(errorChannel, ERROR_CHANNEL_NAME);
 		return new SingleBindingTargetBindable<MessageChannel>(ERROR_CHANNEL_NAME, errorChannel);
 	}
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceConfiguration.java
@@ -88,7 +88,7 @@ public class BindingServiceConfiguration {
 
 	public static final String ERROR_BRIDGE_CHANNEL = "errorBridgeChannel";
 
-	private static final String ERROR_NAME = "error";
+	private static final String ERROR_KEY_NAME = "error";
 
 	@Autowired(required = false)
 	private ObjectMapper objectMapper;
@@ -169,7 +169,7 @@ public class BindingServiceConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnProperty("spring.cloud.stream.bindings." + ERROR_NAME + ".destination")
+	@ConditionalOnProperty("spring.cloud.stream.bindings." + ERROR_KEY_NAME + ".destination")
 	public MessageChannel errorBridgeChannel(
 			@Qualifier(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME) PublishSubscribeChannel errorChannel) {
 		SubscribableChannel errorBridgeChannel = new DirectChannel();
@@ -180,12 +180,12 @@ public class BindingServiceConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnProperty("spring.cloud.stream.bindings." + ERROR_NAME + ".destination")
+	@ConditionalOnProperty("spring.cloud.stream.bindings." + ERROR_KEY_NAME + ".destination")
 	public SingleBindingTargetBindable<MessageChannel> errorBridgeChannelBindable(
 			@Qualifier(ERROR_BRIDGE_CHANNEL) MessageChannel errorBridgeChannel,
 			CompositeMessageChannelConfigurer compositeMessageChannelConfigurer) {
-		compositeMessageChannelConfigurer.configureOutputChannel(errorBridgeChannel, ERROR_NAME);
-		return new SingleBindingTargetBindable<>(ERROR_NAME, errorBridgeChannel);
+		compositeMessageChannelConfigurer.configureOutputChannel(errorBridgeChannel, ERROR_KEY_NAME);
+		return new SingleBindingTargetBindable<>(ERROR_KEY_NAME, errorBridgeChannel);
 	}
 
 	@Bean

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/ErrorBindingTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/ErrorBindingTests.java
@@ -24,11 +24,11 @@ import org.mockito.Mockito;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.config.BindingServiceConfiguration;
 import org.springframework.cloud.stream.messaging.Processor;
 import org.springframework.cloud.stream.utils.MockBinderRegistryConfiguration;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Import;
-import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
@@ -74,7 +74,7 @@ public class ErrorBindingTests {
 		@SuppressWarnings("unchecked")
 		Binder binder = binderFactory.getBinder(null, MessageChannel.class);
 
-		MessageChannel errorChannel = applicationContext.getBean(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME,
+		MessageChannel errorChannel = applicationContext.getBean(BindingServiceConfiguration.ERROR_BRIDGE_CHANNEL,
 				MessageChannel.class);
 
 		Mockito.verify(binder).bindConsumer(eq("input"), isNull(String.class), any(MessageChannel.class),
@@ -93,7 +93,7 @@ public class ErrorBindingTests {
 				"--spring.cloud.stream.bindings.error.content-type=application/json",
 				"--server.port=0");
 
-		MessageChannel errorChannel = applicationContext.getBean(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME,
+		MessageChannel errorChannel = applicationContext.getBean(BindingServiceConfiguration.ERROR_BRIDGE_CHANNEL,
 				MessageChannel.class);
 
 		((SubscribableChannel)errorChannel).subscribe(new MessageHandler() {


### PR DESCRIPTION
Adding unit test to verify message conversion for error channel

Fix #1028 

Needs cherry-picking to the 2.0 branch. 