### PR TITLE
Adding section on cloudfoundry and VCAP_SERVICES

### DIFF
--- a/spring-cloud-stream-core-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
+++ b/spring-cloud-stream-core-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
@@ -2289,3 +2289,9 @@ hello world 1458595078733
 hello world 1458595079734
 hello world 1458595080735
 ----
+
+=== Deploying Stream applications on CloudFoundry
+
+On CloudFoundry services are usually exposed via a special environment variable called https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES[VCAP_SERVICES].
+
+When configuring your binder connections, you can use the values from an environment variable as explained on the http://docs.spring.io/spring-cloud-dataflow-server-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-ups[dataflow cloudfoundry server] docs.


### PR DESCRIPTION
Simple paragraph helping users understand VCAP_SERVICES, points to dataflow server much broader explanation.

Fixes https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/87