### PR TITLE
Use Checkstyle configs from src directly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,21 +159,14 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.springframework.cloud</groupId>
-                        <artifactId>spring-cloud-stream-tools</artifactId>
-                        <version>${project.version}</version>
-                    </dependency>
-                </dependencies>
                 <executions>
                     <execution>
                         <id>checkstyle-validation</id>
                         <phase>validate</phase>
                         <configuration>
-                            <configLocation>checkstyle.xml</configLocation>
-                            <headerLocation>checkstyle-header.txt</headerLocation>
-                            <suppressionsLocation>checkstyle-suppressions.xml</suppressionsLocation>
+                            <configLocation>spring-cloud-stream-tools/src/main/resources/checkstyle.xml</configLocation>
+                            <headerLocation>spring-cloud-stream-tools/src/main/resources/checkstyle-header.txt</headerLocation>
+                            <suppressionsLocation>spring-cloud-stream-tools/src/main/resources/checkstyle-suppressions.xml</suppressionsLocation>
                             <encoding>UTF-8</encoding>
                             <consoleOutput>true</consoleOutput>
                             <failsOnError>true</failsOnError>


### PR DESCRIPTION
Since we rely on the Checkstyle configs in the `spring-cloud-stream-tools`
module, we really need its artifact if we would like to use it as a
dependency for the `maven-checkstyle-plugin`.
But at the same time it is possible only if we run `package` phase.
During `compile/test` phase we don't have artifact yet and end up with
the error that no property set for Checkstyle.

* Use Checkstyle config files directly for the `maven-checkstyle-plugin`
properties.
This way we don't need any artifact to build in advance