### PR TITLE
Generic error handling

### DIFF
--- a/spring-cloud-stream-binder-test/src/main/java/org/springframework/cloud/stream/binder/AbstractBinderTests.java
+++ b/spring-cloud-stream-binder-test/src/main/java/org/springframework/cloud/stream/binder/AbstractBinderTests.java
@@ -48,6 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author David Turanski
  * @author Mark Fisher
  * @author Marius Bogoevici
+ * @author Vinicius Carvalho
  */
 @SuppressWarnings("unchecked")
 public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends AbstractBinder<MessageChannel, CP, PP>, CP, PP>, CP extends ConsumerProperties, PP extends ProducerProperties> {
@@ -90,14 +91,19 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 		Binder binder = getBinder();
 		Binding<MessageChannel> foo0ProducerBinding = binder.bindProducer("foo.0", new DirectChannel(),
 				createProducerProperties());
+		foo0ProducerBinding.bind();
 		Binding<MessageChannel> foo0ConsumerBinding = binder.bindConsumer("foo.0", "testClean", new DirectChannel(),
 				createConsumerProperties());
+		foo0ConsumerBinding.bind();
 		Binding<MessageChannel> foo1ProducerBinding = binder.bindProducer("foo.1", new DirectChannel(),
 				createProducerProperties());
+		foo1ProducerBinding.bind();
 		Binding<MessageChannel> foo1ConsumerBinding = binder.bindConsumer("foo.1", "testClean", new DirectChannel(),
 				createConsumerProperties());
+		foo1ConsumerBinding.bind();
 		Binding<MessageChannel> foo2ProducerBinding = binder.bindProducer("foo.2", new DirectChannel(),
 				createProducerProperties());
+		foo2ProducerBinding.bind();
 		foo0ProducerBinding.unbind();
 		assertThat(TestUtils.getPropertyValue(foo0ProducerBinding, "lifecycle", Lifecycle.class).isRunning())
 				.isFalse();
@@ -123,8 +129,10 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 		QueueChannel moduleInputChannel = new QueueChannel();
 		Binding<MessageChannel> producerBinding = binder.bindProducer("foo.0", moduleOutputChannel,
 				outputBindingProperties.getProducer());
+		producerBinding.bind();
 		Binding<MessageChannel> consumerBinding = binder.bindConsumer("foo.0", "testSendAndReceive", moduleInputChannel,
 				createConsumerProperties());
+		consumerBinding.bind();
 		Message<?> message = MessageBuilder.withPayload("foo").setHeader(MessageHeaders.CONTENT_TYPE, "foo/bar")
 				.build();
 		// Let the consumer actually bind to the producer before sending a msg
@@ -152,13 +160,17 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 
 		Binding<MessageChannel> producerBinding1 = binder.bindProducer("foo.x", moduleOutputChannel1,
 				createProducerProperties());
+		producerBinding1.bind();
 		Binding<MessageChannel> producerBinding2 = binder.bindProducer("foo.y", moduleOutputChannel2,
 				createProducerProperties());
+		producerBinding2.bind();
 
 		Binding<MessageChannel> consumerBinding1 = binder.bindConsumer("foo.x", "testSendAndReceiveMultipleTopics", moduleInputChannel,
 				createConsumerProperties());
+		consumerBinding1.bind();
 		Binding<MessageChannel> consumerBinding2 = binder.bindConsumer("foo.y", "testSendAndReceiveMultipleTopics", moduleInputChannel,
 				createConsumerProperties());
+		consumerBinding2.bind();
 
 		String testPayload1 = "foo" + UUID.randomUUID().toString();
 		Message<?> message1 = MessageBuilder.withPayload(testPayload1.getBytes()).build();
@@ -195,8 +207,10 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 		QueueChannel moduleInputChannel = new QueueChannel();
 		Binding<MessageChannel> producerBinding = binder.bindProducer("bar.0", moduleOutputChannel,
 				producerBindingProperties.getProducer());
+		producerBinding.bind();
 		Binding<MessageChannel> consumerBinding = binder.bindConsumer("bar.0", "testSendAndReceiveNoOriginalContentType", moduleInputChannel,
 				createConsumerProperties());
+		consumerBinding.bind();
 		binderBindUnbindLatency();
 
 		Message<?> message = MessageBuilder.withPayload("foo").build();

--- a/spring-cloud-stream-binder-test/src/main/java/org/springframework/cloud/stream/binder/PartitionCapableBinderTests.java
+++ b/spring-cloud-stream-binder-test/src/main/java/org/springframework/cloud/stream/binder/PartitionCapableBinderTests.java
@@ -43,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gary Russell
  * @author Mark Fisher
  * @author Marius Bogoevici
+ * @author Vinicius Carvalho
  */
 public abstract class PartitionCapableBinderTests<B extends AbstractTestBinder<? extends AbstractBinder<MessageChannel, CP, PP>, CP, PP>, CP extends ConsumerProperties, PP extends ProducerProperties>
 		extends AbstractBinderTests<B, CP, PP> {
@@ -57,14 +58,16 @@ public abstract class PartitionCapableBinderTests<B extends AbstractTestBinder<?
 		DirectChannel output = createBindableChannel("output", producerBindingProperties);
 		Binding<MessageChannel> producerBinding = binder.bindProducer("defaultGroup.0", output,
 				(PP) producerBindingProperties.getProducer());
-
+		producerBinding.bind();
 		QueueChannel input1 = new QueueChannel();
 		Binding<MessageChannel> binding1 = binder.bindConsumer("defaultGroup.0", null, input1,
 				createConsumerProperties());
+		binding1.bind();
 
 		QueueChannel input2 = new QueueChannel();
 		Binding<MessageChannel> binding2 = binder.bindConsumer("defaultGroup.0", null, input2,
 				createConsumerProperties());
+		binding2.bind();
 
 		String testPayload1 = "foo-" + UUID.randomUUID().toString();
 		output.send(new GenericMessage<>(testPayload1.getBytes()));
@@ -83,6 +86,7 @@ public abstract class PartitionCapableBinderTests<B extends AbstractTestBinder<?
 		output.send(new GenericMessage<>(testPayload2.getBytes()));
 
 		binding2 = binder.bindConsumer("defaultGroup.0", null, input2, createConsumerProperties());
+		binding2.bind();
 		String testPayload3 = "foo-" + UUID.randomUUID().toString();
 		output.send(new GenericMessage<>(testPayload3.getBytes()));
 
@@ -112,6 +116,7 @@ public abstract class PartitionCapableBinderTests<B extends AbstractTestBinder<?
 
 		producerProperties.setRequiredGroups("test1");
 		Binding<MessageChannel> producerBinding = binder.bindProducer(testDestination, output, producerProperties);
+		producerBinding.bind();
 
 		String testPayload = "foo-" + UUID.randomUUID().toString();
 		output.send(new GenericMessage<>(testPayload.getBytes()));
@@ -119,6 +124,7 @@ public abstract class PartitionCapableBinderTests<B extends AbstractTestBinder<?
 		QueueChannel inbound1 = new QueueChannel();
 		Binding<MessageChannel> consumerBinding = binder.bindConsumer(testDestination, "test1", inbound1,
 				createConsumerProperties());
+		consumerBinding.bind();
 
 		Message<?> receivedMessage1 = receive(inbound1);
 		assertThat(receivedMessage1).isNotNull();
@@ -139,6 +145,7 @@ public abstract class PartitionCapableBinderTests<B extends AbstractTestBinder<?
 
 		producerProperties.setRequiredGroups("test1", "test2");
 		Binding<MessageChannel> producerBinding = binder.bindProducer(testDestination, output, producerProperties);
+		producerBinding.bind();
 
 		String testPayload = "foo-" + UUID.randomUUID().toString();
 		output.send(new GenericMessage<>(testPayload.getBytes()));
@@ -146,9 +153,12 @@ public abstract class PartitionCapableBinderTests<B extends AbstractTestBinder<?
 		QueueChannel inbound1 = new QueueChannel();
 		Binding<MessageChannel> consumerBinding1 = binder.bindConsumer(testDestination, "test1", inbound1,
 				createConsumerProperties());
+		consumerBinding1.bind();
+
 		QueueChannel inbound2 = new QueueChannel();
 		Binding<MessageChannel> consumerBinding2 = binder.bindConsumer(testDestination, "test2", inbound2,
 				createConsumerProperties());
+		consumerBinding2.bind();
 
 		Message<?> receivedMessage1 = receive(inbound1);
 		assertThat(receivedMessage1).isNotNull();
@@ -174,14 +184,17 @@ public abstract class PartitionCapableBinderTests<B extends AbstractTestBinder<?
 		QueueChannel input0 = new QueueChannel();
 		input0.setBeanName("test.input0S");
 		Binding<MessageChannel> input0Binding = binder.bindConsumer("part.0", "testPartitionedModuleSpEL", input0, consumerProperties);
+		input0Binding.bind();
 		consumerProperties.setInstanceIndex(1);
 		QueueChannel input1 = new QueueChannel();
 		input1.setBeanName("test.input1S");
 		Binding<MessageChannel> input1Binding = binder.bindConsumer("part.0", "testPartitionedModuleSpEL", input1, consumerProperties);
+		input1Binding.bind();
 		consumerProperties.setInstanceIndex(2);
 		QueueChannel input2 = new QueueChannel();
 		input2.setBeanName("test.input2S");
 		Binding<MessageChannel> input2Binding = binder.bindConsumer("part.0", "testPartitionedModuleSpEL", input2, consumerProperties);
+		input2Binding.bind();
 
 		PP producerProperties = createProducerProperties();
 		producerProperties.setPartitionKeyExpression(spelExpressionParser.parseExpression("payload"));
@@ -191,6 +204,7 @@ public abstract class PartitionCapableBinderTests<B extends AbstractTestBinder<?
 		DirectChannel output = createBindableChannel("output", createProducerBindingProperties(producerProperties));
 		output.setBeanName("test.output");
 		Binding<MessageChannel> outputBinding = binder.bindProducer("part.0", output, producerProperties);
+		outputBinding.bind();
 		try {
 			Object endpoint = extractEndpoint(outputBinding);
 			checkRkExpressionForPartitionedModuleSpEL(endpoint);
@@ -264,14 +278,17 @@ public abstract class PartitionCapableBinderTests<B extends AbstractTestBinder<?
 		QueueChannel input0 = new QueueChannel();
 		input0.setBeanName("test.input0J");
 		Binding<MessageChannel> input0Binding = binder.bindConsumer("partJ.0", "testPartitionedModuleJava", input0, consumerProperties);
+		input0Binding.bind();
 		consumerProperties.setInstanceIndex(1);
 		QueueChannel input1 = new QueueChannel();
 		input1.setBeanName("test.input1J");
 		Binding<MessageChannel> input1Binding = binder.bindConsumer("partJ.0", "testPartitionedModuleJava", input1, consumerProperties);
+		input1Binding.bind();
 		consumerProperties.setInstanceIndex(2);
 		QueueChannel input2 = new QueueChannel();
 		input2.setBeanName("test.input2J");
 		Binding<MessageChannel> input2Binding = binder.bindConsumer("partJ.0", "testPartitionedModuleJava", input2, consumerProperties);
+		input2Binding.bind();
 
 		PP producerProperties = createProducerProperties();
 		producerProperties.setPartitionKeyExtractorClass(PartitionTestSupport.class);
@@ -280,6 +297,7 @@ public abstract class PartitionCapableBinderTests<B extends AbstractTestBinder<?
 		DirectChannel output = createBindableChannel("output", createProducerBindingProperties(producerProperties));
 		output.setBeanName("test.output");
 		Binding<MessageChannel> outputBinding = binder.bindProducer("partJ.0", output, producerProperties);
+		outputBinding.bind();
 		if (usesExplicitRouting()) {
 			Object endpoint = extractEndpoint(outputBinding);
 			assertThat(getEndpointRouting(endpoint)).contains(getExpectedRoutingBaseDestination("partJ.0", "testPartitionedModuleJava")

--- a/spring-cloud-stream-binder-test/src/test/java/org/springframework/cloud/stream/binder/MessageChannelBinderSupportTests.java
+++ b/spring-cloud-stream-binder-test/src/test/java/org/springframework/cloud/stream/binder/MessageChannelBinderSupportTests.java
@@ -26,6 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import org.springframework.cloud.stream.error.BinderErrorConfigurer;
 import org.springframework.integration.codec.kryo.KryoRegistrar;
 import org.springframework.integration.codec.kryo.PojoCodec;
 import org.springframework.integration.support.MessageBuilder;

--- a/spring-cloud-stream-binder-test/src/test/java/org/springframework/cloud/stream/binder/MessageChannelBinderSupportTests.java
+++ b/spring-cloud-stream-binder-test/src/test/java/org/springframework/cloud/stream/binder/MessageChannelBinderSupportTests.java
@@ -24,6 +24,7 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Registration;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import org.springframework.integration.codec.kryo.KryoRegistrar;
 import org.springframework.integration.codec.kryo.PojoCodec;
@@ -266,6 +267,10 @@ public class MessageChannelBinderSupportTests {
 
 	public class TestMessageChannelBinder
 			extends AbstractBinder<MessageChannel, ConsumerProperties, ProducerProperties> {
+
+		protected TestMessageChannelBinder() {
+			super(Mockito.mock(BinderErrorConfigurer.class));
+		}
 
 		@Override
 		protected Binding<MessageChannel> doBindConsumer(String name, String group, MessageChannel channel,

--- a/spring-cloud-stream-test-support/src/main/java/org/springframework/cloud/stream/test/binder/TestSupportBinder.java
+++ b/spring-cloud-stream-test-support/src/main/java/org/springframework/cloud/stream/test/binder/TestSupportBinder.java
@@ -47,6 +47,7 @@ import org.springframework.util.Assert;
  * @author Eric Bottard
  * @author Gary Russell
  * @author Mark Fisher
+ * @author Vinicius Carvalho
  * @see MessageQueueMatcher
  */
 public class TestSupportBinder implements Binder<MessageChannel, ConsumerProperties, ProducerProperties> {
@@ -135,6 +136,11 @@ public class TestSupportBinder implements Binder<MessageChannel, ConsumerPropert
 			if (messageCollector != null) {
 				messageCollector.unregister(target);
 			}
+		}
+
+		@Override
+		public MessageChannel getTarget() {
+			return target;
 		}
 	}
 }

--- a/spring-cloud-stream-test-support/src/main/java/org/springframework/cloud/stream/test/binder/TestSupportBinder.java
+++ b/spring-cloud-stream-test-support/src/main/java/org/springframework/cloud/stream/test/binder/TestSupportBinder.java
@@ -139,6 +139,11 @@ public class TestSupportBinder implements Binder<MessageChannel, ConsumerPropert
 		}
 
 		@Override
+		public void bind() {
+
+		}
+
+		@Override
 		public MessageChannel getTarget() {
 			return target;
 		}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
@@ -137,7 +137,7 @@ public abstract class AbstractBinder<T, C extends ConsumerProperties, P extends 
 		}
 		Binding<T> binding = doBindConsumer(name, group, target, properties);
 		registerErrorInfrastructure(name,group,properties);
-		configureErrorInfrastructure(name,binding.getTarget());
+		configureErrorInfrastructure(name,binding);
 		return binding;
 	}
 
@@ -189,15 +189,16 @@ public abstract class AbstractBinder<T, C extends ConsumerProperties, P extends 
 		this.errorConfigurer.destroy(destination,group,consumerProperties);
 	}
 
-	protected void configureErrorInfrastructure(String destination, T target){
-		this.errorConfigurer.configure(destination,target);
+	protected void configureErrorInfrastructure(String destination, Binding<T> binding){
+		this.errorConfigurer.configure(destination,binding);
 	}
 
 	/**
 	 * Create and configure a retry template.
-	 *
+	 * TODO: Perhaps we should deprecate this with BinderErrorConfigurer
 	 * @param properties The properties.
 	 * @return The retry template
+	 *
 	 */
 	public RetryTemplate buildRetryTemplate(ConsumerProperties properties) {
 		RetryTemplate template = new RetryTemplate();
@@ -211,4 +212,6 @@ public abstract class AbstractBinder<T, C extends ConsumerProperties, P extends 
 		template.setBackOffPolicy(backOffPolicy);
 		return template;
 	}
+
+
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
@@ -22,6 +22,7 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.cloud.stream.error.BinderErrorConfigurer;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.support.AbstractApplicationContext;

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
@@ -137,7 +137,7 @@ public abstract class AbstractBinder<T, C extends ConsumerProperties, P extends 
 			Assert.isTrue(!properties.isPartitioned(), "A consumer group is required for a partitioned subscription");
 		}
 		Binding<T> binding = doBindConsumer(name, group, target, properties);
-		registerErrorInfrastructure(binding,group,properties);
+		registerErrorInfrastructure(binding, group, properties);
 		configureErrorInfrastructure(binding);
 		return binding;
 	}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
@@ -136,8 +136,8 @@ public abstract class AbstractBinder<T, C extends ConsumerProperties, P extends 
 			Assert.isTrue(!properties.isPartitioned(), "A consumer group is required for a partitioned subscription");
 		}
 		Binding<T> binding = doBindConsumer(name, group, target, properties);
-		registerErrorInfrastructure(name,group,properties);
-		configureErrorInfrastructure(name,binding);
+		registerErrorInfrastructure(binding,group,properties);
+		configureErrorInfrastructure(binding);
 		return binding;
 	}
 
@@ -181,16 +181,16 @@ public abstract class AbstractBinder<T, C extends ConsumerProperties, P extends 
 		return "'" + expressionRoot + "-' + headers['" + BinderHeaders.PARTITION_HEADER + "']";
 	}
 
-	protected void registerErrorInfrastructure(String destination, String group, C consumerProperties){
-		this.errorConfigurer.register(destination,group,consumerProperties);
+	protected void registerErrorInfrastructure(Binding<T> binding, String group, C consumerProperties){
+		this.errorConfigurer.register(binding,group,consumerProperties);
 	}
 
-	protected void destroyErrorInfrastructure(String destination, String group, C consumerProperties){
-		this.errorConfigurer.destroy(destination,group,consumerProperties);
+	protected void destroyErrorInfrastructure(Binding<T> binding, String group, C consumerProperties){
+		this.errorConfigurer.destroy(binding,group,consumerProperties);
 	}
 
-	protected void configureErrorInfrastructure(String destination, Binding<T> binding){
-		this.errorConfigurer.configure(destination,binding);
+	protected void configureErrorInfrastructure(Binding<T> binding){
+		this.errorConfigurer.configure(binding);
 	}
 
 	/**

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.stream.binder;
 
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.cloud.stream.error.BinderErrorConfigurer;
 import org.springframework.cloud.stream.provisioning.ConsumerDestination;
 import org.springframework.cloud.stream.provisioning.ProducerDestination;
 import org.springframework.cloud.stream.provisioning.ProvisioningException;
@@ -221,12 +222,6 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 			bridge.setBeanName("bridge." + name);
 			consumerEndpoint = createConsumerEndpoint(destination, group, properties);
 			consumerEndpoint.setOutputChannel(bridge);
-//			if (consumerEndpoint instanceof InitializingBean) {
-//				((InitializingBean) consumerEndpoint).afterPropertiesSet();
-//			}
-//			if (consumerEndpoint instanceof Lifecycle) {
-//				((Lifecycle) consumerEndpoint).start();
-//			}
 			final Object endpoint = consumerEndpoint;
 			EventDrivenConsumer edc = new EventDrivenConsumer(bridge, rh);
 			edc.setBeanName("inbound." + groupedName(name, group));

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
@@ -221,12 +221,12 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 			bridge.setBeanName("bridge." + name);
 			consumerEndpoint = createConsumerEndpoint(destination, group, properties);
 			consumerEndpoint.setOutputChannel(bridge);
-			if (consumerEndpoint instanceof InitializingBean) {
-				((InitializingBean) consumerEndpoint).afterPropertiesSet();
-			}
-			if (consumerEndpoint instanceof Lifecycle) {
-				((Lifecycle) consumerEndpoint).start();
-			}
+//			if (consumerEndpoint instanceof InitializingBean) {
+//				((InitializingBean) consumerEndpoint).afterPropertiesSet();
+//			}
+//			if (consumerEndpoint instanceof Lifecycle) {
+//				((Lifecycle) consumerEndpoint).start();
+//			}
 			final Object endpoint = consumerEndpoint;
 			EventDrivenConsumer edc = new EventDrivenConsumer(bridge, rh);
 			edc.setBeanName("inbound." + groupedName(name, group));

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
@@ -248,7 +248,7 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 								.error("Exception thrown while unbinding " + this.toString(), e);
 					}
 					afterUnbindConsumer(destination, this.group, properties);
-					destroyErrorInfrastructure(destination.getName(), group, properties);
+					destroyErrorInfrastructure(this, group, properties);
 				}
 
 			};

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
@@ -19,8 +19,6 @@ package org.springframework.cloud.stream.binder;
 
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
-import org.springframework.beans.factory.support.DefaultSingletonBeanRegistry;
 import org.springframework.cloud.stream.provisioning.ConsumerDestination;
 import org.springframework.cloud.stream.provisioning.ProducerDestination;
 import org.springframework.cloud.stream.provisioning.ProvisioningException;
@@ -29,14 +27,10 @@ import org.springframework.context.Lifecycle;
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.integration.channel.FixedSubscriberChannel;
-import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.core.MessageProducer;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
-import org.springframework.integration.handler.BridgeHandler;
-import org.springframework.integration.handler.advice.ErrorMessageSendingRecoverer;
-import org.springframework.integration.support.ErrorMessageStrategy;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
@@ -60,6 +54,7 @@ import org.springframework.util.MimeTypeUtils;
  * @author Marius Bogoevici
  * @author Ilayaperumal Gopinathan
  * @author Soby Chacko
+ * @author Vinicius Carvalho
  * @since 1.1
  */
 public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties, P extends ProducerProperties, PP extends ProvisioningProvider<C, P>>
@@ -85,7 +80,8 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 	private final String[] headersToEmbed;
 
 	public AbstractMessageChannelBinder(boolean supportsHeadersNatively, String[] headersToEmbed,
-			PP provisioningProvider) {
+			PP provisioningProvider, BinderErrorConfigurer errorConfigurer) {
+		super(errorConfigurer);
 		this.supportsHeadersNatively = supportsHeadersNatively;
 		this.headersToEmbed = headersToEmbed == null ? new String[0] : headersToEmbed;
 		this.provisioningProvider = provisioningProvider;
@@ -249,7 +245,7 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 								.error("Exception thrown while unbinding " + this.toString(), e);
 					}
 					afterUnbindConsumer(destination, this.group, properties);
-					destroyErrorInfrastructure(destination, group, properties);
+					destroyErrorInfrastructure(destination.getName(), group, properties);
 				}
 
 			};
@@ -293,162 +289,7 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 	protected void afterUnbindConsumer(ConsumerDestination destination, String group, C consumerProperties) {
 	}
 
-	/**
-	 * Build an errorChannelRecoverer that writes to a pub/sub channel for the destination.
-	 * @param destination the destination.
-	 * @param group the group.
-	 * @param consumerProperties the properties.
-	 * @return the ErrorInfrastructure which is a holder for the error channel, the recoverer and the
-	 * message handler that is subscribed to the channel.
-	 */
-	protected final ErrorInfrastructure registerErrorInfrastructure(ConsumerDestination destination, String group,
-			C consumerProperties) {
-		ErrorMessageStrategy errorMessageStrategy = getErrorMessageStrategy();
-		ConfigurableListableBeanFactory beanFactory = getApplicationContext().getBeanFactory();
-		String errorChannelName = errorsBaseName(destination, group, consumerProperties);
-		SubscribableChannel errorChannel = null;
-		if (getApplicationContext().containsBean(errorChannelName)) {
-			Object errorChannelObject = getApplicationContext().getBean(errorChannelName);
-			if (!(errorChannelObject instanceof SubscribableChannel)) {
-				throw new IllegalStateException(
-						"Error channel '" + errorChannelName + "' must be a SubscribableChannel");
-			}
-			errorChannel = (SubscribableChannel) errorChannelObject;
-		}
-		else {
-			errorChannel = new BinderErrorChannel();
-			beanFactory.registerSingleton(errorChannelName, errorChannel);
-			errorChannel = (LastSubscriberAwareChannel) beanFactory.initializeBean(errorChannel, errorChannelName);
-		}
-		ErrorMessageSendingRecoverer recoverer;
-		if (errorMessageStrategy == null) {
-			recoverer = new ErrorMessageSendingRecoverer(errorChannel);
-		}
-		else {
-			recoverer = new ErrorMessageSendingRecoverer(errorChannel, errorMessageStrategy);
-		}
-		String recovererBeanName = getErrorRecovererName(destination, group, consumerProperties);
-		beanFactory.registerSingleton(recovererBeanName, recoverer);
-		beanFactory.initializeBean(recoverer, recovererBeanName);
-		MessageHandler handler = getErrorMessageHandler(destination, group, consumerProperties);
-		MessageChannel defaultErrorChannel = null;
-		if (getApplicationContext().containsBean(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME)) {
-			defaultErrorChannel = getApplicationContext().getBean(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME,
-					MessageChannel.class);
-		}
-		if (handler == null && errorChannel instanceof LastSubscriberAwareChannel) {
-			handler = getDefaultErrorMessageHandler((LastSubscriberAwareChannel) errorChannel, defaultErrorChannel != null);
-		}
-		String errorMessageHandlerName = getErrorMessageHandlerName(destination, group, consumerProperties);
-		if (handler != null) {
-			beanFactory.registerSingleton(errorMessageHandlerName, handler);
-			beanFactory.initializeBean(handler, errorMessageHandlerName);
-			errorChannel.subscribe(handler);
-		}
-		if (defaultErrorChannel != null) {
-			BridgeHandler errorBridge = new BridgeHandler();
-			errorBridge.setOutputChannel(defaultErrorChannel);
-			errorChannel.subscribe(errorBridge);
-			String errorBridgeHandlerName = getErrorBridgeName(destination, group, consumerProperties);
-			beanFactory.registerSingleton(errorBridgeHandlerName, errorBridge);
-			beanFactory.initializeBean(errorBridge, errorBridgeHandlerName);
-		}
-		return new ErrorInfrastructure(errorChannel, recoverer, handler);
-	}
 
-	private void destroyErrorInfrastructure(ConsumerDestination destination, String group, C properties) {
-		try {
-			String recoverer = getErrorRecovererName(destination, group, properties);
-			if (getApplicationContext().containsBean(recoverer)) {
-				((DefaultSingletonBeanRegistry) getApplicationContext().getBeanFactory()).destroySingleton(recoverer);
-			}
-			String errorChannelName = errorsBaseName(destination, group, properties);
-			String errorMessageHandlerName = getErrorMessageHandlerName(destination, group, properties);
-			String errorBridgeHandlerName = getErrorBridgeName(destination, group, properties);
-			MessageHandler bridgeHandler = null;
-			if (getApplicationContext().containsBean(errorBridgeHandlerName)) {
-				bridgeHandler = getApplicationContext().getBean(errorBridgeHandlerName, MessageHandler.class);
-			}
-			MessageHandler handler = null;
-			if (getApplicationContext().containsBean(errorMessageHandlerName)) {
-				handler = getApplicationContext().getBean(errorMessageHandlerName, MessageHandler.class);
-			}
-			if (getApplicationContext().containsBean(errorChannelName)) {
-				SubscribableChannel channel = getApplicationContext().getBean(errorChannelName, SubscribableChannel.class);
-				if (bridgeHandler != null) {
-					channel.unsubscribe(bridgeHandler);
-					((DefaultSingletonBeanRegistry) getApplicationContext().getBeanFactory())
-							.destroySingleton(errorBridgeHandlerName);
-				}
-				if (handler != null) {
-					channel.unsubscribe(handler);
-					((DefaultSingletonBeanRegistry) getApplicationContext().getBeanFactory())
-							.destroySingleton(errorMessageHandlerName);
-				}
-				((DefaultSingletonBeanRegistry) getApplicationContext().getBeanFactory())
-						.destroySingleton(errorChannelName);
-			}
-		}
-		catch (IllegalStateException e) {
-			// context is shutting down.
-		}
-	}
-
-	/**
-	 * Binders can return a message handler to be subscribed to the error channel.
-	 * Examples might be if the user wishes to (re)publish messages to a DLQ.
-	 * @param destination the destination.
-	 * @param group the group.
-	 * @param consumerProperties the properties.
-	 * @return the handler (may be null, which is the default, causing the exception to be
-	 * rethrown).
-	 */
-	protected MessageHandler getErrorMessageHandler(final ConsumerDestination destination, final String group,
-			final C consumerProperties) {
-		return null;
-	}
-
-	/**
-	 * Return the default error message handler, which throws the error message payload to
-	 * the caller if there are no user handlers subscribed. The handler is ordered so it
-	 * runs after any user-defined handlers that are subscribed.
-	 * @param errorChannel the error channel.
-	 * @param defaultErrorChannelPresent true if the context has a default 'errorChannel'.
-	 * @return the handler.
-	 */
-	protected MessageHandler getDefaultErrorMessageHandler(LastSubscriberAwareChannel errorChannel,
-			boolean defaultErrorChannelPresent) {
-		return new FinalRethrowingErrorMessageHandler(errorChannel, defaultErrorChannelPresent);
-	}
-
-	/**
-	 * Binders can return an {@link ErrorMessageStrategy} for building error messages; binder
-	 * implementations typically might add extra headers to the error message.
-	 * @return the implementation - may be null.
-	 */
-	protected ErrorMessageStrategy getErrorMessageStrategy() {
-		return null;
-	}
-
-	protected String getErrorRecovererName(ConsumerDestination destination, String group,
-			C consumerProperties) {
-		return errorsBaseName(destination, group, consumerProperties) + ".recoverer";
-	}
-
-	protected String getErrorMessageHandlerName(ConsumerDestination destination, String group,
-			C consumerProperties) {
-		return errorsBaseName(destination, group, consumerProperties) + ".handler";
-	}
-
-	protected String getErrorBridgeName(ConsumerDestination destination, String group,
-			C consumerProperties) {
-		return errorsBaseName(destination, group, consumerProperties) + ".bridge";
-	}
-
-	protected String errorsBaseName(ConsumerDestination destination, String group,
-			C consumerProperties) {
-		return destination.getName() + "." + group + ".errors";
-	}
 
 	private final class ReceivingHandler extends AbstractReplyProducingMessageHandler {
 
@@ -565,35 +406,6 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 		public boolean isRunning() {
 			return this.delegate instanceof Lifecycle && ((Lifecycle) this.delegate).isRunning();
 		}
-	}
-
-	protected static class ErrorInfrastructure {
-
-		private final SubscribableChannel errorChannel;
-
-		private final ErrorMessageSendingRecoverer recoverer;
-
-		private final MessageHandler handler;
-
-		ErrorInfrastructure(SubscribableChannel errorChannel, ErrorMessageSendingRecoverer recoverer,
-				MessageHandler handler) {
-			this.errorChannel = errorChannel;
-			this.recoverer = recoverer;
-			this.handler = handler;
-		}
-
-		public SubscribableChannel getErrorChannel() {
-			return this.errorChannel;
-		}
-
-		public ErrorMessageSendingRecoverer getRecoverer() {
-			return this.recoverer;
-		}
-
-		public MessageHandler getHandler() {
-			return this.handler;
-		}
-
 	}
 
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelErrorConfigurer.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelErrorConfigurer.java
@@ -191,7 +191,7 @@ public abstract class AbstractMessageChannelErrorConfigurer<C extends ConsumerPr
 
 	protected String errorsBaseName(ConsumerDestination destination, String group,
 			C consumerProperties) {
-		return destination.getName() + "." + group + ".errors";
+		return destination.getName() + ".errors";
 	}
 
 	/**

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelErrorConfigurer.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelErrorConfigurer.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.DefaultSingletonBeanRegistry;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.integration.context.IntegrationContextUtils;
+import org.springframework.integration.handler.BridgeHandler;
+import org.springframework.integration.handler.advice.ErrorMessageSendingRecoverer;
+import org.springframework.integration.support.ErrorMessageStrategy;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.SubscribableChannel;
+import org.springframework.util.Assert;
+
+/**
+ * @author Vinicius Carvalho
+ * @author Gary Russel
+ */
+public abstract class AbstractMessageChannelErrorConfigurer<C extends ConsumerProperties> implements BinderErrorConfigurer<C,MessageChannel>, ApplicationContextAware{
+
+	private volatile AbstractApplicationContext applicationContext;
+
+	private Map<String,ErrorInfrastructure> destinationErrors = new ConcurrentHashMap<>();
+
+	protected AbstractApplicationContext getApplicationContext() {
+		return this.applicationContext;
+	}
+
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		Assert.isInstanceOf(AbstractApplicationContext.class, applicationContext);
+		this.applicationContext = (AbstractApplicationContext) applicationContext;
+	}
+
+	@Override
+	public void register(String destination, String group, C consumerProperties) {
+		ErrorMessageStrategy errorMessageStrategy = getErrorMessageStrategy();
+		ConfigurableListableBeanFactory beanFactory = getApplicationContext().getBeanFactory();
+		String errorChannelName = errorsBaseName(destination, group, consumerProperties);
+		SubscribableChannel errorChannel = null;
+		if (getApplicationContext().containsBean(errorChannelName)) {
+			Object errorChannelObject = getApplicationContext().getBean(errorChannelName);
+			if (!(errorChannelObject instanceof SubscribableChannel)) {
+				throw new IllegalStateException(
+						"Error channel '" + errorChannelName + "' must be a SubscribableChannel");
+			}
+			errorChannel = (SubscribableChannel) errorChannelObject;
+		}
+		else {
+			errorChannel = new BinderErrorChannel();
+			beanFactory.registerSingleton(errorChannelName, errorChannel);
+			errorChannel = (LastSubscriberAwareChannel) beanFactory.initializeBean(errorChannel, errorChannelName);
+		}
+		ErrorMessageSendingRecoverer recoverer;
+		if (errorMessageStrategy == null) {
+			recoverer = new ErrorMessageSendingRecoverer(errorChannel);
+		}
+		else {
+			recoverer = new ErrorMessageSendingRecoverer(errorChannel, errorMessageStrategy);
+		}
+		String recovererBeanName = getErrorRecovererName(destination, group, consumerProperties);
+		beanFactory.registerSingleton(recovererBeanName, recoverer);
+		beanFactory.initializeBean(recoverer, recovererBeanName);
+		MessageHandler handler = getErrorMessageHandler(destination, group, consumerProperties);
+		MessageChannel defaultErrorChannel = null;
+		if (getApplicationContext().containsBean(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME)) {
+			defaultErrorChannel = getApplicationContext().getBean(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME,
+					MessageChannel.class);
+		}
+		if (handler == null && errorChannel instanceof LastSubscriberAwareChannel) {
+			handler = getDefaultErrorMessageHandler((LastSubscriberAwareChannel) errorChannel, defaultErrorChannel != null);
+		}
+		String errorMessageHandlerName = getErrorMessageHandlerName(destination, group, consumerProperties);
+		if (handler != null) {
+			beanFactory.registerSingleton(errorMessageHandlerName, handler);
+			beanFactory.initializeBean(handler, errorMessageHandlerName);
+			errorChannel.subscribe(handler);
+		}
+		if (defaultErrorChannel != null) {
+			BridgeHandler errorBridge = new BridgeHandler();
+			errorBridge.setOutputChannel(defaultErrorChannel);
+			errorChannel.subscribe(errorBridge);
+			String errorBridgeHandlerName = getErrorBridgeName(destination, group, consumerProperties);
+			beanFactory.registerSingleton(errorBridgeHandlerName, errorBridge);
+			beanFactory.initializeBean(errorBridge, errorBridgeHandlerName);
+		}
+		destinationErrors.put(destination,new ErrorInfrastructure(errorChannel,recoverer,handler));
+	}
+
+	@Override
+	public void destroy(String destination, String group, C consumerProperties) {
+		try {
+			String recoverer = getErrorRecovererName(destination, group, consumerProperties);
+			if (getApplicationContext().containsBean(recoverer)) {
+				((DefaultSingletonBeanRegistry) getApplicationContext().getBeanFactory()).destroySingleton(recoverer);
+			}
+			String errorChannelName = errorsBaseName(destination, group, consumerProperties);
+			String errorMessageHandlerName = getErrorMessageHandlerName(destination, group, consumerProperties);
+			String errorBridgeHandlerName = getErrorBridgeName(destination, group, consumerProperties);
+			MessageHandler bridgeHandler = null;
+			if (getApplicationContext().containsBean(errorBridgeHandlerName)) {
+				bridgeHandler = getApplicationContext().getBean(errorBridgeHandlerName, MessageHandler.class);
+			}
+			MessageHandler handler = null;
+			if (getApplicationContext().containsBean(errorMessageHandlerName)) {
+				handler = getApplicationContext().getBean(errorMessageHandlerName, MessageHandler.class);
+			}
+			if (getApplicationContext().containsBean(errorChannelName)) {
+				SubscribableChannel channel = getApplicationContext().getBean(errorChannelName, SubscribableChannel.class);
+				if (bridgeHandler != null) {
+					channel.unsubscribe(bridgeHandler);
+					((DefaultSingletonBeanRegistry) getApplicationContext().getBeanFactory())
+							.destroySingleton(errorBridgeHandlerName);
+				}
+				if (handler != null) {
+					channel.unsubscribe(handler);
+					((DefaultSingletonBeanRegistry) getApplicationContext().getBeanFactory())
+							.destroySingleton(errorMessageHandlerName);
+				}
+				((DefaultSingletonBeanRegistry) getApplicationContext().getBeanFactory())
+						.destroySingleton(errorChannelName);
+			}
+			destinationErrors.remove(destination);
+		}
+		catch (IllegalStateException e) {
+			// context is shutting down.
+		}
+	}
+
+
+	/**
+	 * Binders can return an {@link ErrorMessageStrategy} for building error messages; binder
+	 * implementations typically might add extra headers to the error message.
+	 * @return the implementation - may be null.
+	 */
+	protected ErrorMessageStrategy getErrorMessageStrategy() {
+		return null;
+	}
+
+	protected String getErrorRecovererName(String destination, String group,
+			C consumerProperties) {
+		return errorsBaseName(destination, group, consumerProperties) + ".recoverer";
+	}
+
+	protected String getErrorMessageHandlerName(String destination, String group,
+			C consumerProperties) {
+		return errorsBaseName(destination, group, consumerProperties) + ".handler";
+	}
+
+	protected String getErrorBridgeName(String destination, String group,
+			C consumerProperties) {
+		return errorsBaseName(destination, group, consumerProperties) + ".bridge";
+	}
+
+	protected String errorsBaseName(String destination, String group,
+			C consumerProperties) {
+		return destination + "." + group + ".errors";
+	}
+
+	/**
+	 * Return the default error message handler, which throws the error message payload to
+	 * the caller if there are no user handlers subscribed. The handler is ordered so it
+	 * runs after any user-defined handlers that are subscribed.
+	 * @param errorChannel the error channel.
+	 * @param defaultErrorChannelPresent true if the context has a default 'errorChannel'.
+	 * @return the handler.
+	 */
+	protected MessageHandler getDefaultErrorMessageHandler(LastSubscriberAwareChannel errorChannel,
+			boolean defaultErrorChannelPresent) {
+		return new FinalRethrowingErrorMessageHandler(errorChannel, defaultErrorChannelPresent);
+	}
+
+	/**
+	 * Binders can return a message handler to be subscribed to the error channel.
+	 * Examples might be if the user wishes to (re)publish messages to a DLQ.
+	 * @param destination the destination.
+	 * @param group the group.
+	 * @param consumerProperties the properties.
+	 * @return the handler (may be null, which is the default, causing the exception to be
+	 * rethrown).
+	 */
+	protected MessageHandler getErrorMessageHandler(final String destination, final String group,
+			final C consumerProperties) {
+		return null;
+	}
+
+	public ErrorInfrastructure getErrorInfrastructure(String destinationName){
+		return destinationErrors.get(destinationName);
+	}
+
+	protected static class ErrorInfrastructure {
+
+		private final SubscribableChannel errorChannel;
+
+		private final ErrorMessageSendingRecoverer recoverer;
+
+		private final MessageHandler handler;
+
+		ErrorInfrastructure(SubscribableChannel errorChannel, ErrorMessageSendingRecoverer recoverer,
+				MessageHandler handler) {
+			this.errorChannel = errorChannel;
+			this.recoverer = recoverer;
+			this.handler = handler;
+		}
+
+		public SubscribableChannel getErrorChannel() {
+			return this.errorChannel;
+		}
+
+		public ErrorMessageSendingRecoverer getRecoverer() {
+			return this.recoverer;
+		}
+
+		public MessageHandler getHandler() {
+			return this.handler;
+		}
+
+	}
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelErrorConfigurer.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelErrorConfigurer.java
@@ -97,7 +97,7 @@ public abstract class AbstractMessageChannelErrorConfigurer<C extends ConsumerPr
 		String recovererBeanName = getErrorRecovererName(consumerBinding.getDestination(), group, consumerProperties);
 		beanFactory.registerSingleton(recovererBeanName, recoverer);
 		beanFactory.initializeBean(recoverer, recovererBeanName);
-		MessageHandler handler = getErrorMessageHandler(consumerBinding.getDestination().getName(), group, consumerProperties);
+		MessageHandler handler = getErrorMessageHandler(consumerBinding.getDestination(), group, consumerProperties);
 		MessageChannel defaultErrorChannel = null;
 		if (getApplicationContext().containsBean(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME)) {
 			defaultErrorChannel = getApplicationContext().getBean(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME,
@@ -216,7 +216,7 @@ public abstract class AbstractMessageChannelErrorConfigurer<C extends ConsumerPr
 	 * @return the handler (may be null, which is the default, causing the exception to be
 	 * rethrown).
 	 */
-	protected MessageHandler getErrorMessageHandler(final String destination, final String group,
+	protected MessageHandler getErrorMessageHandler(final ConsumerDestination destination, final String group,
 			final C consumerProperties) {
 		return null;
 	}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderErrorConfigurer.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderErrorConfigurer.java
@@ -18,12 +18,14 @@ package org.springframework.cloud.stream.binder;
 
 
 /**
+ * Binder implementations should implement their Error Handling strategy using sub classes of this interface.
+ * The {@link AbstractBinder} uses lifecycle hooks to call each of the methods describe in this interface.
  * @author Vinicius Carvalho
- * TODO: Find a better name
+ *
  * @since 1.3
  */
 public interface BinderErrorConfigurer<C extends ConsumerProperties, T> {
 	void register(String destination, String group, C consumerProperties);
 	void destroy(String destination, String group, C consumerProperties);
-	void configure(String destination, T target);
+	void configure(String destination, Binding<T> binding);
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderErrorConfigurer.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderErrorConfigurer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder;
+
+
+/**
+ * @author Vinicius Carvalho
+ * TODO: Find a better name
+ * @since 1.3
+ */
+public interface BinderErrorConfigurer<C extends ConsumerProperties, T> {
+	void register(String destination, String group, C consumerProperties);
+	void destroy(String destination, String group, C consumerProperties);
+	void configure(String destination, T target);
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderErrorConfigurer.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderErrorConfigurer.java
@@ -25,7 +25,7 @@ package org.springframework.cloud.stream.binder;
  * @since 1.3
  */
 public interface BinderErrorConfigurer<C extends ConsumerProperties, T> {
-	void register(String destination, String group, C consumerProperties);
-	void destroy(String destination, String group, C consumerProperties);
-	void configure(String destination, Binding<T> binding);
+	void register(Binding<T> binding, String group, C consumerProperties);
+	void destroy(Binding<T> binding, String group, C consumerProperties);
+	void configure(Binding<T> binding);
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/Binding.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/Binding.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.stream.binder;
 
-import org.springframework.context.Lifecycle;
 
 /**
  * Represents a binding between an input or output and an adapter endpoint that connects
@@ -41,10 +40,15 @@ public interface Binding<T>{
 	 */
 	void unbind();
 
+	/**
+	 * Binds the target component represented by this instance. Should be used to call any
+	 * lifecycle method on the represented target. Implementations must be idempotent.
+	 * This method is called after the concrete {@link Binder} implementation returns from
+	 * its create binding methods
+	 */
 	void bind();
 
 	/**
-	 *
 	 * @return the binding target instance
 	 */
 	T getTarget();

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/Binding.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/Binding.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.stream.binder;
 
+import org.springframework.context.Lifecycle;
+
 /**
  * Represents a binding between an input or output and an adapter endpoint that connects
  * via a Binder. The binding could be for a consumer or a producer. A consumer binding
@@ -29,7 +31,7 @@ package org.springframework.cloud.stream.binder;
  * @author Vinicius Carvalho
  * @see org.springframework.cloud.stream.annotation.EnableBinding
  */
-public interface Binding<T> {
+public interface Binding<T>{
 
 	/**
 	 * Unbinds the target component represented by this instance and stops any active
@@ -38,6 +40,8 @@ public interface Binding<T> {
 	 * and a new Binding should be created instead.
 	 */
 	void unbind();
+
+	void bind();
 
 	/**
 	 *

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/Binding.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/Binding.java
@@ -26,6 +26,7 @@ package org.springframework.cloud.stream.binder;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Marius Bogoevici
+ * @author Vinicius Carvalho
  * @see org.springframework.cloud.stream.annotation.EnableBinding
  */
 public interface Binding<T> {
@@ -37,4 +38,10 @@ public interface Binding<T> {
 	 * and a new Binding should be created instead.
 	 */
 	void unbind();
+
+	/**
+	 *
+	 * @return the binding target instance
+	 */
+	T getTarget();
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ConsumerBinding.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ConsumerBinding.java
@@ -20,6 +20,8 @@ import org.springframework.cloud.stream.provisioning.ConsumerDestination;
 import org.springframework.context.Lifecycle;
 
 /**
+ * An implementation of {@link DefaultBinding} that uses {@link ConsumerDestination} as a source of configuration
+ *
  * @author Vinicius Carvalho
  */
 public class ConsumerBinding<T> extends  DefaultBinding<T, ConsumerDestination>{

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ConsumerBinding.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ConsumerBinding.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder;
+
+import org.springframework.cloud.stream.provisioning.ConsumerDestination;
+import org.springframework.context.Lifecycle;
+
+/**
+ * @author Vinicius Carvalho
+ */
+public class ConsumerBinding<T> extends  DefaultBinding<T, ConsumerDestination>{
+	/**
+	 * Creates an instance that associates a given name, group and binding target with an
+	 * optional {@link Lifecycle} component, which will be stopped during unbinding.
+	 *  @param name the name of the binding target
+	 * @param group the group (only for input targets)
+	 * @param target the binding target
+	 * @param lifecycle {@link Lifecycle} that runs while the binding is active and will
+	 * @param provisioningDestination the provisioned destination created for this binding
+	 */
+	public ConsumerBinding(String name, String group, T target, Lifecycle lifecycle, ConsumerDestination provisioningDestination) {
+		super(name, group, target, lifecycle, provisioningDestination);
+	}
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinding.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinding.java
@@ -99,6 +99,10 @@ public abstract class DefaultBinding<T,D extends Destination> implements Binding
 	protected void afterUnbind(){
 	}
 
+	/**
+	 * Listener method that executes after binding. Subclasses can implement their own
+	 * behaviour on unbinding by overriding this method.
+	 */
 	protected void afterBind() throws Exception {}
 
 	@Override

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinding.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinding.java
@@ -31,7 +31,7 @@ import org.springframework.util.ObjectUtils;
  * @author Vinicius Carvalho
  * @see org.springframework.cloud.stream.annotation.EnableBinding
  */
-public class DefaultBinding<T,D extends Destination> implements Binding<T> {
+public abstract class DefaultBinding<T,D extends Destination> implements Binding<T> {
 
 	protected final String name;
 
@@ -40,6 +40,8 @@ public class DefaultBinding<T,D extends Destination> implements Binding<T> {
 	protected final T target;
 
 	protected final Lifecycle lifecycle;
+
+	protected volatile boolean running = false;
 
 	protected final D provisioningDestination;
 
@@ -71,6 +73,17 @@ public class DefaultBinding<T,D extends Destination> implements Binding<T> {
 		return this.group;
 	}
 
+
+	@Override
+	public void bind() {
+		try {
+			afterBind();
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
 	@Override
 	public final void unbind() {
 		if (this.lifecycle != null) {
@@ -83,8 +96,10 @@ public class DefaultBinding<T,D extends Destination> implements Binding<T> {
 	 * Listener method that executes after unbinding. Subclasses can implement their own
 	 * behaviour on unbinding by overriding this method.
 	 */
-	protected void afterUnbind() {
+	protected void afterUnbind(){
 	}
+
+	protected void afterBind() throws Exception {}
 
 	@Override
 	public String toString() {
@@ -103,4 +118,6 @@ public class DefaultBinding<T,D extends Destination> implements Binding<T> {
 	public D getDestination() {
 		return provisioningDestination;
 	}
+
+
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinding.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinding.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.stream.binder;
 
+import org.springframework.cloud.stream.provisioning.Destination;
 import org.springframework.context.Lifecycle;
 import org.springframework.integration.support.context.NamedComponent;
 import org.springframework.util.Assert;
@@ -30,7 +31,7 @@ import org.springframework.util.ObjectUtils;
  * @author Vinicius Carvalho
  * @see org.springframework.cloud.stream.annotation.EnableBinding
  */
-public class DefaultBinding<T> implements Binding<T> {
+public class DefaultBinding<T,D extends Destination> implements Binding<T> {
 
 	protected final String name;
 
@@ -40,6 +41,8 @@ public class DefaultBinding<T> implements Binding<T> {
 
 	protected final Lifecycle lifecycle;
 
+	protected final D provisioningDestination;
+
 	/**
 	 * Creates an instance that associates a given name, group and binding target with an
 	 * optional {@link Lifecycle} component, which will be stopped during unbinding.
@@ -48,14 +51,16 @@ public class DefaultBinding<T> implements Binding<T> {
 	 * @param group the group (only for input targets)
 	 * @param target the binding target
 	 * @param lifecycle {@link Lifecycle} that runs while the binding is active and will
+	 * @param provisioningDestination the provisioned destination created for this binding, can be {@link org.springframework.cloud.stream.provisioning.ConsumerDestination} or {@link org.springframework.cloud.stream.provisioning.ProducerDestination}
 	 * be stopped during unbinding
 	 */
-	public DefaultBinding(String name, String group, T target, Lifecycle lifecycle) {
+	public DefaultBinding(String name, String group, T target, Lifecycle lifecycle, D provisioningDestination) {
 		Assert.notNull(target, "target must not be null");
 		this.name = name;
 		this.group = group;
 		this.target = target;
 		this.lifecycle = lifecycle;
+		this.provisioningDestination = provisioningDestination;
 	}
 
 	public String getName() {
@@ -93,5 +98,9 @@ public class DefaultBinding<T> implements Binding<T> {
 	@Override
 	public T getTarget() {
 		return this.target;
+	}
+
+	public D getDestination() {
+		return provisioningDestination;
 	}
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinding.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinding.java
@@ -27,6 +27,7 @@ import org.springframework.util.ObjectUtils;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Marius Bogoevici
+ * @author Vinicius Carvalho
  * @see org.springframework.cloud.stream.annotation.EnableBinding
  */
 public class DefaultBinding<T> implements Binding<T> {
@@ -87,5 +88,10 @@ public class DefaultBinding<T> implements Binding<T> {
 						? ((NamedComponent) this.lifecycle).getComponentName()
 						: ObjectUtils.nullSafeToString(this.lifecycle))
 				+ "]";
+	}
+
+	@Override
+	public T getTarget() {
+		return this.target;
 	}
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinding.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinding.java
@@ -80,7 +80,7 @@ public abstract class DefaultBinding<T,D extends Destination> implements Binding
 			afterBind();
 		}
 		catch (Exception e) {
-			e.printStackTrace();
+			throw new IllegalStateException(e);
 		}
 	}
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/MessageHandlerBinding.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/MessageHandlerBinding.java
@@ -22,6 +22,7 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 
 /**
+ * Implementation of {@link ProducerBinding} used by {@link AbstractMessageChannelBinder} implementations.
  * @author Vinicius Carvalho
  */
 public class MessageHandlerBinding extends ProducerBinding<MessageChannel> {

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/MessageHandlerBinding.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/MessageHandlerBinding.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder;
+
+import org.springframework.cloud.stream.provisioning.ProducerDestination;
+import org.springframework.context.Lifecycle;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHandler;
+
+/**
+ * @author Vinicius Carvalho
+ */
+public class MessageHandlerBinding extends ProducerBinding<MessageChannel> {
+
+	private MessageHandler messageHandler;
+
+	/**
+	 * Creates an instance that associates a given name, group and binding target with an
+	 * optional {@link Lifecycle} component, which will be stopped during unbinding.
+
+	 * @param name
+	the name of the binding target
+	 * @param group the group (only for input targets)
+	 * @param target the binding target
+	 * @param lifecycle {@link Lifecycle} that runs while the binding is active and will
+	 * @param provisioningDestination the provisioned destination created for this binding
+	 */
+	public MessageHandlerBinding(String name, String group, MessageChannel target, Lifecycle lifecycle, ProducerDestination
+			provisioningDestination) {
+		super(name, group, target, lifecycle, provisioningDestination);
+	}
+
+	public MessageHandler getMessageHandler() {
+		return messageHandler;
+	}
+
+	public void setMessageHandler(MessageHandler messageHandler) {
+		this.messageHandler = messageHandler;
+	}
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/MessageProducerBinding.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/MessageProducerBinding.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder;
+
+import org.springframework.cloud.stream.provisioning.ConsumerDestination;
+import org.springframework.context.Lifecycle;
+import org.springframework.integration.core.MessageProducer;
+import org.springframework.messaging.MessageChannel;
+
+/**
+ * @author Vinicius Carvalho
+ */
+public class MessageProducerBinding extends ConsumerBinding<MessageChannel> {
+
+	private MessageProducer messageProducer;
+
+	/**
+	 * Creates an instance that associates a given name, group and binding target with an
+	 * optional {@link Lifecycle} component, which will be stopped during unbinding.
+	 * @param name
+	the name of the binding target
+	 * @param group the group (only for input targets)
+	 * @param target the binding target
+	 * @param lifecycle {@link Lifecycle} that runs while the binding is active and will
+	 * @param provisioningDestination the provisioned destination created for this binding
+	}
+	 */
+	public MessageProducerBinding(String name, String group, MessageChannel target, Lifecycle lifecycle, ConsumerDestination
+			provisioningDestination) {
+		super(name, group, target, lifecycle, provisioningDestination);
+	}
+
+	public MessageProducer getMessageProducer() {
+		return messageProducer;
+	}
+
+	public void setMessageProducer(MessageProducer messageProducer) {
+		this.messageProducer = messageProducer;
+	}
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/MessageProducerBinding.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/MessageProducerBinding.java
@@ -23,6 +23,9 @@ import org.springframework.integration.core.MessageProducer;
 import org.springframework.messaging.MessageChannel;
 
 /**
+ * Implementation of {@link ConsumerBinding} used by {@link AbstractMessageChannelBinder} implementations.
+ * Uses the lifecycle hook of {@link Binding} to initialize the {@link MessageProducer} returned by {@link AbstractMessageChannelBinder#createConsumerEndpoint(ConsumerDestination, String, ConsumerProperties)}
+ *
  * @author Vinicius Carvalho
  */
 public class MessageProducerBinding extends ConsumerBinding<MessageChannel> {
@@ -46,7 +49,7 @@ public class MessageProducerBinding extends ConsumerBinding<MessageChannel> {
 	}
 
 	public MessageProducer getMessageProducer() {
-		return messageProducer;
+		return this.messageProducer;
 	}
 
 	public void setMessageProducer(MessageProducer messageProducer) {
@@ -54,12 +57,15 @@ public class MessageProducerBinding extends ConsumerBinding<MessageChannel> {
 	}
 
 	@Override
+	/**
+	 * Initializes the {@link MessageProducer} instance associated with this instance.
+	 */
 	protected void afterBind() throws Exception{
 		if (messageProducer instanceof InitializingBean) {
-			((InitializingBean) messageProducer).afterPropertiesSet();
+			((InitializingBean) this.messageProducer).afterPropertiesSet();
 		}
 		if (messageProducer instanceof Lifecycle) {
-			((Lifecycle) messageProducer).start();
+			((Lifecycle) this.messageProducer).start();
 		}
 	}
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/MessageProducerBinding.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/MessageProducerBinding.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.stream.binder;
 
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.cloud.stream.provisioning.ConsumerDestination;
 import org.springframework.context.Lifecycle;
 import org.springframework.integration.core.MessageProducer;
@@ -50,5 +51,15 @@ public class MessageProducerBinding extends ConsumerBinding<MessageChannel> {
 
 	public void setMessageProducer(MessageProducer messageProducer) {
 		this.messageProducer = messageProducer;
+	}
+
+	@Override
+	protected void afterBind() throws Exception{
+		if (messageProducer instanceof InitializingBean) {
+			((InitializingBean) messageProducer).afterPropertiesSet();
+		}
+		if (messageProducer instanceof Lifecycle) {
+			((Lifecycle) messageProducer).start();
+		}
 	}
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ProducerBinding.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ProducerBinding.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder;
+
+import org.springframework.cloud.stream.provisioning.ProducerDestination;
+import org.springframework.context.Lifecycle;
+
+/**
+ * @author Vinicius Carvalho
+ */
+public class ProducerBinding<T> extends DefaultBinding<T,ProducerDestination> {
+	/**
+	 * Creates an instance that associates a given name, group and binding target with an
+	 * optional {@link Lifecycle} component, which will be stopped during unbinding.
+	 *  @param name the name of the binding target
+	 * @param group the group (only for input targets)
+	 * @param target the binding target
+	 * @param lifecycle {@link Lifecycle} that runs while the binding is active and will
+	 * @param provisioningDestination the provisioned destination created for this binding
+	 */
+	public ProducerBinding(String name, String group, T target, Lifecycle lifecycle, ProducerDestination provisioningDestination) {
+		super(name, group, target, lifecycle, provisioningDestination);
+	}
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ProducerBinding.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ProducerBinding.java
@@ -20,6 +20,7 @@ import org.springframework.cloud.stream.provisioning.ProducerDestination;
 import org.springframework.context.Lifecycle;
 
 /**
+ * An implementation of {@link DefaultBinding} that uses {@link ProducerDestination} as a source of configuration
  * @author Vinicius Carvalho
  */
 public class ProducerBinding<T> extends DefaultBinding<T,ProducerDestination> {

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindingService.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindingService.java
@@ -97,6 +97,7 @@ public class BindingService {
 			Binding<T> binding = binder.bindConsumer(target,
 					bindingServiceProperties.getGroup(inputName), input,
 					consumerProperties);
+			binding.bind();
 			bindings.add(binding);
 		}
 		bindings = Collections.unmodifiableCollection(bindings);
@@ -123,6 +124,7 @@ public class BindingService {
 		validate(producerProperties);
 		Binding<T> binding = binder.bindProducer(bindingTarget, output,
 				producerProperties);
+		binding.bind();
 		this.producerBindings.put(outputName, binding);
 		return binding;
 	}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindingService.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindingService.java
@@ -49,6 +49,7 @@ import org.springframework.validation.beanvalidation.CustomValidatorBean;
  * @author Marius Bogoevici
  * @author Ilayaperumal Gopinathan
  * @author Gary Russell
+ * @author Vinicius Carvalho
  */
 public class BindingService {
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/error/AbstractMessageChannelErrorConfigurer.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/error/AbstractMessageChannelErrorConfigurer.java
@@ -57,7 +57,7 @@ public abstract class AbstractMessageChannelErrorConfigurer<C extends ConsumerPr
 
 	private volatile AbstractApplicationContext applicationContext;
 
-	private Map<String,ErrorInfrastructure> destinationErrors = new ConcurrentHashMap<>();
+	private Map<String,ErrorInfrastructure> errorInfrastructureMap = new ConcurrentHashMap<>();
 
 	protected final Log logger = LogFactory.getLog(getClass());
 
@@ -124,7 +124,7 @@ public abstract class AbstractMessageChannelErrorConfigurer<C extends ConsumerPr
 			beanFactory.registerSingleton(errorBridgeHandlerName, errorBridge);
 			beanFactory.initializeBean(errorBridge, errorBridgeHandlerName);
 		}
-		destinationErrors.put(consumerBinding.getDestination().getName(),new ErrorInfrastructure(errorChannel,recoverer,handler));
+		errorInfrastructureMap.put(consumerBinding.getDestination().getName(),new ErrorInfrastructure(errorChannel,recoverer,handler));
 	}
 
 	@Override
@@ -161,7 +161,7 @@ public abstract class AbstractMessageChannelErrorConfigurer<C extends ConsumerPr
 				((DefaultSingletonBeanRegistry) getApplicationContext().getBeanFactory())
 						.destroySingleton(errorChannelName);
 			}
-			destinationErrors.remove(consumerBinding.getDestination().getName());
+			errorInfrastructureMap.remove(consumerBinding.getDestination().getName());
 		}
 		catch (IllegalStateException e) {
 			// context is shutting down.
@@ -226,7 +226,7 @@ public abstract class AbstractMessageChannelErrorConfigurer<C extends ConsumerPr
 	}
 
 	public ErrorInfrastructure getErrorInfrastructure(String destinationName){
-		return destinationErrors.get(destinationName);
+		return errorInfrastructureMap.get(destinationName);
 	}
 
 	protected static class ErrorInfrastructure {

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/error/AbstractMessageChannelErrorConfigurer.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/error/AbstractMessageChannelErrorConfigurer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.stream.binder;
+package org.springframework.cloud.stream.error;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -25,6 +25,10 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.DefaultSingletonBeanRegistry;
+import org.springframework.cloud.stream.binder.Binder;
+import org.springframework.cloud.stream.binder.Binding;
+import org.springframework.cloud.stream.binder.ConsumerProperties;
+import org.springframework.cloud.stream.binder.MessageProducerBinding;
 import org.springframework.cloud.stream.provisioning.ConsumerDestination;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/error/BinderErrorChannel.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/error/BinderErrorChannel.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.stream.binder;
+package org.springframework.cloud.stream.error;
 
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/error/BinderErrorConfigurer.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/error/BinderErrorConfigurer.java
@@ -14,8 +14,12 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.stream.binder;
+package org.springframework.cloud.stream.error;
 
+
+import org.springframework.cloud.stream.binder.AbstractBinder;
+import org.springframework.cloud.stream.binder.Binding;
+import org.springframework.cloud.stream.binder.ConsumerProperties;
 
 /**
  * Binder implementations should implement their Error Handling strategy using sub classes of this interface.
@@ -25,7 +29,30 @@ package org.springframework.cloud.stream.binder;
  * @since 1.3
  */
 public interface BinderErrorConfigurer<C extends ConsumerProperties, T> {
+	/**
+	 * Registers any error infrastructure needed by the binder to handle errors.
+	 *
+	 * @param binding target binding that error configuration should be applied
+	 * @param group binding group
+	 * @param consumerProperties
+	 */
 	void register(Binding<T> binding, String group, C consumerProperties);
+
+	/**
+	 * Cleans any infrastructure created on the register method. It's up to an implementation to keep
+	 * track of any resources created so it can destroy it later.
+	 *
+	 * @param binding target binding that error configuration should be applied
+	 * @param group binding group
+	 * @param consumerProperties
+	 */
 	void destroy(Binding<T> binding, String group, C consumerProperties);
+
+	/**
+	 * Concrete implementations should override this and configure the binding target. Implementations should
+	 * keep track of what is being registered and then fetch the proper infrastructure resource to configure it.
+	 *
+	 * @param binding target binding that error configuration should be applied
+	 */
 	void configure(Binding<T> binding);
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/error/FinalRethrowingErrorMessageHandler.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/error/FinalRethrowingErrorMessageHandler.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.stream.binder;
+package org.springframework.cloud.stream.error;
 
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/error/LastSubscriberAwareChannel.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/error/LastSubscriberAwareChannel.java
@@ -14,17 +14,24 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.stream.binder;
+package org.springframework.cloud.stream.error;
 
-import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.SubscribableChannel;
 
 /**
- * A marker interface designating a subscriber that must be the last.
+ * A channel that can ensure a {@code LastSubscriberMessageHandler} is always
+ * the last subscriber.
  *
  * @author Gary Russell
  * @since 1.3
  *
  */
-public interface LastSubscriberMessageHandler extends MessageHandler {
+interface LastSubscriberAwareChannel extends SubscribableChannel {
+
+	/**
+	 * Return the current subscribers.
+	 * @return the subscribers.
+	 */
+	int subscribers();
 
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/error/LastSubscriberMessageHandler.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/error/LastSubscriberMessageHandler.java
@@ -14,24 +14,17 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.stream.binder;
+package org.springframework.cloud.stream.error;
 
-import org.springframework.messaging.SubscribableChannel;
+import org.springframework.messaging.MessageHandler;
 
 /**
- * A channel that can ensure a {@code LastSubscriberMessageHandler} is always
- * the last subscriber.
+ * A marker interface designating a subscriber that must be the last.
  *
  * @author Gary Russell
  * @since 1.3
  *
  */
-interface LastSubscriberAwareChannel extends SubscribableChannel {
-
-	/**
-	 * Return the current subscribers.
-	 * @return the subscribers.
-	 */
-	int subscribers();
+public interface LastSubscriberMessageHandler extends MessageHandler {
 
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/provisioning/Destination.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/provisioning/Destination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,18 +16,23 @@
 
 package org.springframework.cloud.stream.provisioning;
 
-import org.springframework.cloud.stream.binder.ConsumerProperties;
 
 /**
- * Represents a ConsumerDestination that provides the information about the destination
- * that is physically provisioned through
- * {@link ProvisioningProvider#provisionConsumerDestination(String, String, ConsumerProperties)}
- *
- * @author Soby Chacko
+ * Represents a destination that is provisioned via a {@link ProvisioningProvider}
  * @author Vinicius Carvalho
- *
- * @since 1.2
  */
-public interface ConsumerDestination<C extends ConsumerProperties> extends Destination<C> {
+public interface Destination<P> {
 
+	/**
+	 * Provides the destination name.
+	 *
+	 * @return destination name
+	 */
+	String getName();
+
+	/**
+	 * Provides the properties used to create this instance
+	 * @return
+	 */
+	P getProperties();
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/provisioning/ProducerDestination.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/provisioning/ProducerDestination.java
@@ -24,17 +24,11 @@ import org.springframework.cloud.stream.binder.ProducerProperties;
  * {@link ProvisioningProvider#provisionProducerDestination(String, ProducerProperties)}
  *
  * @author Soby Chacko
+ * @author Vinicius Carvalho
  *
  * @since 1.2
  */
-public interface ProducerDestination {
-
-	/**
-	 * Provides the destination name.
-	 *
-	 * @return destination name
-	 */
-	String getName();
+public interface ProducerDestination<P extends ProducerProperties> extends Destination<P> {
 
 	/**
 	 * Provides the destination name for a given partition.
@@ -54,4 +48,7 @@ public interface ProducerDestination {
 	 * @return destination name for the given partition
 	 */
 	String getNameForPartition(int partition);
+
 }
+
+

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/provisioning/ProvisioningProvider.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/provisioning/ProvisioningProvider.java
@@ -35,6 +35,7 @@ import org.springframework.cloud.stream.binder.ProducerProperties;
  * @param <P> the producer properties type
  *
  * @author Soby Chacko
+ * @author Vinicius Carvalho
  *
  * @since 1.2
  */
@@ -49,7 +50,7 @@ public interface ProvisioningProvider<C extends ConsumerProperties, P extends Pr
 	 * @return reference to {@link ProducerDestination} that represents a producer
 	 * @throws ProvisioningException on underlying provisioning errors from the middleware
 	 */
-	ProducerDestination provisionProducerDestination(String name, P properties) throws ProvisioningException;
+	ProducerDestination<P> provisionProducerDestination(String name, P properties) throws ProvisioningException;
 
 	/**
 	 * Creates the middleware destination on the physical broker for the consumer to
@@ -61,7 +62,7 @@ public interface ProvisioningProvider<C extends ConsumerProperties, P extends Pr
 	 * @return reference to {@link ConsumerDestination} that represents a consumer
 	 * @throws ProvisioningException on underlying provisioning errors from the middleware
 	 */
-	ConsumerDestination provisionConsumerDestination(String name, String group, C properties)
+	ConsumerDestination<C> provisionConsumerDestination(String name, String group, C properties)
 			throws ProvisioningException;
 
 }

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinderTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinderTests.java
@@ -200,9 +200,8 @@ public class AbstractMessageChannelBinderTests {
 
 	static class MockMessageChannelErrorConfigurer<C extends ConsumerProperties> extends AbstractMessageChannelErrorConfigurer<C>{
 
-
 		@Override
-		public void configure(String destination, MessageChannel target) {
+		public void configure(String destination, Binding<MessageChannel> binding) {
 
 		}
 	}
@@ -218,6 +217,11 @@ public class AbstractMessageChannelBinderTests {
 		@Override
 		public String getName() {
 			return this.name;
+		}
+
+		@Override
+		public Object getProperties() {
+			return null;
 		}
 
 	}

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinderTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinderTests.java
@@ -200,8 +200,9 @@ public class AbstractMessageChannelBinderTests {
 
 	static class MockMessageChannelErrorConfigurer<C extends ConsumerProperties> extends AbstractMessageChannelErrorConfigurer<C>{
 
+
 		@Override
-		public void configure(String destination, Binding<MessageChannel> binding) {
+		public void configure(Binding<MessageChannel> binding) {
 
 		}
 	}

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinderTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinderTests.java
@@ -28,6 +28,8 @@ import org.mockito.stubbing.Answer;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.cloud.stream.error.AbstractMessageChannelErrorConfigurer;
+import org.springframework.cloud.stream.error.LastSubscriberMessageHandler;
 import org.springframework.cloud.stream.provisioning.ConsumerDestination;
 import org.springframework.cloud.stream.provisioning.ProducerDestination;
 import org.springframework.cloud.stream.provisioning.ProvisioningProvider;
@@ -188,11 +190,11 @@ public class AbstractMessageChannelBinderTests {
 
 	}
 
-	static class MockMessageChannelErrorConfigurer<C extends ConsumerProperties> extends AbstractMessageChannelErrorConfigurer<C>{
+	static class MockMessageChannelErrorConfigurer<C extends ConsumerProperties> extends AbstractMessageChannelErrorConfigurer<C> {
 
 		private final boolean hasRecoverer;
 
-		public MockMessageChannelErrorConfigurer(ApplicationContext context, boolean hasRecoverer) {
+		MockMessageChannelErrorConfigurer(ApplicationContext context, boolean hasRecoverer) {
 			this.hasRecoverer = hasRecoverer;
 			setApplicationContext(context);
 		}

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinderTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinderTests.java
@@ -28,7 +28,7 @@ import org.mockito.stubbing.Answer;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.cloud.stream.binder.AbstractMessageChannelBinder.ErrorInfrastructure;
+import org.springframework.cloud.stream.binder.AbstractMessageChannelErrorConfigurer.ErrorInfrastructure;
 import org.springframework.cloud.stream.provisioning.ConsumerDestination;
 import org.springframework.cloud.stream.provisioning.ProducerDestination;
 import org.springframework.cloud.stream.provisioning.ProvisioningProvider;
@@ -151,7 +151,7 @@ public class AbstractMessageChannelBinderTests {
 
 		@SuppressWarnings("unchecked")
 		StubMessageChannelBinder(boolean hasRecoverer) {
-			super(true, null, Mockito.mock(ProvisioningProvider.class));
+			super(true, null, Mockito.mock(ProvisioningProvider.class), new MockMessageChannelErrorConfigurer());
 			mockProvisioner();
 			this.hasRecoverer = hasRecoverer;
 		}
@@ -179,14 +179,13 @@ public class AbstractMessageChannelBinderTests {
 		@Override
 		protected MessageProducer createConsumerEndpoint(ConsumerDestination destination, String group,
 				ConsumerProperties properties) throws Exception {
-			this.errorInfrastructure = registerErrorInfrastructure(destination, group, properties);
+
 			MessageProducer adapter = Mockito.mock(MessageProducer.class,
 					Mockito.withSettings().extraInterfaces(Lifecycle.class, InitializingBean.class,
 							DisposableBean.class));
 			return adapter;
 		}
 
-		@Override
 		protected MessageHandler getErrorMessageHandler(ConsumerDestination destination, String group,
 				ConsumerProperties consumerProperties) {
 			if (this.hasRecoverer) {
@@ -197,6 +196,15 @@ public class AbstractMessageChannelBinderTests {
 			}
 		}
 
+	}
+
+	static class MockMessageChannelErrorConfigurer<C extends ConsumerProperties> extends AbstractMessageChannelErrorConfigurer<C>{
+
+
+		@Override
+		public void configure(String destination, MessageChannel target) {
+
+		}
 	}
 
 	private static class SimpleConsumerDestination implements ConsumerDestination {

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/BinderAwareChannelResolverTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/BinderAwareChannelResolverTests.java
@@ -253,6 +253,11 @@ public class BinderAwareChannelResolverTests {
 			}
 
 			@Override
+			public void bind() {
+				bound = true;
+			}
+
+			@Override
 			public MessageChannel getTarget() {
 				return null;
 			}

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/BinderAwareChannelResolverTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/BinderAwareChannelResolverTests.java
@@ -252,6 +252,11 @@ public class BinderAwareChannelResolverTests {
 				destinations.get(name).unsubscribe(directHandler);
 			}
 
+			@Override
+			public MessageChannel getTarget() {
+				return null;
+			}
+
 			public boolean isBound() {
 				return bound;
 			}

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/ExtendedPropertiesBinderAwareChannelResolverTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/ExtendedPropertiesBinderAwareChannelResolverTests.java
@@ -202,6 +202,11 @@ public class ExtendedPropertiesBinderAwareChannelResolverTests extends BinderAwa
 			}
 
 			@Override
+			public MessageChannel getTarget() {
+				return null;
+			}
+
+			@Override
 			public void unbind() {
 				bound = false;
 				destinations.get(name).unsubscribe(directHandler);

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/ExtendedPropertiesBinderAwareChannelResolverTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/ExtendedPropertiesBinderAwareChannelResolverTests.java
@@ -207,6 +207,11 @@ public class ExtendedPropertiesBinderAwareChannelResolverTests extends BinderAwa
 			}
 
 			@Override
+			public void bind() {
+				bound = true;
+			}
+
+			@Override
 			public void unbind() {
 				bound = false;
 				destinations.get(name).unsubscribe(directHandler);


### PR DESCRIPTION
This PR fixes #1036 

A great amount of changes happened here, I'll try to summarize some of them in order to make reviewing easier.

General idea was to pull any code for ErrorInfrastructure from `AbstractMessageChannelBinder` to become available on `AbstractBinder`. 

In order to achieve some of that, some core Interfaces needed a boost:

 - `Binding` -> A new lifecycle `bind()` method was added, so that `BindingService` could trigger any error handling configuration at the right time. The RabbitBinder had issues if we triggered the lifecycle of MessageProducers too early. A new `getTarget` method was also provided to allow implementations to fetch the target binding in case they needed to configure it.  As a side note, this is probably hinting that `Binding` should be a full blown Spring Bean, where we would allow the container to control it's lifecycle as well provide way for users to add interceptors and other stuff. Should be something to consider on 2.0 baseline

- Several `Binding` implementations. `DefaultBinding` was given a boost, and added a generic type `D` used by implementations to pass along `ConsumerDestination` or `ProducerDestination` both which are required by the error infrastructure.

- `ProvisioningProvider` - The `ConsumerDestination` and `ProducerDestination` now hold a reference to the relevant `ConsumerProperties` and `ProducerProperties`. The creation method for those types already had that reference and since the error configurer needed those, this was the least invasive way to provide : `defaultBinding.getDestination().getProperties()`

- Several test cases were updated, since we now rely on lifecycle `bind()` called via `BindingService` and those tests create binders directly, the invocation for this method was added there.

- `BinderErrorConfigurer` : a new interface that Binder implementations should provide, the `AbstractBinder` has hooks to delegate to the binder implementation of this interface. An abstract version of MessageChannel types is provided : `AbstractMessageChannelErrorConfigurer` much like the `AbstractMessageChannelBinder`

- `AbstractBinder` : Added a few lifecycle methods, and now requires an `BinderErrorConfigurer` type

- All Error types are now under `binder.error` package

The rabbit binder is complete, and I'm starting to work on the kafka binder now, I realize that this could trigger changes on the proposed changes on this PR, but given the size of this PR I'd rather have people providing feedback sooner rather than later.