### PR TITLE
Fixes issue with originalContentTypeHeader

### DIFF
--- a/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/AvroMessageConverterAutoConfiguration.java
+++ b/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/AvroMessageConverterAutoConfiguration.java
@@ -24,7 +24,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
-import org.springframework.cloud.stream.binder.StringConvertingContentTypeResolver;
 import org.springframework.cloud.stream.schema.client.SchemaRegistryClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -52,7 +51,6 @@ public class AvroMessageConverterAutoConfiguration {
 				schemaRegistryClient);
 		avroSchemaRegistryClientMessageConverter.setDynamicSchemaGenerationEnabled(
 				this.avroMessageConverterProperties.isDynamicSchemaGenerationEnabled());
-		avroSchemaRegistryClientMessageConverter.setContentTypeResolver(new StringConvertingContentTypeResolver());
 		if (this.avroMessageConverterProperties.getReaderSchema() != null) {
 			avroSchemaRegistryClientMessageConverter.setReaderSchema(
 					this.avroMessageConverterProperties.getReaderSchema());

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/OriginalContentTypeResolver.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/OriginalContentTypeResolver.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.converter.ContentTypeResolver;
+import org.springframework.util.MimeType;
+
+/**
+ * @author Vinicius Carvalho
+ *
+ * Resolves contentType looking for a originalContentType header first. If not found
+ * returns the contentType
+ *
+ */
+public class OriginalContentTypeResolver implements ContentTypeResolver {
+
+	private ConcurrentMap<String, MimeType> mimeTypeCache = new ConcurrentHashMap<>();
+
+	@Override
+	public MimeType resolve(MessageHeaders headers) {
+		Object contentType = headers
+				.get(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE) != null
+						? headers.get(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE)
+						: headers.get(MessageHeaders.CONTENT_TYPE);
+		MimeType mimeType = null;
+		if (contentType instanceof MimeType) {
+			mimeType = (MimeType) contentType;
+		}
+		else if (contentType instanceof String) {
+			mimeType = mimeTypeCache.get(contentType);
+			if (mimeType == null) {
+				String valueAsString = (String) contentType;
+				mimeType = MimeType.valueOf(valueAsString);
+				mimeTypeCache.put(valueAsString, mimeType);
+			}
+		}
+		return mimeType;
+	}
+}


### PR DESCRIPTION
- Fixes #1072 
- Added a new ContentTypeResolver that searches for originalContentType
  as well as contentType headers
- This should fix issues with converters not being able to find the proper contentType information. The new Resolver could be used in 2.0 line as a fallback to read messages from 1.3 producers