### PR TITLE
Fixing @Transformer for ProcessorApplication.

### DIFF
--- a/spring-cloud-stream-core-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
+++ b/spring-cloud-stream-core-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
@@ -790,6 +790,8 @@ A possible alternative is to provide the source, sink or processor configuration
 ----
 package com.app.mysink;
 
+// Imports omitted
+
 @SpringBootApplication
 @EnableBinding(Sink.class)
 public class SinkApplication {
@@ -813,7 +815,7 @@ package com.app.myprocessor;
 @EnableBinding(Processor.class)
 public class ProcessorApplication {
 
-	@Transformer
+	@Transformer(inputChannel = Processor.INPUT, outputChannel = Processor.OUTPUT)
 	public String loggerSink(String payload) {
 		return payload.toUpperCase();
 	}


### PR DESCRIPTION
Without explicitly naming the `inputChannel` and `outputChannel`, well get this error on startup `org.springframework.integration.MessageDispatchingException: Dispatcher has no subscribers`.

Also adding the `// Imports omitted` that appeared in the other Application classes.