### PR TITLE
KAFKA GH-223: Handle unexpected content type

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/MessageSerializationUtils.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/MessageSerializationUtils.java
@@ -147,6 +147,9 @@ public abstract class MessageSerializationUtils {
 		}
 		else {
 			String className = JavaClassMimeTypeUtils.classNameFromMimeType(contentType);
+			if (className == null) {
+				return bytes;
+			}
 			try {
 				// Cache types to avoid unnecessary ClassUtils.forName calls.
 				Class<?> targetType = payloadTypeCache.get(className);


### PR DESCRIPTION
See https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/223

When using native encoding; NPE when no class name derived from the content type.

Do not attempt deserialization if `JavaClassMimeTypeUtils.classNameFromMimeType(contentType)`
returns `null`.

Test case in the Kafka binder.

__cherry-pick to master__