### PR TITLE
Configurable subject naming for Avro classes

### DIFF
--- a/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/AvroMessageConverterAutoConfiguration.java
+++ b/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/AvroMessageConverterAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.stream.schema.avro;
 
+import java.lang.reflect.Constructor;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -30,8 +32,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.ReflectionUtils;
-
-import java.lang.reflect.Constructor;
 
 /**
  * @author Marius Bogoevici

--- a/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/AvroMessageConverterAutoConfiguration.java
+++ b/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/AvroMessageConverterAutoConfiguration.java
@@ -28,7 +28,6 @@ import org.springframework.cloud.stream.annotation.StreamMessageConverter;
 import org.springframework.cloud.stream.schema.client.SchemaRegistryClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.util.ClassUtils;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.ReflectionUtils;
 

--- a/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/AvroMessageConverterAutoConfiguration.java
+++ b/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/AvroMessageConverterAutoConfiguration.java
@@ -28,7 +28,11 @@ import org.springframework.cloud.stream.annotation.StreamMessageConverter;
 import org.springframework.cloud.stream.schema.client.SchemaRegistryClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.ClassUtils;
 import org.springframework.util.ObjectUtils;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Constructor;
 
 /**
  * @author Marius Bogoevici
@@ -63,6 +67,21 @@ public class AvroMessageConverterAutoConfiguration {
 		}
 		avroSchemaRegistryClientMessageConverter.setPrefix(this.avroMessageConverterProperties.getPrefix());
 		avroSchemaRegistryClientMessageConverter.setCacheManager(cacheManager());
+
+		try {
+			Class clazz = this.avroMessageConverterProperties.getSubjectNamingStrategy();
+			Constructor constructor = ReflectionUtils.accessibleConstructor(clazz);
+
+			avroSchemaRegistryClientMessageConverter.setSubjectNamingStrategy(
+					(SubjectNamingStrategy) constructor.newInstance()
+			);
+		} catch (Exception ex) {
+			throw new IllegalStateException("Unable to create SubjectNamingStrategy " +
+					this.avroMessageConverterProperties.getSubjectNamingStrategy().toString(),
+					ex
+			);
+		}
+
 		return avroSchemaRegistryClientMessageConverter;
 	}
 

--- a/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/AvroMessageConverterProperties.java
+++ b/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/AvroMessageConverterProperties.java
@@ -34,6 +34,8 @@ public class AvroMessageConverterProperties {
 
 	private String prefix = "vnd";
 
+	private Class<? extends SubjectNamingStrategy> subjectNamingStrategy = DefaultSubjectNamingStrategy.class;
+
 	public Resource getReaderSchema() {
 		return this.readerSchema;
 	}
@@ -66,5 +68,14 @@ public class AvroMessageConverterProperties {
 
 	public void setPrefix(String prefix) {
 		this.prefix = prefix;
+	}
+
+	public Class<?> getSubjectNamingStrategy() {
+		return subjectNamingStrategy;
+	}
+
+	public void setSubjectNamingStrategy(Class<? extends SubjectNamingStrategy>  subjectNamingStrategy) {
+		Assert.notNull(subjectNamingStrategy, "cannot be null");
+		this.subjectNamingStrategy = subjectNamingStrategy;
 	}
 }

--- a/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/AvroSchemaRegistryClientMessageConverter.java
+++ b/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/AvroSchemaRegistryClientMessageConverter.java
@@ -100,6 +100,8 @@ public class AvroSchemaRegistryClientMessageConverter extends AbstractAvroMessag
 
 	private String prefix = "vnd";
 
+	private SubjectNamingStrategy subjectNamingStrategy;
+
 	/**
 	 * @deprecated as of release 1.2.2 in favor of
 	 * {@link #AvroSchemaRegistryClientMessageConverter(SchemaRegistryClient, CacheManager)}
@@ -205,7 +207,7 @@ public class AvroSchemaRegistryClientMessageConverter extends AbstractAvroMessag
 	}
 
 	protected String toSubject(Schema schema) {
-		return schema.getName().toLowerCase();
+		return subjectNamingStrategy.toSubject(schema);
 	}
 
 	@Override
@@ -346,5 +348,9 @@ public class AvroSchemaRegistryClientMessageConverter extends AbstractAvroMessag
 	public void setCacheManager(CacheManager cacheManager) {
 		Assert.notNull(cacheManager, "'cacheManager' cannot be null");
 		this.cacheManager = cacheManager;
+	}
+
+	public void setSubjectNamingStrategy(SubjectNamingStrategy subjectNamingStrategy) {
+		this.subjectNamingStrategy = subjectNamingStrategy;
 	}
 }

--- a/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/DefaultSubjectNamingStrategy.java
+++ b/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/DefaultSubjectNamingStrategy.java
@@ -7,8 +7,8 @@ import org.apache.avro.Schema;
  */
 public class DefaultSubjectNamingStrategy implements SubjectNamingStrategy {
 
-    @Override
-    public String toSubject(Schema schema) {
-        return schema.getName().toLowerCase();
-    }
+	@Override
+	public String toSubject(Schema schema) {
+		return schema.getName().toLowerCase();
+	}
 }

--- a/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/DefaultSubjectNamingStrategy.java
+++ b/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/DefaultSubjectNamingStrategy.java
@@ -1,0 +1,14 @@
+package org.springframework.cloud.stream.schema.avro;
+
+import org.apache.avro.Schema;
+
+/**
+ * @author David Kalosi
+ */
+public class DefaultSubjectNamingStrategy implements SubjectNamingStrategy {
+
+    @Override
+    public String toSubject(Schema schema) {
+        return schema.getName().toLowerCase();
+    }
+}

--- a/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/DefaultSubjectNamingStrategy.java
+++ b/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/DefaultSubjectNamingStrategy.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.stream.schema.avro;
 
 import org.apache.avro.Schema;

--- a/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/SubjectNamingStrategy.java
+++ b/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/SubjectNamingStrategy.java
@@ -1,0 +1,16 @@
+package org.springframework.cloud.stream.schema.avro;
+
+import org.apache.avro.Schema;
+
+/**
+ * @author David Kalosi
+ */
+public interface SubjectNamingStrategy {
+
+    /**
+     * Takes the Avro schema on input and returns the generated subject under which the schema should be registered.
+     * @param schema
+     * @return subject name
+     */
+    String toSubject(Schema schema);
+}

--- a/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/SubjectNamingStrategy.java
+++ b/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/SubjectNamingStrategy.java
@@ -1,8 +1,25 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.stream.schema.avro;
 
 import org.apache.avro.Schema;
 
 /**
+ * Provides function towards naming schema registry subjects for Avro files.
  * @author David Kalosi
  */
 public interface SubjectNamingStrategy {

--- a/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/SubjectNamingStrategy.java
+++ b/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/SubjectNamingStrategy.java
@@ -7,10 +7,10 @@ import org.apache.avro.Schema;
  */
 public interface SubjectNamingStrategy {
 
-    /**
-     * Takes the Avro schema on input and returns the generated subject under which the schema should be registered.
-     * @param schema
-     * @return subject name
-     */
-    String toSubject(Schema schema);
+	/**
+	 * Takes the Avro schema on input and returns the generated subject under which the schema should be registered.
+	 * @param schema
+	 * @return subject name
+	 */
+	String toSubject(Schema schema);
 }

--- a/spring-cloud-stream-schema/src/test/java/org/springframework/cloud/schema/avro/AvroMessageConverterSerializationTests.java
+++ b/spring-cloud-stream-schema/src/test/java/org/springframework/cloud/schema/avro/AvroMessageConverterSerializationTests.java
@@ -41,6 +41,7 @@ import org.springframework.cache.support.NoOpCacheManager;
 import org.springframework.cloud.stream.binder.BinderHeaders;
 import org.springframework.cloud.stream.schema.SchemaReference;
 import org.springframework.cloud.stream.schema.avro.AvroSchemaRegistryClientMessageConverter;
+import org.springframework.cloud.stream.schema.avro.DefaultSubjectNamingStrategy;
 import org.springframework.cloud.stream.schema.client.DefaultSchemaRegistryClient;
 import org.springframework.cloud.stream.schema.client.SchemaRegistryClient;
 import org.springframework.cloud.stream.schema.server.SchemaRegistryServerApplication;
@@ -86,6 +87,8 @@ public class AvroMessageConverterSerializationTests {
 		SchemaRegistryClient client = new DefaultSchemaRegistryClient();
 		AvroSchemaRegistryClientMessageConverter converter = new AvroSchemaRegistryClientMessageConverter(
 				client, new NoOpCacheManager());
+
+		converter.setSubjectNamingStrategy(new DefaultSubjectNamingStrategy());
 		converter.setDynamicSchemaGenerationEnabled(false);
 		converter.afterPropertiesSet();
 

--- a/spring-cloud-stream-schema/src/test/java/org/springframework/cloud/schema/avro/CustomSubjectNamingStrategy.java
+++ b/spring-cloud-stream-schema/src/test/java/org/springframework/cloud/schema/avro/CustomSubjectNamingStrategy.java
@@ -1,18 +1,35 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.schema.avro;
 
 import org.apache.avro.Schema;
+
 import org.springframework.cloud.stream.schema.avro.SubjectNamingStrategy;
 
 /**
- * Created by david.kalosi on 10/23/2017.
+ * @author David Kalosi
  */
 class CustomSubjectNamingStrategy implements SubjectNamingStrategy {
 
-    public CustomSubjectNamingStrategy() {
-    }
+	CustomSubjectNamingStrategy() {
+	}
 
-    @Override
-    public String toSubject(Schema schema) {
-        return schema.getFullName();
-    }
+	@Override
+	public String toSubject(Schema schema) {
+		return schema.getFullName();
+	}
 }

--- a/spring-cloud-stream-schema/src/test/java/org/springframework/cloud/schema/avro/CustomSubjectNamingStrategy.java
+++ b/spring-cloud-stream-schema/src/test/java/org/springframework/cloud/schema/avro/CustomSubjectNamingStrategy.java
@@ -1,0 +1,18 @@
+package org.springframework.cloud.schema.avro;
+
+import org.apache.avro.Schema;
+import org.springframework.cloud.stream.schema.avro.SubjectNamingStrategy;
+
+/**
+ * Created by david.kalosi on 10/23/2017.
+ */
+class CustomSubjectNamingStrategy implements SubjectNamingStrategy {
+
+    public CustomSubjectNamingStrategy() {
+    }
+
+    @Override
+    public String toSubject(Schema schema) {
+        return schema.getFullName();
+    }
+}

--- a/spring-cloud-stream-schema/src/test/java/org/springframework/cloud/schema/avro/SubjectNamingStrategyTest.java
+++ b/spring-cloud-stream-schema/src/test/java/org/springframework/cloud/schema/avro/SubjectNamingStrategyTest.java
@@ -1,12 +1,30 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.schema.avro;
 
-import org.apache.avro.Schema;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
 import org.junit.Test;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.messaging.Source;
-import org.springframework.cloud.stream.schema.avro.SubjectNamingStrategy;
 import org.springframework.cloud.stream.schema.client.SchemaRegistryClient;
 import org.springframework.cloud.stream.test.binder.MessageCollector;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -14,48 +32,45 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Created by david.kalosi on 10/23/2017.
+ * @author David Kalosi
  */
 public class SubjectNamingStrategyTest {
 
-    static StubSchemaRegistryClient stubSchemaRegistryClient = new StubSchemaRegistryClient();
+	static StubSchemaRegistryClient stubSchemaRegistryClient = new StubSchemaRegistryClient();
 
-    @Test
-    public void testCustomNamingStrategy() throws Exception{
-        ConfigurableApplicationContext sourceContext = SpringApplication.run(AvroSourceApplication.class,
-             "--server.port=0",
-             "--debug",
-             "--spring.jmx.enabled=false",
-             "--spring.cloud.stream.bindings.output.contentType=application/*+avro",
-             "--spring.cloud.stream.schema.avro.subjectNamingStrategy=org.springframework.cloud.schema.avro.CustomSubjectNamingStrategy",
-             "--spring.cloud.stream.schema.avro.dynamicSchemaGenerationEnabled=true");
+	@Test
+	public void testCustomNamingStrategy() throws Exception {
+		ConfigurableApplicationContext sourceContext = SpringApplication.run(AvroSourceApplication.class,
+			"--server.port=0",
+			"--debug",
+			"--spring.jmx.enabled=false",
+			"--spring.cloud.stream.bindings.output.contentType=application/*+avro",
+			"--spring.cloud.stream.schema.avro.subjectNamingStrategy=org.springframework.cloud.schema.avro.CustomSubjectNamingStrategy",
+			"--spring.cloud.stream.schema.avro.dynamicSchemaGenerationEnabled=true");
 
-        Source source = sourceContext.getBean(Source.class);
-        User1 user1 = new User1();
-        user1.setFavoriteColor("foo" + UUID.randomUUID().toString());
-        user1.setName("foo" + UUID.randomUUID().toString());
-        source.output().send(MessageBuilder.withPayload(user1).build());
+		Source source = sourceContext.getBean(Source.class);
+		User1 user1 = new User1();
+		user1.setFavoriteColor("foo" + UUID.randomUUID().toString());
+		user1.setName("foo" + UUID.randomUUID().toString());
+		source.output().send(MessageBuilder.withPayload(user1).build());
 
-        MessageCollector barSourceMessageCollector = sourceContext.getBean(MessageCollector.class);
-        Message<?> message = barSourceMessageCollector.forChannel(source.output()).poll(1000, TimeUnit.MILLISECONDS);
+		MessageCollector barSourceMessageCollector = sourceContext.getBean(MessageCollector.class);
+		Message<?> message = barSourceMessageCollector.forChannel(source.output()).poll(1000, TimeUnit.MILLISECONDS);
 
-        assertThat(message.getHeaders().get("contentType"))
-                .isEqualTo("application/vnd.org.springframework.cloud.schema.avro.User1.v1+avro");
-    }
+		assertThat(message.getHeaders().get("contentType"))
+				.isEqualTo("application/vnd.org.springframework.cloud.schema.avro.User1.v1+avro");
+	}
 
-    @EnableBinding(Source.class)
-    @EnableAutoConfiguration
-    public static class AvroSourceApplication {
+	@EnableBinding(Source.class)
+	@EnableAutoConfiguration
+	public static class AvroSourceApplication {
 
-        @Bean
-        public SchemaRegistryClient schemaRegistryClient() {
-            return stubSchemaRegistryClient;
-        }
-    }
+		@Bean
+		public SchemaRegistryClient schemaRegistryClient() {
+			return stubSchemaRegistryClient;
+		}
+	}
 }

--- a/spring-cloud-stream-schema/src/test/java/org/springframework/cloud/schema/avro/SubjectNamingStrategyTest.java
+++ b/spring-cloud-stream-schema/src/test/java/org/springframework/cloud/schema/avro/SubjectNamingStrategyTest.java
@@ -1,0 +1,61 @@
+package org.springframework.cloud.schema.avro;
+
+import org.apache.avro.Schema;
+import org.junit.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.messaging.Source;
+import org.springframework.cloud.stream.schema.avro.SubjectNamingStrategy;
+import org.springframework.cloud.stream.schema.client.SchemaRegistryClient;
+import org.springframework.cloud.stream.test.binder.MessageCollector;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Created by david.kalosi on 10/23/2017.
+ */
+public class SubjectNamingStrategyTest {
+
+    static StubSchemaRegistryClient stubSchemaRegistryClient = new StubSchemaRegistryClient();
+
+    @Test
+    public void testCustomNamingStrategy() throws Exception{
+        ConfigurableApplicationContext sourceContext = SpringApplication.run(AvroSourceApplication.class,
+             "--server.port=0",
+             "--debug",
+             "--spring.jmx.enabled=false",
+             "--spring.cloud.stream.bindings.output.contentType=application/*+avro",
+             "--spring.cloud.stream.schema.avro.subjectNamingStrategy=org.springframework.cloud.schema.avro.CustomSubjectNamingStrategy",
+             "--spring.cloud.stream.schema.avro.dynamicSchemaGenerationEnabled=true");
+
+        Source source = sourceContext.getBean(Source.class);
+        User1 user1 = new User1();
+        user1.setFavoriteColor("foo" + UUID.randomUUID().toString());
+        user1.setName("foo" + UUID.randomUUID().toString());
+        source.output().send(MessageBuilder.withPayload(user1).build());
+
+        MessageCollector barSourceMessageCollector = sourceContext.getBean(MessageCollector.class);
+        Message<?> message = barSourceMessageCollector.forChannel(source.output()).poll(1000, TimeUnit.MILLISECONDS);
+
+        assertThat(message.getHeaders().get("contentType"))
+                .isEqualTo("application/vnd.org.springframework.cloud.schema.avro.User1.v1+avro");
+    }
+
+    @EnableBinding(Source.class)
+    @EnableAutoConfiguration
+    public static class AvroSourceApplication {
+
+        @Bean
+        public SchemaRegistryClient schemaRegistryClient() {
+            return stubSchemaRegistryClient;
+        }
+    }
+}


### PR DESCRIPTION
Hi All,

this PR is an attempt to provide a flexible way of controlling the subject naming for Avro classes and Schema registry integration. 

Given the model class ```org.springframework.cloud.schema.avro.User1``` the current solution is generating content type headers in the following format ```application/vnd.user1.v1+avro``` or by calling ```return schema.getName().toLowerCase();```.  Those are then registered in the schema registry with a subject user1, which is pretty ambiguous. In the current project we need a much more robust behaviour and agreed that the headers should ideally look like this ```application/vnd.org.springframework.cloud.schema.avro.User1.v1+avro``` - with the FQCN as the subject. This will then register the full class name as subject to the schema registry. 

In this PR I have extracted the naming to a separate Strategy interface and the default implementation is backward compatible and at the same time it allows to supply a custom naming strategy through the configuration. No idea if this implementation is sufficient, I am happy to take comments / suggestions to get this feature through. 