### PR TITLE
Legacy cotent-type changes for the consumer

### DIFF
--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/LegacyContentTypeTests.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/LegacyContentTypeTests.java
@@ -28,7 +28,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.binder.BinderHeaders;
 import org.springframework.cloud.stream.messaging.Sink;
-import org.springframework.context.annotation.PropertySource;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;
@@ -61,14 +60,16 @@ public class LegacyContentTypeTests {
 			}
 		};
 		testSink.input().subscribe(messageHandler);
-		testSink.input().send(MessageBuilder.withPayload("{\"message\":\"Hi\"}".getBytes()).setHeader(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE, "application/json").build());
+		testSink.input().send(MessageBuilder.withPayload("{\"message\":\"Hi\"}".getBytes())
+							.setHeader(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE, "application/json")
+							.setHeader(BinderHeaders.SCST_VERSION, "1.x")
+							.build());
 		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
 		testSink.input().unsubscribe(messageHandler);
 	}
 
 	@EnableBinding(Sink.class)
 	@EnableAutoConfiguration
-	@PropertySource("classpath:/org/springframework/cloud/stream/config/channel/legacy-sink-channel-configurers.properties")
 	public static class LegacyTestSink {
 
 	}

--- a/spring-cloud-stream-integration-tests/src/test/resources/org/springframework/cloud/stream/config/channel/legacy-sink-channel-configurers.properties
+++ b/spring-cloud-stream-integration-tests/src/test/resources/org/springframework/cloud/stream/config/channel/legacy-sink-channel-configurers.properties
@@ -1,4 +1,0 @@
-spring.cloud.stream.bindings.input.destination=configure1
-spring.cloud.stream.bindings.input.legacyContentTypeHeaderEnabled=true
-spring.cloud.stream.bindings.input.contentType=application/x-spring-tuple
-

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
@@ -152,16 +152,6 @@ public abstract class AbstractBinder<T, C extends ConsumerProperties, P extends 
 	}
 
 	@Deprecated
-	protected final MessageValues deserializePayloadIfNecessary(Message<?> message) {
-		return MessageSerializationUtils.deserializePayload(new MessageValues(message), this.contentTypeResolver);
-	}
-
-	@Deprecated
-	protected final MessageValues deserializePayloadIfNecessary(MessageValues messageValues) {
-		return MessageSerializationUtils.deserializePayload(messageValues, this.contentTypeResolver);
-	}
-
-	@Deprecated
 	protected String buildPartitionRoutingExpression(String expressionRoot) {
 		return "'" + expressionRoot + "-' + headers['" + BinderHeaders.PARTITION_HEADER + "']";
 	}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderHeaders.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderHeaders.java
@@ -23,6 +23,7 @@ import org.springframework.messaging.MessageHeaders;
  * Spring Integration message headers for Spring Cloud Stream.
  * @author Gary Russell
  * @author David Turanski
+ * @author Soby Chacko
  */
 public final class BinderHeaders {
 
@@ -66,6 +67,13 @@ public final class BinderHeaders {
 	 * @since 2.0
 	 */
 	public static final String NATIVE_HEADERS_PRESENT = PREFIX + "nativeHeadersPresent";
+
+	/**
+	 * Indicates the Spring Cloud Stream version.
+	 * Used for determining if legacy content type check supported or not.
+	 * @since 2.0
+	 */
+	public static final String SCST_VERSION = PREFIX + "version";
 
 	private BinderHeaders() {
 		super();

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/MessageSerializationUtils.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/MessageSerializationUtils.java
@@ -16,13 +16,8 @@
 
 package org.springframework.cloud.stream.binder;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
-import org.springframework.messaging.converter.ContentTypeResolver;
-import org.springframework.util.MimeType;
 
 /**
  * Utility class for serializing and de-serializing the message payload.
@@ -31,8 +26,6 @@ import org.springframework.util.MimeType;
  * @author Vinicius Carvalho
  */
 public abstract class MessageSerializationUtils {
-
-	private static final Map<String, Class<?>> payloadTypeCache = new ConcurrentHashMap<>();
 
 	/**
 	 * Serialize the message payload unless it is a byte array.
@@ -48,26 +41,5 @@ public abstract class MessageSerializationUtils {
 		messageValues.put(MessageHeaders.CONTENT_TYPE, originalContentType);
 		return messageValues;
 	}
-
-
-
-	/**
-	 * De-serialize the message payload if necessary.
-	 *
-	 * @param messageValues message with the payload to deserialize
-	 * @param contentTypeResolver used for resolving the mime type.
-	 * @return Deserialized Message.
-	 */
-	public static MessageValues deserializePayload(MessageValues messageValues, ContentTypeResolver contentTypeResolver) {
-		Object payload = messageValues.getPayload();
-		MimeType contentType = contentTypeResolver.resolve(new MessageHeaders(messageValues.getHeaders()));
-		if (payload != null) {
-			messageValues.setPayload(payload);
-			messageValues.put(MessageHeaders.CONTENT_TYPE, contentType);
-		}
-		return messageValues;
-	}
-
-
 
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/MessageConverterConfigurer.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/MessageConverterConfigurer.java
@@ -121,7 +121,7 @@ public class MessageConverterConfigurer
 					getPartitionKeyExtractorStrategy(producerProperties),
 					getPartitionSelectorStrategy(producerProperties)));
 		}
-		if (input && bindingProperties.isLegacyContentTypeHeaderEnabled()) {
+		if (input) {
 			messageChannel.addInterceptor(new LegacyContentTypeHeaderInterceptor());
 		}
 		// TODO: Set all interceptors in the correct order for input/output channels
@@ -306,11 +306,12 @@ public class MessageConverterConfigurer
 
 		@Override
 		public Message<?> preSend(Message<?> message, MessageChannel channel) {
-			Object originalContentType = message.getHeaders().get(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE);
-			if (originalContentType != null) {
-				return MessageConverterConfigurer.this.messageBuilderFactory
+			if (!message.getHeaders().containsKey(BinderHeaders.SCST_VERSION) ||
+					!message.getHeaders().get(BinderHeaders.SCST_VERSION).equals("2.x")) {
+				Object originalContentType = message.getHeaders().get(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE);
+				return originalContentType != null ? MessageConverterConfigurer.this.messageBuilderFactory
 						.fromMessage(message)
-						.setHeader(MessageHeaders.CONTENT_TYPE, originalContentType).build();
+						.setHeader(MessageHeaders.CONTENT_TYPE, originalContentType).build() : message;
 			}
 			return message;
 		}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingProperties.java
@@ -58,8 +58,6 @@ public class BindingProperties {
 
 	private String contentType = MimeTypeUtils.APPLICATION_JSON_VALUE;
 
-	private boolean legacyContentTypeHeaderEnabled = false;
-
 	private String binder;
 
 	private ConsumerProperties consumer;
@@ -88,14 +86,6 @@ public class BindingProperties {
 
 	public void setContentType(String contentType) {
 		this.contentType = contentType;
-	}
-
-	public boolean isLegacyContentTypeHeaderEnabled() {
-		return legacyContentTypeHeaderEnabled;
-	}
-
-	public void setLegacyContentTypeHeaderEnabled(boolean legacyContentTypeHeaderEnabled) {
-		this.legacyContentTypeHeaderEnabled = legacyContentTypeHeaderEnabled;
 	}
 
 	public String getBinder() {


### PR DESCRIPTION
- Remove binding config property `legacyContentTypeHeaderEnabled` that was
  introduced to enable legacy content type handling
- Enable LegacyContentTypeInterceptor in 2.0 always, but bypass any
  legacy content type handling if the message received is from
  a 2.0 producer by checking on the version header
- Introdce a new BinderHeader property for version
- Fix the LegacyContentType related tests
- Remove the check for originalContentType in ReceivingHandler when
  the payload received is a byte[]
- Remove unnecessary deserializePayloadIfNecessary calls in ReceivingHandler
- Remove deprecated deserializePayload methods in AbstractBinder
  and MessageSerializationUtils

Partly fixes #1106
Fixes #1110