### PR TITLE
GH-1127 Added initial support for SI backed Binder [DO NOT MERGE]

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
@@ -78,6 +78,10 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 	 */
 	private final String[] headersToEmbed;
 
+	public AbstractMessageChannelBinder(PP provisioningProvider) {
+		this(new String[0], provisioningProvider);
+	}
+
 	public AbstractMessageChannelBinder(String[] headersToEmbed,
 			PP provisioningProvider) {
 		this.headersToEmbed = headersToEmbed == null ? new String[0] : headersToEmbed;

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/AbstractBindingLifecycle.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/AbstractBindingLifecycle.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binding;
+
+import java.util.Map;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.SmartLifecycle;
+
+/**
+ * @author Oleg Zhurakousky
+ *
+ */
+abstract class AbstractBindingLifecycle implements SmartLifecycle {
+
+	private volatile boolean running;
+
+	private final BindingService bindingService;
+
+	private final Map<String, Bindable> bindables;
+
+	private final boolean input;
+
+	AbstractBindingLifecycle(BindingService bindingService, Map<String, Bindable> bindables, boolean input) {
+		this.bindingService = bindingService;
+		this.bindables = bindables;
+		this.input = input;
+	}
+
+	@Override
+	public void start() {
+		if (!running) {
+			for (Bindable bindable : bindables.values()) {
+				if (input) {
+					bindable.bindInputs(bindingService);
+				}
+				else {
+					bindable.bindOutputs(bindingService);
+				}
+			}
+			this.running = true;
+		}
+	}
+
+	@Override
+	public void stop() {
+		if (running) {
+			try {
+				for (Bindable bindable : bindables.values()) {
+					if (input) {
+						bindable.unbindInputs(bindingService);
+					}
+					else {
+						bindable.unbindOutputs(bindingService);
+					}
+				}
+			}
+			catch (BeansException e) {
+				throw new IllegalStateException("Cannot perform unbinding, no proper implementation found", e);
+			}
+			this.running = false;
+		}
+	}
+
+	@Override
+	public boolean isRunning() {
+		return running;
+	}
+
+	@Override
+	public boolean isAutoStartup() {
+		return true;
+	}
+
+	@Override
+	public void stop(Runnable callback) {
+		stop();
+		if (callback != null) {
+			callback.run();
+		}
+	}
+
+	/**
+	 * Return a low value so that this bean is started after receiving Lifecycle beans are
+	 * started. Beans that need to start before bindings will set a lower phase value.
+	 */
+	@Override
+	public int getPhase() {
+		return this.input ? Integer.MAX_VALUE - 1000 : Integer.MIN_VALUE + 1000;
+	}
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/InputBindingLifecycle.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/InputBindingLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,97 +18,16 @@ package org.springframework.cloud.stream.binding;
 
 import java.util.Map;
 
-import org.springframework.beans.BeansException;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
-import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.context.SmartLifecycle;
-
 /**
  * Coordinates binding/unbinding of input binding targets in accordance to the lifecycle
  * of the host context.
  * @author Marius Bogoevici
  * @author Ilayaperumal Gopinathan
+ * @author Oleg Zhurakousky
  */
-public class InputBindingLifecycle implements SmartLifecycle, ApplicationContextAware {
+public class InputBindingLifecycle extends AbstractBindingLifecycle {
 
-	private volatile boolean running;
-
-	private ConfigurableApplicationContext applicationContext;
-
-	@Override
-	public void setApplicationContext(ApplicationContext applicationContext)
-			throws BeansException {
-		this.applicationContext = (ConfigurableApplicationContext) applicationContext;
-	}
-
-	@Override
-	public void start() {
-		if (!running) {
-			// retrieve the BindingService lazily, avoiding early initialization
-			try {
-				BindingService bindingService = this.applicationContext
-						.getBean(BindingService.class);
-				Map<String, Bindable> bindables = this.applicationContext
-						.getBeansOfType(Bindable.class);
-				for (Bindable bindable : bindables.values()) {
-					bindable.bindInputs(bindingService);
-				}
-			}
-			catch (BeansException e) {
-				throw new IllegalStateException(
-						"Cannot perform binding, no proper implementation found", e);
-			}
-			this.running = true;
-		}
-	}
-
-	@Override
-	public void stop() {
-		if (running) {
-			try {
-				// retrieve the BindingService lazily, avoiding early
-				// initialization
-				BindingService bindingService = this.applicationContext
-						.getBean(BindingService.class);
-				Map<String, Bindable> bindables = this.applicationContext
-						.getBeansOfType(Bindable.class);
-				for (Bindable bindable : bindables.values()) {
-					bindable.unbindInputs(bindingService);
-				}
-			}
-			catch (BeansException e) {
-				throw new IllegalStateException(
-						"Cannot perform unbinding, no proper implementation found", e);
-			}
-			this.running = false;
-		}
-	}
-
-	@Override
-	public boolean isRunning() {
-		return running;
-	}
-
-	@Override
-	public boolean isAutoStartup() {
-		return true;
-	}
-
-	@Override
-	public void stop(Runnable callback) {
-		stop();
-		if (callback != null) {
-			callback.run();
-		}
-	}
-
-	/**
-	 * Return a high value so that this bean is started after receiving Lifecycle beans
-	 * are started. Beans that need to start after bindings will set a higher phase value.
-	 */
-	@Override
-	public int getPhase() {
-		return Integer.MAX_VALUE - 1000;
+	public InputBindingLifecycle(BindingService bindingService, Map<String, Bindable> bindables) {
+		super(bindingService, bindables, true);
 	}
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceConfiguration.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-
 import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactoryUtils;
@@ -33,6 +32,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.binder.BinderFactory;
 import org.springframework.cloud.stream.binding.AbstractBindingTargetFactory;
+import org.springframework.cloud.stream.binding.Bindable;
 import org.springframework.cloud.stream.binding.BinderAwareChannelResolver;
 import org.springframework.cloud.stream.binding.BinderAwareRouterBeanPostProcessor;
 import org.springframework.cloud.stream.binding.BindingService;
@@ -133,15 +133,13 @@ public class BindingServiceConfiguration {
 	}
 
 	@Bean
-	@DependsOn("bindingService")
-	public OutputBindingLifecycle outputBindingLifecycle() {
-		return new OutputBindingLifecycle();
+	public OutputBindingLifecycle outputBindingLifecycle(BindingService bindingService, Map<String, Bindable> bindables) {
+		return new OutputBindingLifecycle(bindingService, bindables);
 	}
 
 	@Bean
-	@DependsOn("bindingService")
-	public InputBindingLifecycle inputBindingLifecycle() {
-		return new InputBindingLifecycle();
+	public InputBindingLifecycle inputBindingLifecycle(BindingService bindingService, Map<String, Bindable> bindables) {
+		return new InputBindingLifecycle(bindingService, bindables);
 	}
 
 	@Bean

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/provisioning/AbstractNamedDestination.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/provisioning/AbstractNamedDestination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,26 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.stream.binder.stub2;
+package org.springframework.cloud.stream.provisioning;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.cloud.stream.binder.Binder;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.util.Assert;
 
 /**
- * @author Marius Bogoevici
+ * @author Oleg Zhurakousky
+ *
  */
-@Configuration
-public class StubBinder2ConfigurationA {
+public abstract class AbstractNamedDestination implements NamedDestination {
 
-	@Bean
-	@ConditionalOnMissingBean
-	public Binder<?, ?, ?> binder(StubBinder2Dependency dependency) {
-		return new StubBinder2(dependency);
+	private final String name;
+
+	public AbstractNamedDestination(String name) {
+		Assert.hasText(name, "'name' must not be null or empty");
+		this.name = name;
 	}
+
+	@Override
+	public String getName() {
+		return this.name;
+	}
+
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/provisioning/NamedDestination.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/provisioning/NamedDestination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,16 @@
 
 package org.springframework.cloud.stream.provisioning;
 
-import org.springframework.cloud.stream.binder.ConsumerProperties;
-
 /**
- * Represents a ConsumerDestination that provides the information about the destination
- * that is physically provisioned through
- * {@link ProvisioningProvider#provisionConsumerDestination(String, String, ConsumerProperties)}
- *
- * @author Soby Chacko
  * @author Oleg Zhurakousky
  *
- * @since 1.2
  */
-public interface ConsumerDestination extends NamedDestination {
+interface NamedDestination {
+
+	/**
+	 * Provides the destination name.
+	 *
+	 * @return destination name
+	 */
+	String getName();
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/provisioning/ProducerDestination.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/provisioning/ProducerDestination.java
@@ -24,17 +24,11 @@ import org.springframework.cloud.stream.binder.ProducerProperties;
  * {@link ProvisioningProvider#provisionProducerDestination(String, ProducerProperties)}
  *
  * @author Soby Chacko
+ * @author Oleg Zhurakousky
  *
  * @since 1.2
  */
-public interface ProducerDestination {
-
-	/**
-	 * Provides the destination name.
-	 *
-	 * @return destination name
-	 */
-	String getName();
+public interface ProducerDestination extends NamedDestination {
 
 	/**
 	 * Provides the destination name for a given partition.

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/BinderAwareChannelResolverTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/BinderAwareChannelResolverTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -28,25 +27,19 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
-import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.cloud.stream.binder.integration.SpringIntegrationBinderConfiguration;
 import org.springframework.cloud.stream.binding.AbstractBindingTargetFactory;
+import org.springframework.cloud.stream.binding.Bindable;
 import org.springframework.cloud.stream.binding.BinderAwareChannelResolver;
 import org.springframework.cloud.stream.binding.BindingService;
 import org.springframework.cloud.stream.binding.DynamicDestinationsBindable;
-import org.springframework.cloud.stream.binding.InputBindingLifecycle;
-import org.springframework.cloud.stream.binding.MessageConverterConfigurer;
-import org.springframework.cloud.stream.binding.OutputBindingLifecycle;
-import org.springframework.cloud.stream.binding.SubscribableChannelBindingTargetFactory;
 import org.springframework.cloud.stream.config.BindingProperties;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
-import org.springframework.cloud.stream.converter.CompositeMessageConverterFactory;
-import org.springframework.context.support.StaticApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.integration.channel.DirectChannel;
-import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilder;
-import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
@@ -54,10 +47,11 @@ import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.SubscribableChannel;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.matches;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -66,10 +60,11 @@ import static org.mockito.Mockito.when;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Ilayaperumal Gopinathan
+ * @author Oleg Zhurakousky
  */
 public class BinderAwareChannelResolverTests {
 
-	protected final StaticApplicationContext context = new StaticApplicationContext();
+	protected ConfigurableApplicationContext context;
 
 	protected volatile BinderAwareChannelResolver resolver;
 
@@ -81,68 +76,43 @@ public class BinderAwareChannelResolverTests {
 
 	protected volatile DynamicDestinationsBindable dynamicDestinationsBindable;
 
-	private volatile List<TestBinder.TestBinding> producerBindings;
-
 	@Before
 	public void setupContext() throws Exception {
-		producerBindings = new ArrayList<>();
-		this.binder = new TestBinder();
-		BinderFactory binderFactory = new BinderFactory() {
-
-			@Override
-			public <T> Binder<T, ? extends ConsumerProperties, ? extends ProducerProperties> getBinder(
-					String configurationName, Class<? extends T> bindableType) {
-				return (Binder<T, ? extends ConsumerProperties, ? extends ProducerProperties>) binder;
-			}
-		};
-		this.bindingServiceProperties = new BindingServiceProperties();
-		Map<String, BindingProperties> bindings = new HashMap<>();
-		BindingProperties bindingProperties = new BindingProperties();
-		bindingProperties.setContentType("text/plain");
-		bindings.put("foo", bindingProperties);
-		this.bindingServiceProperties.setBindings(bindings);
-		BindingService bindingService = new BindingService(bindingServiceProperties,
-				binderFactory);
-		MessageConverterConfigurer messageConverterConfigurer = new MessageConverterConfigurer(
-				this.bindingServiceProperties,
-				new CompositeMessageConverterFactory());
-		messageConverterConfigurer.setBeanFactory(Mockito.mock(ConfigurableListableBeanFactory.class));
-		messageConverterConfigurer.afterPropertiesSet();
-		this.bindingTargetFactory = new SubscribableChannelBindingTargetFactory(messageConverterConfigurer);
-		dynamicDestinationsBindable = new DynamicDestinationsBindable();
-		this.resolver = new BinderAwareChannelResolver(bindingService, this.bindingTargetFactory,
-				dynamicDestinationsBindable);
-		this.resolver.setBeanFactory(context.getBeanFactory());
-		context.getBeanFactory().registerSingleton("channelResolver", this.resolver);
-		context.getBeanFactory().registerSingleton("dynamicDestinationBindable", this.dynamicDestinationsBindable);
-		context.registerSingleton("other", DirectChannel.class);
-		context.registerSingleton(IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME,
-				DefaultMessageBuilderFactory.class);
-		context.getBeanFactory().registerSingleton("bindingService", bindingService);
-		context.registerSingleton("inputBindingLifecycle", InputBindingLifecycle.class);
-		context.registerSingleton("outputBindingLifecycle", OutputBindingLifecycle.class);
-		context.refresh();
+		this.context = new SpringApplicationBuilder(SpringIntegrationBinderConfiguration.getCompleteConfiguration()).web(WebApplicationType.NONE).run();
+		this.resolver = context.getBean(BinderAwareChannelResolver.class);
+		this.binder = context.getBean(Binder.class);
+		this.bindingServiceProperties = context.getBean(BindingServiceProperties.class);
+		this.bindingTargetFactory = context.getBean(AbstractBindingTargetFactory.class);
 	}
 
 	@Test
 	public void resolveChannel() {
-		assertThat(producerBindings).hasSize(0);
+		Map<String, Bindable> bindables = context.getBeansOfType(Bindable.class);
+		assertThat(bindables).hasSize(1);
+		for (Bindable bindable : bindables.values()) {
+			assertEquals(0, bindable.getInputs().size()); // producer
+			assertEquals(0, bindable.getOutputs().size());// consumer
+		}
 		MessageChannel registered = resolver.resolveDestination("foo");
-		assertThat(producerBindings).hasSize(1);
-		TestBinder.TestBinding binding = producerBindings.get(0);
-		assertThat(binding.isBound()).describedAs("Must be bound");
+
+		bindables = context.getBeansOfType(Bindable.class);
+		assertThat(bindables).hasSize(1);
+		for (Bindable bindable : bindables.values()) {
+			assertEquals(0, bindable.getInputs().size()); // producer
+			assertEquals(1, bindable.getOutputs().size());// consumer
+		}
 		DirectChannel testChannel = new DirectChannel();
+		testChannel.setComponentName("INPUT");
 		final CountDownLatch latch = new CountDownLatch(1);
 		final List<Message<?>> received = new ArrayList<>();
 		testChannel.subscribe(new MessageHandler() {
-
 			@Override
 			public void handleMessage(Message<?> message) throws MessagingException {
 				received.add(message);
 				latch.countDown();
 			}
 		});
-		binder.bindConsumer("foo", null, testChannel, new ConsumerProperties());
+		this.binder.bindConsumer("foo", null, testChannel, new ConsumerProperties());
 		assertThat(received).hasSize(0);
 		registered.send(MessageBuilder.withPayload("hello").build());
 		try {
@@ -154,15 +124,18 @@ public class BinderAwareChannelResolverTests {
 		}
 		assertThat(received).hasSize(1);
 		assertThat(new String((byte[])received.get(0).getPayload())).isEqualTo("hello");
-		context.close();
-		assertThat(producerBindings).hasSize(1);
-		assertThat(binding.isBound()).isFalse().describedAs("Must not be bound");
+		this.context.close();
+		for (Bindable bindable : bindables.values()) {
+			assertEquals(0, bindable.getInputs().size());
+			assertEquals(0, bindable.getOutputs().size());//Must not be bound"
+		}
 	}
 
 	@Test
 	public void resolveNonRegisteredChannel() {
 		MessageChannel other = resolver.resolveDestination("other");
 		assertThat(context.getBean("other")).isSameAs(other);
+		this.context.close();
 	}
 
 	@Test
@@ -173,7 +146,6 @@ public class BinderAwareChannelResolverTests {
 		genericProperties.setContentType("text/plain");
 		bindings.put("foo", genericProperties);
 		this.bindingServiceProperties.setBindings(bindings);
-		@SuppressWarnings("unchecked")
 		Binder binder = mock(Binder.class);
 		Binder binder2 = mock(Binder.class);
 		BinderFactory mockBinderFactory = Mockito.mock(BinderFactory.class);
@@ -187,74 +159,12 @@ public class BinderAwareChannelResolverTests {
 		when(mockBinderFactory.getBinder("someTransport", DirectChannel.class)).thenReturn(binder2);
 		BindingService bindingService = new BindingService(bindingServiceProperties,
 				mockBinderFactory);
-		@SuppressWarnings("unchecked")
 		BinderAwareChannelResolver resolver = new BinderAwareChannelResolver(bindingService, this.bindingTargetFactory,
 				new DynamicDestinationsBindable());
-		BeanFactory beanFactory = new DefaultListableBeanFactory();
-		resolver.setBeanFactory(beanFactory);
+		resolver.setBeanFactory(context.getBeanFactory());
 		SubscribableChannel resolved = (SubscribableChannel) resolver.resolveDestination("foo");
 		verify(binder).bindProducer(eq("foo"), any(MessageChannel.class), any(ProducerProperties.class));
-		assertThat(resolved).isSameAs(beanFactory.getBean("foo"));
-	}
-
-	/**
-	 * A simple test binder that creates queues for the destinations. Ignores groups.
-	 */
-	private class TestBinder implements Binder<MessageChannel, ConsumerProperties, ProducerProperties> {
-
-		private final Map<String, DirectChannel> destinations = new ConcurrentHashMap<>();
-
-		@Override
-		public Binding<MessageChannel> bindConsumer(String name, String group,
-				MessageChannel inboundBindTarget, ConsumerProperties properties) {
-			synchronized (destinations) {
-				if (!destinations.containsKey(name)) {
-					destinations.put(name, new DirectChannel());
-				}
-			}
-			DirectHandler directHandler = new DirectHandler(inboundBindTarget);
-			destinations.get(name).subscribe(directHandler);
-			return new TestBinding(name, directHandler);
-		}
-
-		@Override
-		public Binding<MessageChannel> bindProducer(String name,
-				MessageChannel outboundBindTarget, ProducerProperties properties) {
-			synchronized (destinations) {
-				if (!destinations.containsKey(name)) {
-					destinations.put(name, new DirectChannel());
-				}
-			}
-			DirectHandler directHandler = new DirectHandler(destinations.get(name));
-			// for test purposes we can assume it is a SubscribableChannel
-			((SubscribableChannel) outboundBindTarget).subscribe(directHandler);
-			TestBinding binding = new TestBinding(name, directHandler);
-			producerBindings.add(binding);
-			return binding;
-		}
-
-		private final class TestBinding implements Binding<MessageChannel> {
-
-			private final String name;
-
-			private final DirectHandler directHandler;
-
-			private boolean bound = true;
-
-			private TestBinding(String name, DirectHandler directHandler) {
-				this.name = name;
-				this.directHandler = directHandler;
-			}
-
-			@Override
-			public void unbind() {
-				bound = false;
-				destinations.get(name).unsubscribe(directHandler);
-			}
-
-			public boolean isBound() {
-				return bound;
-			}
-		}
+		assertThat(resolved).isSameAs(context.getBean("foo"));
+		this.context.close();
 	}
 }

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/ExtendedPropertiesBinderAwareChannelResolverTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/ExtendedPropertiesBinderAwareChannelResolverTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,102 +17,49 @@
 package org.springframework.cloud.stream.binder;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
-import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
-import org.springframework.cloud.stream.binding.BinderAwareChannelResolver;
-import org.springframework.cloud.stream.binding.BindingService;
-import org.springframework.cloud.stream.binding.DynamicDestinationsBindable;
-import org.springframework.cloud.stream.binding.InputBindingLifecycle;
-import org.springframework.cloud.stream.binding.MessageConverterConfigurer;
-import org.springframework.cloud.stream.binding.OutputBindingLifecycle;
-import org.springframework.cloud.stream.binding.SubscribableChannelBindingTargetFactory;
-import org.springframework.cloud.stream.config.BindingProperties;
-import org.springframework.cloud.stream.config.BindingServiceProperties;
-import org.springframework.cloud.stream.converter.CompositeMessageConverterFactory;
+import org.springframework.cloud.stream.binding.Bindable;
 import org.springframework.integration.channel.DirectChannel;
-import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilder;
-import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessagingException;
-import org.springframework.messaging.SubscribableChannel;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
  * @author Mark Fisher
  * @author Gary Russell
  * @author Ilayaperumal Gopinathan
+ * @author Oleg Zhurakousky
  */
 public class ExtendedPropertiesBinderAwareChannelResolverTests extends BinderAwareChannelResolverTests {
-
-	private volatile ExtendedPropertiesBinder<MessageChannel, ExtendedConsumerProperties, ExtendedProducerProperties> binder;
-
-	private volatile List<TestBinder.TestBinding> producerBindings;
-
-	@Before
-	@Override
-	public void setupContext() throws Exception {
-		producerBindings = new ArrayList<>();
-		this.binder = new TestBinder();
-		BinderFactory binderFactory = new BinderFactory() {
-
-			@Override
-			public <T> Binder<T, ? extends ConsumerProperties, ? extends ProducerProperties> getBinder(
-					String configurationName, Class<? extends T> bindableType) {
-				return (Binder<T, ? extends ConsumerProperties, ? extends ProducerProperties>) binder;
-			}
-		};
-		this.bindingServiceProperties = new BindingServiceProperties();
-		Map<String, BindingProperties> bindings = new HashMap<String, BindingProperties>();
-		BindingProperties bindingProperties = new BindingProperties();
-		bindingProperties.setContentType("text/plain");
-		bindings.put("foo", bindingProperties);
-		this.bindingServiceProperties.setBindings(bindings);
-		MessageConverterConfigurer messageConverterConfigurer = new MessageConverterConfigurer(
-				this.bindingServiceProperties,
-				new CompositeMessageConverterFactory());
-		messageConverterConfigurer.setBeanFactory(Mockito.mock(ConfigurableListableBeanFactory.class));
-		messageConverterConfigurer.afterPropertiesSet();
-		this.bindingTargetFactory = new SubscribableChannelBindingTargetFactory(messageConverterConfigurer);
-		dynamicDestinationsBindable = new DynamicDestinationsBindable();
-		BindingService bindingService = new BindingService(bindingServiceProperties,
-				binderFactory);
-		this.resolver = new BinderAwareChannelResolver(bindingService, this.bindingTargetFactory,
-				dynamicDestinationsBindable);
-		this.resolver.setBeanFactory(context.getBeanFactory());
-		context.getBeanFactory().registerSingleton("channelResolver", this.resolver);
-		context.getBeanFactory().registerSingleton("dynamicDestinationBindable", this.dynamicDestinationsBindable);
-		context.registerSingleton("other", DirectChannel.class);
-		context.registerSingleton(IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME,
-				DefaultMessageBuilderFactory.class);
-		context.getBeanFactory().registerSingleton("bindingService", bindingService);
-		context.registerSingleton("inputBindingLifecycle", InputBindingLifecycle.class);
-		context.registerSingleton("outputBindingLifecycle", OutputBindingLifecycle.class);
-		context.refresh();
-	}
 
 	@Test
 	@Override
 	public void resolveChannel() {
-		assertThat(producerBindings).hasSize(0);
+		Map<String, Bindable> bindables = context.getBeansOfType(Bindable.class);
+		assertThat(bindables).hasSize(1);
+		for (Bindable bindable : bindables.values()) {
+			assertEquals(0, bindable.getInputs().size()); // producer
+			assertEquals(0, bindable.getOutputs().size());// consumer
+		}
 		MessageChannel registered = resolver.resolveDestination("foo");
-		assertThat(producerBindings).hasSize(1);
-		TestBinder.TestBinding binding = producerBindings.get(0);
-		assertThat(binding.isBound()).describedAs("Must be bound");
+		bindables = context.getBeansOfType(Bindable.class);
+		assertThat(bindables).hasSize(1);
+		for (Bindable bindable : bindables.values()) {
+			assertEquals(0, bindable.getInputs().size()); // producer
+			assertEquals(1, bindable.getOutputs().size());// consumer
+		}
 		DirectChannel testChannel = new DirectChannel();
 		final CountDownLatch latch = new CountDownLatch(1);
 		final List<Message<?>> received = new ArrayList<>();
@@ -124,7 +71,7 @@ public class ExtendedPropertiesBinderAwareChannelResolverTests extends BinderAwa
 				latch.countDown();
 			}
 		});
-		binder.bindConsumer("foo", null, testChannel, new ExtendedConsumerProperties(new ConsumerProperties()));
+		binder.bindConsumer("foo", null, testChannel, new ExtendedConsumerProperties<ConsumerProperties>(new ConsumerProperties()));
 		assertThat(received).hasSize(0);
 		registered.send(MessageBuilder.withPayload("hello").build());
 		try {
@@ -137,79 +84,9 @@ public class ExtendedPropertiesBinderAwareChannelResolverTests extends BinderAwa
 		assertThat(received).hasSize(1);
 		assertThat(new String((byte[])received.get(0).getPayload())).isEqualTo("hello");
 		context.close();
-		assertThat(producerBindings).hasSize(1);
-		assertThat(binding.isBound()).isFalse().describedAs("Must not be bound");
-	}
-
-	/**
-	 * A simple test binder that creates queues for the destinations. Ignores groups.
-	 */
-	class TestBinder implements
-			ExtendedPropertiesBinder<MessageChannel, ExtendedConsumerProperties, ExtendedProducerProperties> {
-
-		private final Map<String, DirectChannel> destinations = new ConcurrentHashMap<>();
-
-		@Override
-		public Binding<MessageChannel> bindConsumer(String name, String group,
-				MessageChannel inboundBindTarget, ExtendedConsumerProperties properties) {
-			synchronized (destinations) {
-				if (!destinations.containsKey(name)) {
-					destinations.put(name, new DirectChannel());
-				}
-			}
-			DirectHandler directHandler = new DirectHandler(inboundBindTarget);
-			destinations.get(name).subscribe(directHandler);
-			return new TestBinding(name, directHandler);
-		}
-
-		@Override
-		public Binding<MessageChannel> bindProducer(String name,
-				MessageChannel outboundBindTarget, ExtendedProducerProperties properties) {
-			synchronized (destinations) {
-				if (!destinations.containsKey(name)) {
-					destinations.put(name, new DirectChannel());
-				}
-			}
-			DirectHandler directHandler = new DirectHandler(destinations.get(name));
-			// for test purposes we can assume it is a SubscribableChannel
-			((SubscribableChannel) outboundBindTarget).subscribe(directHandler);
-			TestBinding binding = new TestBinding(name, directHandler);
-			producerBindings.add(binding);
-			return binding;
-		}
-
-		@Override
-		public ExtendedConsumerProperties getExtendedConsumerProperties(String channelName) {
-			return new ExtendedConsumerProperties(new ConsumerProperties());
-		}
-
-		@Override
-		public ExtendedProducerProperties getExtendedProducerProperties(String channelName) {
-			return new ExtendedProducerProperties(new ProducerProperties());
-		}
-
-		private final class TestBinding implements Binding<MessageChannel> {
-
-			private final String name;
-
-			private final DirectHandler directHandler;
-
-			private boolean bound = true;
-
-			private TestBinding(String name, DirectHandler directHandler) {
-				this.name = name;
-				this.directHandler = directHandler;
-			}
-
-			@Override
-			public void unbind() {
-				bound = false;
-				destinations.get(name).unsubscribe(directHandler);
-			}
-
-			public boolean isBound() {
-				return bound;
-			}
+		for (Bindable bindable : bindables.values()) {
+			assertEquals(0, bindable.getInputs().size());
+			assertEquals(0, bindable.getOutputs().size());//Must not be bound"
 		}
 	}
 }

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/InputOutputBindingOrderTest.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/InputOutputBindingOrderTest.java
@@ -45,7 +45,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
  */
 public class InputOutputBindingOrderTest {
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testInputOutputBindingOrder() {
 		ConfigurableApplicationContext applicationContext = SpringApplication.run(TestSource.class, "--server.port=-1");
@@ -83,7 +82,7 @@ public class InputOutputBindingOrderTest {
 		private boolean running;
 
 		@Override
-		@SuppressWarnings({ "unchecked", "rawtypes" })
+		@SuppressWarnings({"rawtypes" })
 		public synchronized void start() {
 			Binder binder = this.binderFactory.getBinder(null, MessageChannel.class);
 			verify(binder).bindProducer(eq("output"), eq(this.processor.output()), Mockito.<ProducerProperties>any());

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/SourceBindingWithGlobalPropertiesOnlyTest.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/SourceBindingWithGlobalPropertiesOnlyTest.java
@@ -24,11 +24,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.binder.integration.SpringIntegrationBinderConfiguration;
 import org.springframework.cloud.stream.config.BindingProperties;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.cloud.stream.messaging.Source;
-import org.springframework.cloud.stream.utils.MockBinderRegistryConfiguration;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
@@ -36,7 +35,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Ilayaperumal Gopinathan
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(classes = SourceBindingWithGlobalPropertiesOnlyTest.TestSource.class, properties = {
+@SpringBootTest(classes = {SpringIntegrationBinderConfiguration.class, SourceBindingWithGlobalPropertiesOnlyTest.TestSource.class}, properties = {
 		"spring.cloud.stream.default.contentType=application/json",
 		"spring.cloud.stream.default.producer.partitionKeyExpression=key" })
 public class SourceBindingWithGlobalPropertiesOnlyTest {
@@ -44,7 +43,6 @@ public class SourceBindingWithGlobalPropertiesOnlyTest {
 	@Autowired
 	private BindingServiceProperties bindingServiceProperties;
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testGlobalPropertiesSet() {
 		BindingProperties bindingProperties = bindingServiceProperties.getBindingProperties(Source.OUTPUT);
@@ -53,10 +51,12 @@ public class SourceBindingWithGlobalPropertiesOnlyTest {
 		Assertions.assertThat(bindingProperties.getProducer().getPartitionKeyExpression().getExpressionString()).isEqualTo("key");
 	}
 
-	@EnableBinding(Source.class)
 	@EnableAutoConfiguration
-	@Import(MockBinderRegistryConfiguration.class)
+	@EnableBinding(Source.class)
 	public static class TestSource {
 
 	}
+
+	public final static Class<?>[] configurations = null;
+
 }

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/integration/AbstractDestination.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/integration/AbstractDestination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,28 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.stream.binder.stub2;
+package org.springframework.cloud.stream.binder.integration;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.cloud.stream.binder.Binder;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.SubscribableChannel;
 
 /**
- * @author Marius Bogoevici
+ * @author Oleg Zhurakousky
+ *
  */
-@Configuration
-public class StubBinder2ConfigurationA {
+abstract class AbstractDestination {
 
-	@Bean
-	@ConditionalOnMissingBean
-	public Binder<?, ?, ?> binder(StubBinder2Dependency dependency) {
-		return new StubBinder2(dependency);
+	private SubscribableChannel channel;
+
+	public SubscribableChannel getChannel() {
+		return channel;
+	}
+
+	void setChannel(SubscribableChannel channel) {
+		this.channel = channel;
+		this.afterChannelIsSet();
+	}
+
+	void afterChannelIsSet() {
+		// noop
 	}
 }

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/integration/SourceDestination.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/integration/SourceDestination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,18 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.stream.binder.stub2;
+package org.springframework.cloud.stream.binder.integration;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.cloud.stream.binder.Binder;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
 
 /**
- * @author Marius Bogoevici
+ *
+ * @author Oleg Zhurakousky
+ *
  */
-@Configuration
-public class StubBinder2ConfigurationA {
+public class SourceDestination extends AbstractDestination {
 
-	@Bean
-	@ConditionalOnMissingBean
-	public Binder<?, ?, ?> binder(StubBinder2Dependency dependency) {
-		return new StubBinder2(dependency);
+	public void send(Message<?> message) {
+		this.getChannel().send(message);
 	}
 }

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/integration/SpringIntegrationBinderConfiguration.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/integration/SpringIntegrationBinderConfiguration.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.integration;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.binder.Binder;
+import org.springframework.cloud.stream.binder.BinderType;
+import org.springframework.cloud.stream.binder.BinderTypeRegistry;
+import org.springframework.cloud.stream.binder.ConsumerProperties;
+import org.springframework.cloud.stream.binder.DefaultBinderTypeRegistry;
+import org.springframework.cloud.stream.binder.ProducerProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.integration.config.EnableIntegration;
+
+/**
+ * {@link Binder} configuration backed by Spring Integration.
+ *
+ * Please see {@link SpringIntegrationChannelBinder} for more details.
+ *
+ * @author Oleg Zhurakousky
+ *
+ * @see SpringIntegrationChannelBinder
+ */
+@Configuration
+@ConditionalOnMissingBean(Binder.class)
+@EnableIntegration
+public class SpringIntegrationBinderConfiguration<T> {
+
+	public static final String NAME = "integration";
+
+	/**
+	 * Utility operation to return an array of configuration classes
+	 * defined in {@link EnableBinding} annotation.
+	 * Typically used for tests that do not rely on creating an SCSt boot
+	 * application annotated with {@link EnableBinding}, yet require
+	 * full {@link Binder} configuration.
+	 */
+	public static Class<?>[] getCompleteConfiguration() {
+		List<Class<?>> configClasses = new ArrayList<>();
+		configClasses.add(SpringIntegrationBinderConfiguration.class);
+		Import annotation = AnnotationUtils.getAnnotation(EnableBinding.class, Import.class);
+		Map<String, Object> annotationAttributes = AnnotationUtils.getAnnotationAttributes(annotation);
+		configClasses.addAll(Arrays.asList((Class<?>[])annotationAttributes.get("value")));
+		return configClasses.toArray(new Class<?>[] {});
+	}
+
+	@Bean
+	public BinderTypeRegistry binderTypeRegistry() {
+		BinderType bt = new BinderType(NAME, new Class[] {SpringIntegrationBinderConfiguration.class});
+		Map<String, BinderType> binderTypes = new HashMap<>();
+		binderTypes.put(NAME, bt);
+		BinderTypeRegistry btr = new DefaultBinderTypeRegistry(binderTypes);
+		return btr;
+	}
+
+	@Bean
+	public SourceDestination sourceDestination() {
+		return new SourceDestination();
+	}
+
+	@Bean
+	public TargetDestination targetDestination() {
+		return new TargetDestination();
+	}
+
+	@SuppressWarnings("unchecked")
+	@Bean
+	public Binder<T, ? extends ConsumerProperties, ? extends ProducerProperties> springIntegrationChannelBinder(SpringIntegrationProvisioner provisioner) {
+		return (Binder<T, ? extends ConsumerProperties, ? extends ProducerProperties>) new SpringIntegrationChannelBinder(provisioner);
+	}
+
+	@Bean
+	public SpringIntegrationProvisioner springIntegrationProvisioner() {
+		return new SpringIntegrationProvisioner();
+	}
+
+}

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/integration/SpringIntegrationChannelBinder.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/integration/SpringIntegrationChannelBinder.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.integration;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.stream.binder.AbstractMessageChannelBinder;
+import org.springframework.cloud.stream.binder.Binder;
+import org.springframework.cloud.stream.binder.ConsumerProperties;
+import org.springframework.cloud.stream.binder.ProducerProperties;
+import org.springframework.cloud.stream.binder.integration.SpringIntegrationProvisioner.SpringIntegrationConsumerDestination;
+import org.springframework.cloud.stream.binder.integration.SpringIntegrationProvisioner.SpringIntegrationProducerDestination;
+import org.springframework.cloud.stream.provisioning.ConsumerDestination;
+import org.springframework.cloud.stream.provisioning.ProducerDestination;
+import org.springframework.integration.core.MessageProducer;
+import org.springframework.integration.handler.BridgeHandler;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.SubscribableChannel;
+
+/**
+ * Implementation of {@link Binder} backed by Spring Integration framework.
+ * It is useful for localized demos and testing.
+ * <p>
+ * This binder extends from the same base class ({@link AbstractMessageChannelBinder}) as
+ * other binders (i.e., Rabbit, Kafka etc). Interaction with this binder is done via a pair of named {@link MessageChannel}s.
+ * <br>
+ * The names of the channels are:
+ * <ul>
+ * <li>{@link SpringIntegrationBinderConfiguration#BINDER_INPUT}</li>
+ * <li>{@link SpringIntegrationBinderConfiguration#BINDER_OUTPUT}</li>
+ * </ul>
+ * Simply autowire them in your your application and send/receive messages.
+ * </p>
+ * You must also add {@link SpringIntegrationBinderConfiguration} to your configuration.
+ * Below is the example using Spring Boot test.
+ * <pre class="code">
+ *
+ * &#064;RunWith(SpringJUnit4ClassRunner.class)
+ * &#064;SpringBootTest(classes = {SpringIntegrationBinderConfiguration.class, TestWithSIBinder.MyProcessor.class})
+ * public class TestWithSIBinder {
+ *     &#064;Autowired
+ *     private MessageChannel BINDER_INPUT;
+ *
+ *     &#064;Autowired
+ *     private QueueChannel BINDER_OUTPUT;
+ *
+ *     &#064;Test
+ *     public void testWiring() {
+ *         BINDER_INPUT.send(new GenericMessage<String>("Hello"));
+ *         assertEquals("Hello world", new String((byte[])BINDER_OUTPUT.receive().getPayload(), StandardCharsets.UTF_8));
+ *     }
+ *
+ *     &#064;SpringBootApplication
+ *     &#064;EnableBinding(Processor.class)
+ *     public static class MyProcessor {
+ *         &#064;Transformer(inputChannel = Processor.INPUT, outputChannel = Processor.OUTPUT)
+ *         public String transform(String in) {
+ *             return in + " world";
+ *         }
+ *     }
+ * }
+ * </pre>
+ *
+ * @author Oleg Zhurakousky
+ */
+class SpringIntegrationChannelBinder extends AbstractMessageChannelBinder<ConsumerProperties,
+	ProducerProperties, SpringIntegrationProvisioner> {
+
+	@Autowired
+	private BeanFactory beanFactory;
+
+	SpringIntegrationChannelBinder(SpringIntegrationProvisioner provisioningProvider) {
+		super(provisioningProvider);
+	}
+
+	@Override
+	protected MessageHandler createProducerMessageHandler(ProducerDestination destination,
+			ProducerProperties producerProperties, MessageChannel errorChannel) throws Exception {
+		BridgeHandler handler = new BridgeHandler();
+		handler.setBeanFactory(this.beanFactory);
+		handler.setOutputChannel(((SpringIntegrationProducerDestination)destination).getChannel());
+		return handler;
+	}
+
+	@Override
+	protected MessageProducer createConsumerEndpoint(ConsumerDestination destination, String group, ConsumerProperties properties)
+			throws Exception {
+		SubscribableChannel siBinderInputChannel = ((SpringIntegrationConsumerDestination)destination).getChannel();
+		BridgeHandler handler = new BridgeHandler();
+		handler.setBeanFactory(this.beanFactory);
+		siBinderInputChannel.subscribe(handler);
+		return handler;
+	}
+}

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/integration/SpringIntegrationProvisioner.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/integration/SpringIntegrationProvisioner.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.integration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.stream.binder.Binder;
+import org.springframework.cloud.stream.binder.ConsumerProperties;
+import org.springframework.cloud.stream.binder.ProducerProperties;
+import org.springframework.cloud.stream.provisioning.AbstractNamedDestination;
+import org.springframework.cloud.stream.provisioning.ConsumerDestination;
+import org.springframework.cloud.stream.provisioning.ProducerDestination;
+import org.springframework.cloud.stream.provisioning.ProvisioningException;
+import org.springframework.cloud.stream.provisioning.ProvisioningProvider;
+import org.springframework.integration.channel.AbstractMessageChannel;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.SubscribableChannel;
+
+/**
+ * {@link ProvisioningProvider} to support {@link SpringIntegrationChannelBinder}. It
+ * exists primarily to support {@link AbstractMessageChannel} semantics for creating
+ * {@link ConsumerDestination} and {@link ProducerDestination}, thus it returns SI
+ * specific destinations which contain {@link MessageChannel}s used to interact with this
+ * {@link Binder}
+ *
+ * @author Oleg Zhurakousky
+ *
+ */
+public class SpringIntegrationProvisioner implements ProvisioningProvider<ConsumerProperties, ProducerProperties> {
+
+	private Map<String, SubscribableChannel> provisionedDestinations = new HashMap<>();
+
+	@Autowired
+	private SourceDestination source;
+
+	@Autowired
+	private TargetDestination target;
+
+	@Override
+	public ProducerDestination provisionProducerDestination(String name, ProducerProperties properties) throws ProvisioningException {
+		SubscribableChannel destination = this.provisionDestination(name);
+		this.target.setChannel(destination);
+		return new SpringIntegrationProducerDestination(name, destination);
+	}
+
+	@Override
+	public ConsumerDestination provisionConsumerDestination(String name, String group, ConsumerProperties properties) throws ProvisioningException {
+		SubscribableChannel destination = this.provisionDestination(name);
+		this.source.setChannel(destination);
+		return new SpringIntegrationConsumerDestination(name, destination);
+	}
+
+	private SubscribableChannel provisionDestination(String name) {
+		String destinationName = name + ".destination";
+		SubscribableChannel destination = this.provisionedDestinations.get(destinationName);
+		if (destination == null) {
+			destination = new DirectChannel();
+			((DirectChannel)destination).setBeanName(destinationName);
+			((DirectChannel)destination).setComponentName(destinationName);
+			this.provisionedDestinations.put(destinationName, destination);
+		}
+		return destination;
+	}
+
+	class SpringIntegrationConsumerDestination extends AbstractNamedDestination implements ConsumerDestination {
+		private final SubscribableChannel channel;
+
+		SpringIntegrationConsumerDestination(String name, SubscribableChannel channel) {
+			super(name);
+			this.channel = channel;
+		}
+
+		public SubscribableChannel getChannel() {
+			return this.channel;
+		}
+	}
+
+	class SpringIntegrationProducerDestination extends AbstractNamedDestination implements ProducerDestination {
+		private final SubscribableChannel channel;
+
+		SpringIntegrationProducerDestination(String name, SubscribableChannel channel) {
+			super(name);
+			this.channel = channel;
+		}
+
+		@Override
+		public String getNameForPartition(int partition) {
+			return this.getName() + partition;
+		}
+
+		public SubscribableChannel getChannel() {
+			return this.channel;
+		}
+	}
+}

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/integration/TargetDestination.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/integration/TargetDestination.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.integration;
+
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.MessagingException;
+
+/**
+ *
+ * @author Oleg Zhurakousky
+ *
+ */
+public class TargetDestination extends AbstractDestination {
+
+	private Queue<Message<?>> messages;
+
+	public Message<?> receive() {
+		return messages.poll();
+	}
+
+	@Override
+	void afterChannelIsSet() {
+		this.messages = new ArrayBlockingQueue<>(1000);
+		this.getChannel().subscribe(new MessageHandler() {
+
+			@Override
+			public void handleMessage(Message<?> message) throws MessagingException {
+				System.out.println("Enqueueing message: " + message);
+				messages.offer(message);
+			}
+		});
+	}
+}

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/stub1/StubBinder1Configuration.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/stub1/StubBinder1Configuration.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.stream.binder.stub1;
 
 import org.springframework.boot.actuate.health.ApplicationHealthIndicator;
 import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.binder.Binder;
@@ -33,6 +34,7 @@ public class StubBinder1Configuration {
 
 	@Bean
 	@ConfigurationProperties("binder1")
+	@ConditionalOnMissingBean
 	public Binder<?, ?, ?> binder() {
 		return new StubBinder1();
 	}


### PR DESCRIPTION
The idea is to introduce a standard Stub Binder that relies on the same core configuration as Kafka and Rabbit binders (using Spring Integration is just a natural choice for implementing such binder).
**This is primarily to introduce consistency around testing various stream components.** 
Basically, we already have variations of such binder scattered around many tests, resulting in some code duplication across `setupContext()` methods. This could eventually lead to such tests going out of sink with the core configuration if it were to change making those tests less valid.