### PR TITLE
GH-1126 Fixed default app port in Tests

### DIFF
--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/aggregate/AggregateApplicationTests.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/aggregate/AggregateApplicationTests.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.stream.config.aggregate;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -41,6 +42,11 @@ import static org.hamcrest.Matchers.notNullValue;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 public class AggregateApplicationTests {
+
+	@Before
+	public void before() {
+		System.setProperty("server.port", "0");
+	}
 
 	@Test
 	@SuppressWarnings("unchecked")

--- a/spring-cloud-stream-test-support/src/test/java/org/springframework/cloud/stream/test/aggregate/main/AggregateWithMainTest.java
+++ b/spring-cloud-stream-test-support/src/test/java/org/springframework/cloud/stream/test/aggregate/main/AggregateWithMainTest.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.stream.test.aggregate.main;
 
 import java.util.concurrent.TimeUnit;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,6 +42,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Artem Bilan
  */
 public class AggregateWithMainTest {
+
+	@Before
+	public void before() {
+		System.setProperty("server.port", "0");
+	}
 
 	@SuppressWarnings("unchecked")
 	@Test

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/aggregation/AggregationTest.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/aggregation/AggregationTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import org.springframework.beans.DirectFieldAccessor;
@@ -50,6 +51,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+
+
 /**
  * @author Marius Bogoevici
  * @author Ilayaperumal Gopinathan
@@ -60,6 +63,11 @@ import static org.junit.Assert.assertTrue;
 public class AggregationTest {
 
 	private ConfigurableApplicationContext aggregatedApplicationContext;
+
+	@Before
+	public void before() {
+		System.setProperty("server.port", "0");
+	}
 
 	@After
 	public void closeContext() {
@@ -245,6 +253,7 @@ public class AggregationTest {
 				MockBinderRegistryConfiguration.class);
 		System.setProperty("a.foo-value", "sysbara");
 		System.setProperty("c.fooValue", "sysbarc");
+		System.setProperty("server.port", "0");
 		aggregatedApplicationContext = aggregateApplicationBuilder.parent(DummyConfig.class).from(TestSource.class)
 				.namespace("a").args("--foo-value=bar")
 				.via(TestProcessor.class).namespace("b").args("--fooValue=argbarb")
@@ -278,6 +287,7 @@ public class AggregationTest {
 				MockBinderRegistryConfiguration.class);
 		System.setProperty("a.foo-value", "sysbara");
 		System.setProperty("c.fooValue", "sysbarc");
+		System.setProperty("server.port", "0");
 		aggregatedApplicationContext = aggregateApplicationBuilder.parent(DummyConfig.class).from(TestSource.class)
 				.namespace("a").args("--foo-value=bar")
 				.via(TestProcessor.class).namespace("b").args("--fooValue=argbarb")


### PR DESCRIPTION
Ensured AggregateApplicationTests, AggregateWithMainTest and AggregationTest arn't using default 8080 port