### PR TITLE
KGH-12: Late binding for kafka etc

### DIFF
--- a/spring-cloud-stream-core-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
+++ b/spring-cloud-stream-core-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
@@ -1123,6 +1123,12 @@ The typical usage of this property is to be nested in a customized environment <
 +
 Default: false.
 
+spring.cloud.stream.bindingRetryInterval::
+  The interval (seconds) between retrying binding creation when, for example, the binder doesn't support late binding and the broker is down (e.g. Apache Kafka).
+Set to zero to treat such conditions as fatal, preventing the application from starting.
++
+Default: 30
+
 [[binding-properties]]
 === Binding Properties
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindingService.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindingService.java
@@ -216,7 +216,7 @@ public class BindingService {
 				this.bindingServiceProperties.getBindingRetryInterval() + " seconds", exception);
 		this.taskScheduler.schedule(() -> {
 			try {
-				late.delegate = binder.bindProducer(bindingTarget, output, producerProperties);
+				late.setDelegate(binder.bindProducer(bindingTarget, output, producerProperties));
 			}
 			catch (RuntimeException e) {
 				rescheduleProducerBinding(output, bindingTarget, binder, producerProperties, late, e);
@@ -277,9 +277,9 @@ public class BindingService {
 
 	private static class LateBinding<T> implements Binding<T> {
 
-		private volatile Binding<T> delegate;
+		private Binding<T> delegate;
 
-		private volatile boolean unbound;
+		private boolean unbound;
 
 		LateBinding() {
 			super();

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceConfiguration.java
@@ -65,6 +65,7 @@ import org.springframework.messaging.core.DestinationResolutionException;
 import org.springframework.messaging.core.DestinationResolver;
 import org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory;
 import org.springframework.messaging.handler.annotation.support.MessageHandlerMethodFactory;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.tuple.spel.TuplePropertyAccessor;
 
 /**
@@ -82,7 +83,8 @@ import org.springframework.tuple.spel.TuplePropertyAccessor;
 @Import(ContentTypeConfiguration.class)
 public class BindingServiceConfiguration {
 
-	public static final String STREAM_LISTENER_ANNOTATION_BEAN_POST_PROCESSOR_NAME = "streamListenerAnnotationBeanPostProcessor";
+	public static final String STREAM_LISTENER_ANNOTATION_BEAN_POST_PROCESSOR_NAME =
+			"streamListenerAnnotationBeanPostProcessor";
 
 	public static final String ERROR_BRIDGE_CHANNEL = "errorBridgeChannel";
 
@@ -108,8 +110,8 @@ public class BindingServiceConfiguration {
 	// already exists).
 	@ConditionalOnMissingBean(BindingService.class)
 	public BindingService bindingService(BindingServiceProperties bindingServiceProperties,
-			BinderFactory binderFactory) {
-		return new BindingService(bindingServiceProperties, binderFactory);
+			BinderFactory binderFactory, TaskScheduler taskScheduler) {
+		return new BindingService(bindingServiceProperties, binderFactory, taskScheduler);
 	}
 
 	@Bean

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceProperties.java
@@ -48,6 +48,8 @@ import org.springframework.util.Assert;
 @JsonInclude(Include.NON_DEFAULT)
 public class BindingServiceProperties implements ApplicationContextAware, InitializingBean {
 
+	private static final int DEFAULT_BINDING_RETRY_INTERVAL = 30;
+
 	private ConversionService conversionService;
 
 	@Value("${INSTANCE_INDEX:${CF_INSTANCE_INDEX:0}}")
@@ -65,6 +67,8 @@ public class BindingServiceProperties implements ApplicationContextAware, Initia
 	private String[] dynamicDestinations = new String[0];
 
 	private ConfigurableApplicationContext applicationContext;
+
+	private int bindingRetryInterval = DEFAULT_BINDING_RETRY_INTERVAL;
 
 	public Map<String, BindingProperties> getBindings() {
 		return this.bindings;
@@ -212,6 +216,14 @@ public class BindingServiceProperties implements ApplicationContextAware, Initia
 
 	public String getBindingDestination(String bindingName) {
 		return getBindingProperties(bindingName).getDestination();
+	}
+
+	public int getBindingRetryInterval() {
+		return this.bindingRetryInterval;
+	}
+
+	public void setBindingRetryInterval(int bindingRetryInterval) {
+		this.bindingRetryInterval = bindingRetryInterval;
 	}
 
 	public void updateProducerProperties(String bindingName, ProducerProperties producerProperties) {


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/12

Support late binding for binders that don't inherently support it.

Schedule attempts at 30 second intervals (default, configurable).

`IllegalState` and `IllegalArgument` exceptions are fatal.

