### PR TITLE
RGH-83: Allow binders to add interceptors

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
@@ -97,8 +97,8 @@ public abstract class AbstractBinder<T, C extends ConsumerProperties, P extends 
 		return this.applicationContext.getBeanFactory();
 	}
 
-	public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
-		this.evaluationContext = evaluationContext;
+	protected EvaluationContext getEvaluationContext() {
+		return this.evaluationContext;
 	}
 
 	@Override

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
@@ -138,6 +138,7 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 		if (producerMessageHandler instanceof Lifecycle) {
 			((Lifecycle) producerMessageHandler).start();
 		}
+		postProcessOutputChannel(outputChannel, producerProperties);
 		((SubscribableChannel) outputChannel).subscribe(
 				new SendingHandler(producerMessageHandler, HeaderMode.embeddedHeaders
 						.equals(producerProperties.getHeaderMode()), this.headersToEmbed,
@@ -161,6 +162,16 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 				afterUnbindProducer(producerDestination, producerProperties);
 			}
 		};
+	}
+
+	/**
+	 * Allows subclasses to perform post processing on the channel - for example to
+	 * add more interceptors.
+	 * @param outputChannel the channel.
+	 * @param producerProperties the producer properties.
+	 */
+	protected void postProcessOutputChannel(MessageChannel outputChannel, P producerProperties) {
+		// default no-op
 	}
 
 	/**


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-stream-binder-rabbit/issues/83

The RabbitMQ binder needs to add an interceptor to evaluate expressions (if they
include `payload`) before the payload is serialized.

Add a hook to allow the binder to post-process the message channel.