### PR TITLE
Fix AbstractBinderTests to populate properties

### DIFF
--- a/spring-cloud-stream-binder-test/src/main/java/org/springframework/cloud/stream/binder/AbstractBinderTests.java
+++ b/spring-cloud-stream-binder-test/src/main/java/org/springframework/cloud/stream/binder/AbstractBinderTests.java
@@ -73,6 +73,7 @@ import static org.junit.Assert.assertTrue;
  * @author Marius Bogoevici
  * @author Oleg Zhurakousky
  * @author Jacob Severson
+ * @author Artem Bilan
  */
 @SuppressWarnings("unchecked")
 public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends AbstractBinder<MessageChannel, CP, PP>, CP, PP>, CP extends ConsumerProperties, PP extends ProducerProperties> {
@@ -197,6 +198,7 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 	}
 
 	private class Foo {
+
 		private String name;
 
 		@SuppressWarnings("unused")
@@ -250,7 +252,7 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 
 		assertThat(inboundMessageRef.get().getPayload()).isInstanceOf(Foo.class);
 		assertThat(inboundMessageRef.get().getHeaders().get(BinderHeaders.BINDER_ORIGINAL_CONTENT_TYPE)).isNull();
-		assertTrue(equalTypeAndSubType((MimeType)inboundMessageRef.get().getHeaders().get(MessageHeaders.CONTENT_TYPE), MessageConverterUtils.X_JAVA_OBJECT));
+		assertTrue(equalTypeAndSubType((MimeType) inboundMessageRef.get().getHeaders().get(MessageHeaders.CONTENT_TYPE), MessageConverterUtils.X_JAVA_OBJECT));
 		producerBinding.unbind();
 		consumerBinding.unbind();
 	}
@@ -271,8 +273,10 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 				getDestinationNameDelimiter()), "testSendAndReceiveJavaSerialization", moduleInputChannel,
 				createConsumerProperties());
 		SerializableFoo foo = new SerializableFoo();
-		Message<?> message = MessageBuilder.withPayload(foo).setHeader(MessageHeaders.CONTENT_TYPE, MessageConverterUtils.X_JAVA_SERIALIZED_OBJECT)
-				.build();
+		Message<?> message =
+				MessageBuilder.withPayload(foo)
+						.setHeader(MessageHeaders.CONTENT_TYPE, MessageConverterUtils.X_JAVA_SERIALIZED_OBJECT)
+						.build();
 		// Let the consumer actually bind to the producer before sending a msg
 		binderBindUnbindLatency();
 
@@ -444,7 +448,7 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 				new CompositeMessageConverterFactory(null, null));
 		messageConverterConfigurer.setBeanFactory(applicationContext.getBeanFactory());
 		messageConverterConfigurer.afterPropertiesSet();
-		if (inputChannel){
+		if (inputChannel) {
 			messageConverterConfigurer.configureInputChannel(channel, channelName);
 		}
 		else {
@@ -492,12 +496,15 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 				AbstractBinderTests.class, "echoStation", Station.class);
 
 		Binder binder = getBinder();
-		DirectChannel moduleOutputChannel = createBindableChannel("output",
-				new BindingProperties());
-		DirectChannel moduleInputChannel = createBindableChannel("input",
-				new BindingProperties());
+
+		PP producerProperties = createProducerProperties();
+
+		BindingProperties producerBindingProperties = createProducerBindingProperties(producerProperties);
+
+		DirectChannel moduleOutputChannel = createBindableChannel("output", producerBindingProperties);
+		DirectChannel moduleInputChannel = createBindableChannel("input", producerBindingProperties);
 		Binding<MessageChannel> producerBinding = binder.bindProducer(String.format("bad%s0a",
-				getDestinationNameDelimiter()), moduleOutputChannel, createProducerProperties());
+				getDestinationNameDelimiter()), moduleOutputChannel, producerProperties);
 		Binding<MessageChannel> consumerBinding = binder.bindConsumer(String.format("bad%s0a",
 				getDestinationNameDelimiter()), "test-1", moduleInputChannel, createConsumerProperties());
 
@@ -521,12 +528,17 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 				AbstractBinderTests.class, "echoStation", Station.class);
 
 		Binder binder = getBinder();
-		DirectChannel moduleOutputChannel = createBindableChannel("output",
-				new BindingProperties());
-		DirectChannel moduleInputChannel = createBindableChannel("input",
-				new BindingProperties());
+
+		PP producerProperties = createProducerProperties();
+
+		BindingProperties producerBindingProperties = createProducerBindingProperties(producerProperties);
+
+		DirectChannel moduleOutputChannel = createBindableChannel("output", producerBindingProperties);
+		DirectChannel moduleInputChannel = createBindableChannel("input", producerBindingProperties);
+
 		Binding<MessageChannel> producerBinding = binder.bindProducer(String.format("bad%s0b",
-				getDestinationNameDelimiter()), moduleOutputChannel, createProducerProperties());
+				getDestinationNameDelimiter()), moduleOutputChannel, producerProperties);
+
 		Binding<MessageChannel> consumerBinding = binder.bindConsumer(String.format("bad%s0b",
 				getDestinationNameDelimiter()), "test-2", moduleInputChannel, createConsumerProperties());
 
@@ -548,12 +560,16 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 	@Test(expected = MessageHandlingException.class)
 	public void testStreamListenerJavaSerializationNonSerializable() throws Exception {
 		Binder binder = getBinder();
-		DirectChannel moduleOutputChannel = createBindableChannel("output",
-				new BindingProperties());
-		DirectChannel moduleInputChannel = createBindableChannel("input",
-				new BindingProperties());
+
+		PP producerProperties = createProducerProperties();
+
+		BindingProperties producerBindingProperties = createProducerBindingProperties(producerProperties);
+
+		DirectChannel moduleOutputChannel = createBindableChannel("output", producerBindingProperties);
+		DirectChannel moduleInputChannel = createBindableChannel("input", producerBindingProperties);
+
 		Binding<MessageChannel> producerBinding = binder.bindProducer(String.format("bad%s0c",
-				getDestinationNameDelimiter()), moduleOutputChannel, createProducerProperties());
+				getDestinationNameDelimiter()), moduleOutputChannel, producerProperties);
 		Binding<MessageChannel> consumerBinding = binder.bindConsumer(String.format("bad%s0c",
 				getDestinationNameDelimiter()), "test-3", moduleInputChannel, createConsumerProperties());
 		try {
@@ -576,12 +592,17 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 		StreamListenerMessageHandler handler = this.buildStreamListener(
 				AbstractBinderTests.class, "echoStation", Station.class);
 		Binder binder = getBinder();
-		DirectChannel moduleOutputChannel = createBindableChannel("output",
-				new BindingProperties());
-		DirectChannel moduleInputChannel = createBindableChannel("input",
-				new BindingProperties());
+
+		PP producerProperties = createProducerProperties();
+
+		BindingProperties producerBindingProperties = createProducerBindingProperties(producerProperties);
+
+		DirectChannel moduleOutputChannel = createBindableChannel("output", producerBindingProperties);
+		DirectChannel moduleInputChannel = createBindableChannel("input", producerBindingProperties);
+
 		Binding<MessageChannel> producerBinding = binder.bindProducer(String.format("bad%s0d",
-				getDestinationNameDelimiter()), moduleOutputChannel, createProducerProperties());
+				getDestinationNameDelimiter()), moduleOutputChannel, producerProperties);
+
 		Binding<MessageChannel> consumerBinding = binder.bindConsumer(String.format("bad%s0d",
 				getDestinationNameDelimiter()), "test-4", moduleInputChannel, createConsumerProperties());
 
@@ -610,12 +631,17 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 		StreamListenerMessageHandler handler = this.buildStreamListener(
 				AbstractBinderTests.class, "echoStationString", String.class);
 		Binder binder = getBinder();
-		DirectChannel moduleOutputChannel = createBindableChannel("output",
-				new BindingProperties());
-		DirectChannel moduleInputChannel = createBindableChannel("input",
-				new BindingProperties());
+
+		PP producerProperties = createProducerProperties();
+
+		BindingProperties producerBindingProperties = createProducerBindingProperties(producerProperties);
+
+		DirectChannel moduleOutputChannel = createBindableChannel("output", producerBindingProperties);
+		DirectChannel moduleInputChannel = createBindableChannel("input", producerBindingProperties);
+
 		Binding<MessageChannel> producerBinding = binder.bindProducer(String.format("bad%s0e",
-				getDestinationNameDelimiter()), moduleOutputChannel, createProducerProperties());
+				getDestinationNameDelimiter()), moduleOutputChannel, producerProperties);
+
 		Binding<MessageChannel> consumerBinding = binder.bindConsumer(String.format("bad%s0e",
 				getDestinationNameDelimiter()), "test-5", moduleInputChannel, createConsumerProperties());
 
@@ -644,12 +670,17 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 		StreamListenerMessageHandler handler = this.buildStreamListener(
 				AbstractBinderTests.class, "echoStation", Station.class);
 		Binder binder = getBinder();
-		DirectChannel moduleOutputChannel = createBindableChannel("output",
-				new BindingProperties());
-		DirectChannel moduleInputChannel = createBindableChannel("input",
-				new BindingProperties());
+
+		PP producerProperties = createProducerProperties();
+
+		BindingProperties producerBindingProperties = createProducerBindingProperties(producerProperties);
+
+		DirectChannel moduleOutputChannel = createBindableChannel("output", producerBindingProperties);
+		DirectChannel moduleInputChannel = createBindableChannel("input", producerBindingProperties);
+
 		Binding<MessageChannel> producerBinding = binder.bindProducer(String.format("bad%s0f",
-				getDestinationNameDelimiter()), moduleOutputChannel, createProducerProperties());
+				getDestinationNameDelimiter()), moduleOutputChannel, producerProperties);
+
 		Binding<MessageChannel> consumerBinding = binder.bindConsumer(String.format("bad%s0f",
 				getDestinationNameDelimiter()), "test-6", moduleInputChannel, createConsumerProperties());
 
@@ -710,7 +741,7 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 				StreamListenerMessageHandler.class, InvocableHandlerMethod.class,
 				boolean.class, String[].class);
 		StreamListenerMessageHandler handler = (StreamListenerMessageHandler) c
-				.newInstance(method, false, new String[] {});
+				.newInstance(method, false, new String[] { });
 		handler.setOutputChannelName(channelName);
 		handler.setBeanFactory(context);
 		handler.afterPropertiesSet();
@@ -732,8 +763,11 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 
 		@SuppressWarnings("serial")
 		public static class Readings implements Serializable {
+
 			public String stationid;
+
 			public String customerid;
+
 			public String timestamp;
 
 			public String getStationid() {

--- a/spring-cloud-stream-binder-test/src/main/java/org/springframework/cloud/stream/binder/AbstractBinderTests.java
+++ b/spring-cloud-stream-binder-test/src/main/java/org/springframework/cloud/stream/binder/AbstractBinderTests.java
@@ -166,7 +166,7 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 		Binding<MessageChannel> producerBinding = binder.bindProducer(String.format("foo%s0",
 				getDestinationNameDelimiter()), moduleOutputChannel, outputBindingProperties.getProducer());
 		Binding<MessageChannel> consumerBinding = binder.bindConsumer(String.format("foo%s0",
-				getDestinationNameDelimiter()), "testSendAndReceive", moduleInputChannel, createConsumerProperties());
+				getDestinationNameDelimiter()), "testSendAndReceive", moduleInputChannel, inputBindingProperties.getConsumer());
 		Message<?> message = MessageBuilder.withPayload("foo").setHeader(MessageHeaders.CONTENT_TYPE, "foo/bar")
 				.build();
 		// Let the consumer actually bind to the producer before sending a msg
@@ -224,7 +224,7 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 		Binding<MessageChannel> producerBinding = binder.bindProducer(String.format("foo%s0x",
 				getDestinationNameDelimiter()), moduleOutputChannel, outputBindingProperties.getProducer());
 		Binding<MessageChannel> consumerBinding = binder.bindConsumer(String.format("foo%s0x",
-				getDestinationNameDelimiter()), "testSendAndReceiveKryo", moduleInputChannel, createConsumerProperties());
+				getDestinationNameDelimiter()), "testSendAndReceiveKryo", moduleInputChannel, inputBindingProperties.getConsumer());
 		Foo foo = new Foo();
 		foo.setName("Bill");
 		Message<?> message = MessageBuilder.withPayload(foo).setHeader(MessageHeaders.CONTENT_TYPE, MessageConverterUtils.X_JAVA_OBJECT)
@@ -271,7 +271,7 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 				getDestinationNameDelimiter()), moduleOutputChannel, outputBindingProperties.getProducer());
 		Binding<MessageChannel> consumerBinding = binder.bindConsumer(String.format("foo%s0y",
 				getDestinationNameDelimiter()), "testSendAndReceiveJavaSerialization", moduleInputChannel,
-				createConsumerProperties());
+				inputBindingProperties.getConsumer());
 		SerializableFoo foo = new SerializableFoo();
 		Message<?> message =
 				MessageBuilder.withPayload(foo)
@@ -310,17 +310,19 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 	public void testSendAndReceiveMultipleTopics() throws Exception {
 		Binder binder = getBinder();
 
-		DirectChannel moduleOutputChannel1 = createBindableChannel("output1",
-				createProducerBindingProperties(createProducerProperties()));
-		DirectChannel moduleOutputChannel2 = createBindableChannel("output2",
-				createProducerBindingProperties(createProducerProperties()));
+		BindingProperties producerBindingProperties = createProducerBindingProperties(createProducerProperties());
+
+		DirectChannel moduleOutputChannel1 = createBindableChannel("output1", producerBindingProperties);
+
+		DirectChannel moduleOutputChannel2 = createBindableChannel("output2", producerBindingProperties);
 
 		QueueChannel moduleInputChannel = new QueueChannel();
 
 		Binding<MessageChannel> producerBinding1 = binder.bindProducer(String.format("foo%sxy",
-				getDestinationNameDelimiter()), moduleOutputChannel1, createProducerProperties());
+				getDestinationNameDelimiter()), moduleOutputChannel1, producerBindingProperties.getProducer());
 		Binding<MessageChannel> producerBinding2 = binder.bindProducer(String.format("foo%syz",
-				getDestinationNameDelimiter()), moduleOutputChannel2, createProducerProperties());
+
+				getDestinationNameDelimiter()), moduleOutputChannel2, producerBindingProperties.getProducer());
 
 		Binding<MessageChannel> consumerBinding1 = binder.bindConsumer(String.format("foo%sxy",
 				getDestinationNameDelimiter()), "testSendAndReceiveMultipleTopics", moduleInputChannel,
@@ -497,16 +499,19 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 
 		Binder binder = getBinder();
 
-		PP producerProperties = createProducerProperties();
-
-		BindingProperties producerBindingProperties = createProducerBindingProperties(producerProperties);
+		BindingProperties producerBindingProperties = createProducerBindingProperties(createProducerProperties());
 
 		DirectChannel moduleOutputChannel = createBindableChannel("output", producerBindingProperties);
-		DirectChannel moduleInputChannel = createBindableChannel("input", producerBindingProperties);
+
+		BindingProperties consumerBindingProperties = createConsumerBindingProperties(createConsumerProperties());
+
+		DirectChannel moduleInputChannel = createBindableChannel("input", consumerBindingProperties);
+
 		Binding<MessageChannel> producerBinding = binder.bindProducer(String.format("bad%s0a",
-				getDestinationNameDelimiter()), moduleOutputChannel, producerProperties);
+				getDestinationNameDelimiter()), moduleOutputChannel, producerBindingProperties.getProducer());
+
 		Binding<MessageChannel> consumerBinding = binder.bindConsumer(String.format("bad%s0a",
-				getDestinationNameDelimiter()), "test-1", moduleInputChannel, createConsumerProperties());
+				getDestinationNameDelimiter()), "test-1", moduleInputChannel, consumerBindingProperties.getConsumer());
 
 		Station station = new Station();
 		Message<?> message = MessageBuilder.withPayload(station).build();
@@ -529,18 +534,19 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 
 		Binder binder = getBinder();
 
-		PP producerProperties = createProducerProperties();
-
-		BindingProperties producerBindingProperties = createProducerBindingProperties(producerProperties);
+		BindingProperties producerBindingProperties = createProducerBindingProperties(createProducerProperties());
 
 		DirectChannel moduleOutputChannel = createBindableChannel("output", producerBindingProperties);
-		DirectChannel moduleInputChannel = createBindableChannel("input", producerBindingProperties);
+
+		BindingProperties consumerBindingProperties = createConsumerBindingProperties(createConsumerProperties());
+
+		DirectChannel moduleInputChannel = createBindableChannel("input", consumerBindingProperties);
 
 		Binding<MessageChannel> producerBinding = binder.bindProducer(String.format("bad%s0b",
-				getDestinationNameDelimiter()), moduleOutputChannel, producerProperties);
+				getDestinationNameDelimiter()), moduleOutputChannel, producerBindingProperties.getProducer());
 
 		Binding<MessageChannel> consumerBinding = binder.bindConsumer(String.format("bad%s0b",
-				getDestinationNameDelimiter()), "test-2", moduleInputChannel, createConsumerProperties());
+				getDestinationNameDelimiter()), "test-2", moduleInputChannel, consumerBindingProperties.getConsumer());
 
 		Station station = new Station();
 		Message<?> message = MessageBuilder.withPayload(station).setHeader(
@@ -561,17 +567,19 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 	public void testStreamListenerJavaSerializationNonSerializable() throws Exception {
 		Binder binder = getBinder();
 
-		PP producerProperties = createProducerProperties();
-
-		BindingProperties producerBindingProperties = createProducerBindingProperties(producerProperties);
+		BindingProperties producerBindingProperties = createProducerBindingProperties(createProducerProperties());
 
 		DirectChannel moduleOutputChannel = createBindableChannel("output", producerBindingProperties);
-		DirectChannel moduleInputChannel = createBindableChannel("input", producerBindingProperties);
+
+		BindingProperties consumerBindingProperties = createConsumerBindingProperties(createConsumerProperties());
+
+		DirectChannel moduleInputChannel = createBindableChannel("input", consumerBindingProperties);
 
 		Binding<MessageChannel> producerBinding = binder.bindProducer(String.format("bad%s0c",
-				getDestinationNameDelimiter()), moduleOutputChannel, producerProperties);
+				getDestinationNameDelimiter()), moduleOutputChannel, producerBindingProperties.getProducer());
+
 		Binding<MessageChannel> consumerBinding = binder.bindConsumer(String.format("bad%s0c",
-				getDestinationNameDelimiter()), "test-3", moduleInputChannel, createConsumerProperties());
+				getDestinationNameDelimiter()), "test-3", moduleInputChannel, consumerBindingProperties.getConsumer());
 		try {
 			Station station = new Station();
 			Message<?> message = MessageBuilder.withPayload(station)
@@ -593,18 +601,19 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 				AbstractBinderTests.class, "echoStation", Station.class);
 		Binder binder = getBinder();
 
-		PP producerProperties = createProducerProperties();
-
-		BindingProperties producerBindingProperties = createProducerBindingProperties(producerProperties);
+		BindingProperties producerBindingProperties = createProducerBindingProperties(createProducerProperties());
 
 		DirectChannel moduleOutputChannel = createBindableChannel("output", producerBindingProperties);
-		DirectChannel moduleInputChannel = createBindableChannel("input", producerBindingProperties);
+
+		BindingProperties consumerBindingProperties = createConsumerBindingProperties(createConsumerProperties());
+
+		DirectChannel moduleInputChannel = createBindableChannel("input", consumerBindingProperties);
 
 		Binding<MessageChannel> producerBinding = binder.bindProducer(String.format("bad%s0d",
-				getDestinationNameDelimiter()), moduleOutputChannel, producerProperties);
+				getDestinationNameDelimiter()), moduleOutputChannel, producerBindingProperties.getProducer());
 
 		Binding<MessageChannel> consumerBinding = binder.bindConsumer(String.format("bad%s0d",
-				getDestinationNameDelimiter()), "test-4", moduleInputChannel, createConsumerProperties());
+				getDestinationNameDelimiter()), "test-4", moduleInputChannel, consumerBindingProperties.getConsumer());
 
 		String value = "{\"readings\":[{\"stationid\":\"fgh\","
 				+ "\"customerid\":\"12345\",\"timestamp\":null},{\"stationid\":\"hjk\",\"customerid\":\"222\",\"timestamp\":null}]}";
@@ -632,18 +641,19 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 				AbstractBinderTests.class, "echoStationString", String.class);
 		Binder binder = getBinder();
 
-		PP producerProperties = createProducerProperties();
-
-		BindingProperties producerBindingProperties = createProducerBindingProperties(producerProperties);
+		BindingProperties producerBindingProperties = createProducerBindingProperties(createProducerProperties());
 
 		DirectChannel moduleOutputChannel = createBindableChannel("output", producerBindingProperties);
-		DirectChannel moduleInputChannel = createBindableChannel("input", producerBindingProperties);
+
+		BindingProperties consumerBindingProperties = createConsumerBindingProperties(createConsumerProperties());
+
+		DirectChannel moduleInputChannel = createBindableChannel("input", consumerBindingProperties);
 
 		Binding<MessageChannel> producerBinding = binder.bindProducer(String.format("bad%s0e",
-				getDestinationNameDelimiter()), moduleOutputChannel, producerProperties);
+				getDestinationNameDelimiter()), moduleOutputChannel, producerBindingProperties.getProducer());
 
 		Binding<MessageChannel> consumerBinding = binder.bindConsumer(String.format("bad%s0e",
-				getDestinationNameDelimiter()), "test-5", moduleInputChannel, createConsumerProperties());
+				getDestinationNameDelimiter()), "test-5", moduleInputChannel, consumerBindingProperties.getConsumer());
 
 		String value = "{\"readings\":[{\"stationid\":\"fgh\","
 				+ "\"customerid\":\"12345\",\"timestamp\":null},{\"stationid\":\"hjk\",\"customerid\":\"222\",\"timestamp\":null}]}";
@@ -671,18 +681,19 @@ public abstract class AbstractBinderTests<B extends AbstractTestBinder<? extends
 				AbstractBinderTests.class, "echoStation", Station.class);
 		Binder binder = getBinder();
 
-		PP producerProperties = createProducerProperties();
-
-		BindingProperties producerBindingProperties = createProducerBindingProperties(producerProperties);
+		BindingProperties producerBindingProperties = createProducerBindingProperties(createProducerProperties());
 
 		DirectChannel moduleOutputChannel = createBindableChannel("output", producerBindingProperties);
-		DirectChannel moduleInputChannel = createBindableChannel("input", producerBindingProperties);
+
+		BindingProperties consumerBindingProperties = createConsumerBindingProperties(createConsumerProperties());
+
+		DirectChannel moduleInputChannel = createBindableChannel("input", consumerBindingProperties);
 
 		Binding<MessageChannel> producerBinding = binder.bindProducer(String.format("bad%s0f",
-				getDestinationNameDelimiter()), moduleOutputChannel, producerProperties);
+				getDestinationNameDelimiter()), moduleOutputChannel, producerBindingProperties.getProducer());
 
 		Binding<MessageChannel> consumerBinding = binder.bindConsumer(String.format("bad%s0f",
-				getDestinationNameDelimiter()), "test-6", moduleInputChannel, createConsumerProperties());
+				getDestinationNameDelimiter()), "test-6", moduleInputChannel, consumerBindingProperties.getConsumer());
 
 		Readings r1 = new Readings();
 		r1.setCustomerid("123");

--- a/spring-cloud-stream-tools/src/main/resources/checkstyle.xml
+++ b/spring-cloud-stream-tools/src/main/resources/checkstyle.xml
@@ -85,7 +85,12 @@
         <module name="AvoidStarImport"/>
         <module name="AvoidStaticImport">
             <property name="excludes"
-                      value="org.junit.Assert.*,org.mockito.Mockito.*,org.mockito.Matchers.*,org.hamcrest.Matchers.*,org.assertj.core.api.Assertions.*"/>
+                      value="org.junit.Assert.*,
+                      org.mockito.Mockito.*,
+                      org.mockito.BDDMockito.*,
+                      org.mockito.ArgumentMatchers.*,
+                      org.hamcrest.Matchers.*,
+                      org.assertj.core.api.Assertions.*"/>
         </module>
         <module name="FallThrough"/>
         <module name="ImportOrder">


### PR DESCRIPTION
Some tests in `AbstractBinderTests` are rely on the partition header,
but that one can be populated only by the `PartitionInterceptor`.
To allow it we need to provide appropriate producer properties, like
`partitionKeyExpression`.

* Populate test-based `ProducerProperties` to the
`createBindableChannel()` where `PartitionInterceptor` is populated
* Fix `checkstyle.xml` static imports rule for Mockito-2.x as the
current base line