### PR TITLE
New abstraction for StreamListener method setup invoker.

### DIFF
--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerMethodSetupOrchestratorTests.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerMethodSetupOrchestratorTests.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.config;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.annotation.Input;
+import org.springframework.cloud.stream.annotation.Output;
+import org.springframework.cloud.stream.annotation.StreamListener;
+import org.springframework.cloud.stream.binding.StreamListenerAnnotationBeanPostProcessor;
+import org.springframework.cloud.stream.binding.StreamListenerSetupMethodOrchestrator;
+import org.springframework.cloud.stream.messaging.Sink;
+import org.springframework.cloud.stream.messaging.Source;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.SubscribableChannel;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.util.ReflectionUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Soby Chacko
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest
+public class StreamListenerMethodSetupOrchestratorTests {
+
+	@SpyBean
+	CustomOrchestrator customOrchestrator;
+
+	@SpyBean
+	MultipleStreamListenerProcessor multipleStreamListenerProcessor;
+
+	@SpyBean
+	StreamListenerAnnotationBeanPostProcessor streamListenerAnnotationBeanPostProcessor;
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testCustomStreamListenerOrchestratorAndDefaultTogetherInSameContext() throws Exception {
+
+		//Two StreamListener methods, so 2 invocations
+		verify(customOrchestrator, times(2)).supports(any());
+
+		Method method = multipleStreamListenerProcessor.getClass().getMethod("handleMessage");
+		StreamListener streamListener = AnnotatedElementUtils.findMergedAnnotation(method, StreamListener.class);
+		//verify that the invocation happened on the custom Orchestrator
+		verify(customOrchestrator).orchestrateStreamListenerSetupMethod(streamListener, method, multipleStreamListenerProcessor);
+
+		Method method1 = multipleStreamListenerProcessor.getClass().getMethod("produceString");
+		StreamListener streamListener1 = AnnotatedElementUtils.findMergedAnnotation(method, StreamListener.class);
+
+		//Verify that the invocation did not happen on the custom orchestrator
+		verify(customOrchestrator, never()).orchestrateStreamListenerSetupMethod(streamListener1, method1, multipleStreamListenerProcessor);
+
+		Field field = ReflectionUtils.findField(streamListenerAnnotationBeanPostProcessor.getClass(), "streamListenerSetupMethodOrchestrators");
+		ReflectionUtils.makeAccessible(field);
+
+		Set<StreamListenerSetupMethodOrchestrator> field1 =
+				(LinkedHashSet<StreamListenerSetupMethodOrchestrator>)ReflectionUtils.getField(field, streamListenerAnnotationBeanPostProcessor);
+		List<StreamListenerSetupMethodOrchestrator> list = new ArrayList<>(field1);
+
+		//Ensure that the custom orchestrator did not support this request
+		assertThat(list.get(0).supports(method1)).isEqualTo(false);
+		//Ensure that we are using the default Orchestrator in StreamListenerAnnoatationBeanPostProcessor
+		assertThat(list.get(1).supports(method1)).isEqualTo(true);
+	}
+
+	public interface SomeProcessor {
+
+		@Input(Sink.INPUT)
+		SubscribableChannel channel1();
+
+		@Input("foobar")
+		SubscribableChannel channel2();
+
+		@Output(Source.OUTPUT)
+		MessageChannel channel3();
+
+	}
+
+	@EnableBinding(SomeProcessor.class)
+	@EnableAutoConfiguration
+	public static class MultipleStreamListenerProcessor {
+
+		@StreamListener(Sink.INPUT)
+		public void handleMessage() {
+		}
+
+		@StreamListener("foobar")
+		@SendTo("output")
+		public String produceString(){
+			return "foobar";
+		}
+
+		@Bean
+		public CustomOrchestrator myOrchestrator() {
+			return new CustomOrchestrator();
+		}
+
+	}
+
+	static class CustomOrchestrator implements StreamListenerSetupMethodOrchestrator {
+
+		@Override
+		public boolean supports(Method method) {
+			return method.getReturnType() != String.class;
+		}
+
+		@Override
+		public void orchestrateStreamListenerSetupMethod(StreamListener streamListener, Method method, Object bean) {
+			//stub method
+		}
+	}
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerSetupMethodOrchestrator.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/StreamListenerSetupMethodOrchestrator.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binding;
+
+import java.lang.reflect.Method;
+
+import org.springframework.cloud.stream.annotation.Input;
+import org.springframework.cloud.stream.annotation.Output;
+import org.springframework.cloud.stream.annotation.StreamListener;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.MethodParameter;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Orchestrator used for invoking the {@link StreamListener} setup method.
+ *
+ * By default {@link StreamListenerAnnotationBeanPostProcessor} will use an internal implementation
+ * of this interface to invoke {@link StreamListenerParameterAdapter}s and {@link StreamListenerResultAdapter}s
+ * or handler mappings on the method annotated with {@link StreamListener}.
+ *
+ * By providing a different implementation of this interface and registering it as a Spring Bean in the
+ * context, one can override the default invocation strategies used by the {@link StreamListenerAnnotationBeanPostProcessor}.
+ * A typical usecase for such overriding can happen when a downstream {@link org.springframework.cloud.stream.binder.Binder}
+ * implementation wants to change the way in which any of the default StreamListener handling needs to be changed in a
+ * custom manner.
+ *
+ * When beans of this interface are present in the context, they get priority in the {@link StreamListenerAnnotationBeanPostProcessor}
+ * before falling back to the default implementation.
+ *
+ * {@see StreamListener}
+ * {@see StreamListenerAnnotationBeanPostProcessor}
+ *
+ * @author Soby Chacko
+ */
+public interface StreamListenerSetupMethodOrchestrator {
+
+	/**
+	 * Checks the method annotated with {@link StreamListener} to see if this implementation
+	 * can successfully orchestrate this method.
+	 *
+	 * @param method annotated with {@link StreamListener}
+	 * @return true if this implementation can orchestrate this method, false otherwise
+	 */
+	boolean supports(Method method);
+
+	/**
+	 * Method that allows custom orchestration on the {@link StreamListener} setup method.
+	 *
+	 * @param streamListener reference to the {@link StreamListener} annotation on the method
+	 * @param method annotated with {@link StreamListener}
+	 * @param bean that contains the StreamListener method
+	 *
+	 */
+	void orchestrateStreamListenerSetupMethod(StreamListener streamListener, Method method, Object bean);
+
+	/**
+	 * Default implementation for adapting each of the incoming method arguments using an available
+	 * {@link StreamListenerParameterAdapter} and provide the adapted collection of arguments back to the caller.
+	 *
+	 * @param method annotated with {@link StreamListener}
+	 * @param inboundName inbound binding
+	 * @param applicationContext spring application context
+	 * @param streamListenerParameterAdapters used for adapting the method arguments
+	 * @return adapted incoming arguments
+	 */
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	default Object[] adaptAndRetrieveInboundArguments(Method method, String inboundName,
+													ApplicationContext applicationContext,
+													StreamListenerParameterAdapter... streamListenerParameterAdapters) {
+		Object[] arguments = new Object[method.getParameterTypes().length];
+		for (int parameterIndex = 0; parameterIndex < arguments.length; parameterIndex++) {
+			MethodParameter methodParameter = MethodParameter.forExecutable(method, parameterIndex);
+			Class<?> parameterType = methodParameter.getParameterType();
+			Object targetReferenceValue = null;
+			if (methodParameter.hasParameterAnnotation(Input.class)) {
+				targetReferenceValue = AnnotationUtils.getValue(methodParameter.getParameterAnnotation(Input.class));
+			}
+			else if (methodParameter.hasParameterAnnotation(Output.class)) {
+				targetReferenceValue = AnnotationUtils.getValue(methodParameter.getParameterAnnotation(Output.class));
+			}
+			else if (arguments.length == 1 && StringUtils.hasText(inboundName)) {
+				targetReferenceValue = inboundName;
+			}
+			if (targetReferenceValue != null) {
+				Assert.isInstanceOf(String.class, targetReferenceValue, "Annotation value must be a String");
+				Object targetBean = applicationContext.getBean((String) targetReferenceValue);
+				// Iterate existing parameter adapters first
+				for (StreamListenerParameterAdapter streamListenerParameterAdapter : streamListenerParameterAdapters) {
+					if (streamListenerParameterAdapter.supports(targetBean.getClass(), methodParameter)) {
+						arguments[parameterIndex] = streamListenerParameterAdapter.adapt(targetBean, methodParameter);
+						break;
+					}
+				}
+				if (arguments[parameterIndex] == null && parameterType.isAssignableFrom(targetBean.getClass())) {
+					arguments[parameterIndex] = targetBean;
+				}
+				Assert.notNull(arguments[parameterIndex], "Cannot convert argument " + parameterIndex + " of " + method
+						+ "from " + targetBean.getClass() + " to " + parameterType);
+			}
+			else {
+				throw new IllegalStateException(StreamListenerErrorMessages.INVALID_DECLARATIVE_METHOD_PARAMETERS);
+			}
+		}
+		return arguments;
+	}
+
+}


### PR DESCRIPTION
StreamListenerMethodSetupOrchestrator is an API hook that allows
downstram binder implementations or applications to inject custom
strategies to alter the default StreamListener adapter method invocations.

This PR primarily focuses on allowing customizations on the oubound side.
For the inbound, StreamListenerMethodSetupOrchestrator interface provides
a default implementation.

Corresponding refactoring in StreamListenerAnnotationBeanPostProcessor.
By default, StreamListenerAnnotationBeanPostProcessor will use the current
strategies used for invoking the StreamListener adapters. If beans are provided
for orchestration, they take precedence, however.

Test changes.

Further polishing in StreamListenerAnnotationBeanPostProcessor.

Resolves #1177