### PR TITLE
Pollable Consumer : Start Source if Lifecycle

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
@@ -317,6 +317,9 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 					getPolledConsumerRecoveryCallback(resources.getErrorInfrastructure(), properties));
 		}
 		postProcessPollableSource(bindingTarget);
+		if (resources.getSource() instanceof Lifecycle) {
+				((Lifecycle) resources.getSource()).start();
+		}
 		return new DefaultBinding<PollableSource<MessageHandler>>(name, group, inboundBindTarget,
 				resources.getSource() instanceof Lifecycle ? (Lifecycle) resources.getSource() : null) {
 


### PR DESCRIPTION
When binding a `MessageSource`, start it if it implements `Lifecycle`.