### PR TITLE
#1202 Inconsistent use of this.prefix in AvroSchemaRegistryClientMessageConverter.resolveSchemaForWriting

### DIFF
--- a/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/AvroSchemaRegistryClientMessageConverter.java
+++ b/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/AvroSchemaRegistryClientMessageConverter.java
@@ -252,8 +252,8 @@ public class AvroSchemaRegistryClientMessageConverter extends AbstractAvroMessag
 
 		if (headers instanceof MutableMessageHeaders) {
 			headers.put(MessageHeaders.CONTENT_TYPE,
-					"application/vnd." + schemaReference.getSubject() + ".v"
-							+ schemaReference.getVersion() + "+avro");
+					"application/" + this.prefix + "." + schemaReference.getSubject() 
+						+ ".v" + schemaReference.getVersion() + "+avro");
 		}
 
 		return schema;


### PR DESCRIPTION
Replaced hard coding with `this.prefix`