### PR TITLE
1215 CachingCachingRegistryClient stores data by wrong keys resulting in fetch operations always missing.

### DIFF
--- a/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/client/CachingRegistryClient.java
+++ b/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/client/CachingRegistryClient.java
@@ -47,8 +47,8 @@ public class CachingRegistryClient implements SchemaRegistryClient {
 	@Override
 	public SchemaRegistrationResponse register(String subject, String format, String schema) {
 		SchemaRegistrationResponse response = delegate.register(subject, format, schema);
-		cacheManager.getCache(ID_CACHE).put(response.getSchemaReference(), schema);
-		cacheManager.getCache(REF_CACHE).put(response.getId(), schema);
+		cacheManager.getCache(ID_CACHE).put(response.getId(), schema);
+		cacheManager.getCache(REF_CACHE).put(response.getSchemaReference(), schema);
 		return response;
 	}
 


### PR DESCRIPTION
1215  CachingCachingRegistryClient stores data by wrong keys resulting in fetch operations always missing.