### PR TITLE
Publish SI test binder jar as a maven artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,14 @@
                 <artifactId>objenesis</artifactId>
                 <version>${objenesis.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-stream</artifactId>
+                <version>${project.version}</version>
+                <type>test-jar</type>
+                <scope>test</scope>
+                <classifier>test-binder</classifier>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <modules>

--- a/spring-cloud-stream/pom.xml
+++ b/spring-cloud-stream/pom.xml
@@ -63,4 +63,27 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>3.0.2</version>
+				<executions>
+					<execution>
+						<configuration>
+							<includes>
+								<include>**/integration/*</include>
+							</includes>
+							<classifier>test-binder</classifier>
+						</configuration>
+						<goals>
+							<goal>test-jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>


### PR DESCRIPTION
 - spring-cloud-stream module will build a new test-jar called spring-cloud-stream-<version>-test-binder.jar
 - This artifact contains all the classes from the package org/springframework/cloud/stream/binder/integration/
   in test source for spring-cloud-stream

The new test artifact can be used any module in core spring-cloud-stream as below:
```
<dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-stream</artifactId>
       <type>test-jar</type>
       <classifier>test-binder</classifier>
</dependency>
```
Anywhere else outside of core spring-cloud-stream, this has to be configured as below:

```
<dependency>
     <groupId>org.springframework.cloud</groupId>
     <artifactId>spring-cloud-stream</artifactId>
     <version>SPRING_CLOUD_STREAM_VERSION</version>
     <type>test-jar</type>
     <scope>test</scope>
     <classifier>test-binder</classifier>
 </dependency>
```
Here are the contents of the artifact:
```
META-INF/MANIFEST.MF
META-INF/
org/
org/springframework/
org/springframework/cloud/
org/springframework/cloud/stream/
org/springframework/cloud/stream/binder/
org/springframework/cloud/stream/binder/integration/
Publish SI test binder jar as a maven artifact
META-INF/maven/
META-INF/maven/org.springframework.cloud/
META-INF/maven/org.springframework.cloud/spring-cloud-stream/
org/springframework/cloud/stream/binder/integration/SpringIntegrationProvisioner$SpringIntegrationConsumerDestination.class
org/springframework/cloud/stream/binder/integration/SpringIntegrationChannelBinder$IntegrationMessageListeningContainer.class
META-INF/maven/org.springframework.cloud/spring-cloud-stream/pom.properties
org/springframework/cloud/stream/binder/integration/SpringIntegrationChannelBinder$IntegrationBinderInboundChannelAdapter.class
org/springframework/cloud/stream/binder/integration/TargetDestination.class
org/springframework/cloud/stream/binder/integration/SampleStreamApp.class
org/springframework/cloud/stream/binder/integration/SpringIntegrationChannelBinder$IntegrationBinderInboundChannelAdapter$Listener.class
org/springframework/cloud/stream/binder/integration/SampleStreamApp$PolledConsumer.class
org/springframework/cloud/stream/binder/integration/SpringIntegrationProvisioner$SpringIntegrationProducerDestination.class
org/springframework/cloud/stream/binder/integration/SpringIntegrationProvisioner.class
org/springframework/cloud/stream/binder/integration/SpringIntegrationBinderConfiguration.class
org/springframework/cloud/stream/binder/integration/SpringIntegrationChannelBinder$1.class
org/springframework/cloud/stream/binder/integration/SourceDestination.class
org/springframework/cloud/stream/binder/integration/AbstractDestination.class
META-INF/maven/org.springframework.cloud/spring-cloud-stream/pom.xml
org/springframework/cloud/stream/binder/integration/SpringIntegrationChannelBinder.class
```
It is worth to point out that any transitive dependencies from this artifact need to be explicitly specified by the users. 