### PR TITLE
GH-1294 Fixed NPE in AvroSchemaRegistryClientMessageConverter

### DIFF
--- a/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/AvroSchemaRegistryClientMessageConverter.java
+++ b/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/AvroSchemaRegistryClientMessageConverter.java
@@ -268,27 +268,23 @@ public class AvroSchemaRegistryClientMessageConverter extends AbstractAvroMessag
 	@Override
 	protected Schema resolveWriterSchemaForDeserialization(MimeType mimeType) {
 		if (this.readerSchema == null) {
-			Schema schema = null;
-			ParsedSchema parsedSchema = null;
 			SchemaReference schemaReference = extractSchemaReference(mimeType);
 			if (schemaReference != null) {
-				parsedSchema = cacheManager.getCache(REFERENCE_CACHE_NAME)
-						.get(schemaReference, ParsedSchema.class);
+				ParsedSchema parsedSchema = cacheManager.getCache(REFERENCE_CACHE_NAME).get(schemaReference, ParsedSchema.class);
 				if (parsedSchema == null) {
-					String schemaContent = this.schemaRegistryClient
-							.fetch(schemaReference);
-					schema = new Schema.Parser().parse(schemaContent);
-					parsedSchema = new ParsedSchema(schema);
-					cacheManager.getCache(REFERENCE_CACHE_NAME)
-							.putIfAbsent(schemaReference, parsedSchema);
+					String schemaContent = this.schemaRegistryClient.fetch(schemaReference);
+					if (schemaContent != null) {
+						Schema schema = new Schema.Parser().parse(schemaContent);
+						parsedSchema = new ParsedSchema(schema);
+						cacheManager.getCache(REFERENCE_CACHE_NAME).putIfAbsent(schemaReference, parsedSchema);
+					}
 				}
-
+				if (parsedSchema != null) {
+					return parsedSchema.getSchema();
+				}
 			}
-			return parsedSchema.getSchema();
 		}
-		else {
-			return this.readerSchema;
-		}
+		return this.readerSchema;
 	}
 
 	@Override


### PR DESCRIPTION
The NPE was a result of not following defensive programming practices and that is fixed.
Also, we already support both reader and writer schema being null where new ReflectDatumReader(type) is used in getDatumReader(..)  operation.
That said there may still be conditions which are not supported and that is okay since in the end it's a MessageConverter and as such it is one
of the extension points of the framework allowing user to provide a custom one follwing instructions in 'User-defined Message Converters' of the reference guide.

Resolves #1294