### PR TITLE
Native multiple input binding changes

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ConsumerProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ConsumerProperties.java
@@ -124,15 +124,16 @@ public class ConsumerProperties {
 	private boolean useNativeDecoding;
 
 	/**
-	 * When set to true, the underlying binder natively deals with multiple destinations on the same input.
+	 * When set to true, the underlying binder will natively multiplex destinations on the same input binding.
 	 * For example, in the case of a comma separated multiple destinations, the core framework will skip binding
 	 * them individually if this is set to true, but delegate that responsibility to the binder.
 	 *
-	 * By default this property is set to `false` and the end users are not expected to configure this
-	 * property directly in the application. The individual binder implementations that need to support multiple
-	 * input bindings natively can enable this property by calling the setter method to do so.
+	 * By default this property is set to `false` and the binder will individually bind each destinations in case
+	 * of a comma separated multi destination list. The individual binder implementations that need to support multiple
+	 * input bindings natively (multiplex) can enable this property. Under normal circumstances, the end users are
+	 * not expected to enable or disable this property directly.
 	 */
-	private boolean nativeMultipleBinding;
+	private boolean multiplex;
 
 	@Min(value = 1, message = "Concurrency should be greater than zero.")
 	public int getConcurrency() {
@@ -221,11 +222,11 @@ public class ConsumerProperties {
 		this.useNativeDecoding = useNativeDecoding;
 	}
 
-	public boolean isNativeMultipleBinding() {
-		return nativeMultipleBinding;
+	public boolean isMultiplex() {
+		return multiplex;
 	}
 
-	public void setNativeMultipleBinding(boolean nativeMultipleBinding) {
-		this.nativeMultipleBinding = nativeMultipleBinding;
+	public void setMultiplex(boolean multiplex) {
+		this.multiplex = multiplex;
 	}
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ConsumerProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ConsumerProperties.java
@@ -123,6 +123,17 @@ public class ConsumerProperties {
 	 */
 	private boolean useNativeDecoding;
 
+	/**
+	 * When set to true, the underlying binder natively deals with multiple destinations on the same input.
+	 * For example, in the case of a comma separated multiple destinations, the core framework will skip binding
+	 * them individually if this is set to true, but delegate that responsibility to the binder.
+	 *
+	 * By default this property is set to `false` and the end users are not expected to configure this
+	 * property directly in the application. The individual binder implementations that need to support multiple
+	 * input bindings natively can enable this property by calling the setter method to do so.
+	 */
+	private boolean nativeMultipleBinding;
+
 	@Min(value = 1, message = "Concurrency should be greater than zero.")
 	public int getConcurrency() {
 		return concurrency;
@@ -208,5 +219,13 @@ public class ConsumerProperties {
 
 	public void setUseNativeDecoding(boolean useNativeDecoding) {
 		this.useNativeDecoding = useNativeDecoding;
+	}
+
+	public boolean isNativeMultipleBinding() {
+		return nativeMultipleBinding;
+	}
+
+	public void setNativeMultipleBinding(boolean nativeMultipleBinding) {
+		this.nativeMultipleBinding = nativeMultipleBinding;
 	}
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindingService.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindingService.java
@@ -109,7 +109,7 @@ public class BindingService {
 		String bindingTarget = this.bindingServiceProperties
 				.getBindingDestination(inputName);
 
-		if (consumerProperties.isNativeMultipleBinding()) {
+		if (consumerProperties.isMultiplex()) {
 			bindings.add(doBindConsumer(input, inputName, binder, consumerProperties, bindingTarget));
 		}
 		else {

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binding/BindingServiceTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binding/BindingServiceTests.java
@@ -166,14 +166,14 @@ public class BindingServiceTests {
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
-	public void testConsumerBindingWhenNativeMultipleBindingIsEnabled() throws Exception {
+	public void testConsumerBindingWhenMultiplexingIsEnabled() throws Exception {
 		BindingServiceProperties properties = new BindingServiceProperties();
 		Map<String, BindingProperties> bindingProperties = new HashMap<>();
 		BindingProperties props = new BindingProperties();
 		props.setDestination("foo,bar");
 
 		ConsumerProperties consumer = properties.getConsumerProperties("input");
-		consumer.setNativeMultipleBinding(true);
+		consumer.setMultiplex(true);
 		props.setConsumer(consumer);
 
 		final String inputChannelName = "input";

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binding/BindingServiceTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binding/BindingServiceTests.java
@@ -81,6 +81,7 @@ import static org.mockito.Mockito.when;
  * @author Marius Bogoevici
  * @author Ilayaperumal Gopinathan
  * @author Janne Valkealahti
+ * @author Soby Chacko
  */
 public class BindingServiceTests {
 
@@ -159,6 +160,53 @@ public class BindingServiceTests {
 				any(ConsumerProperties.class));
 		verify(binding1).unbind();
 		verify(binding2).unbind();
+
+		binderFactory.destroy();
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	public void testConsumerBindingWhenNativeMultipleBindingIsEnabled() throws Exception {
+		BindingServiceProperties properties = new BindingServiceProperties();
+		Map<String, BindingProperties> bindingProperties = new HashMap<>();
+		BindingProperties props = new BindingProperties();
+		props.setDestination("foo,bar");
+
+		ConsumerProperties consumer = properties.getConsumerProperties("input");
+		consumer.setNativeMultipleBinding(true);
+		props.setConsumer(consumer);
+
+		final String inputChannelName = "input";
+		bindingProperties.put(inputChannelName, props);
+
+		properties.setBindings(bindingProperties);
+
+		DefaultBinderFactory binderFactory = createMockBinderFactory();
+
+		Binder binder = binderFactory.getBinder("mock", MessageChannel.class);
+		BindingService service = new BindingService(properties,
+				binderFactory);
+		MessageChannel inputChannel = new DirectChannel();
+
+		Binding<MessageChannel> mockBinding1 = Mockito.mock(Binding.class);
+
+		when(binder.bindConsumer(eq("foo,bar"), isNull(), same(inputChannel),
+				any(ConsumerProperties.class))).thenReturn(mockBinding1);
+
+		Collection<Binding<MessageChannel>> bindings = service.bindConsumer(inputChannel,
+				"input");
+		assertThat(bindings).hasSize(1);
+
+		Iterator<Binding<MessageChannel>> iterator = bindings.iterator();
+		Binding<MessageChannel> binding1 = iterator.next();
+
+		assertThat(binding1).isSameAs(mockBinding1);
+
+		service.unbindConsumers("input");
+
+		verify(binder).bindConsumer(eq("foo,bar"), isNull(), same(inputChannel),
+				any(ConsumerProperties.class));
+		verify(binding1).unbind();
 
 		binderFactory.destroy();
 	}


### PR DESCRIPTION
If the binder implementation enables native multiple input binding, skip individual
consumer binding per binding target (for example - from a comma separated targets
provided as input destination property).

By default, native multiple input binding is disabled at the core framework level
and the binder implementation explicitly needs to override that to enable it.

Fixes #1365