### PR TITLE
GH-1385: Add qualifier for error infrastructure

### DIFF
--- a/spring-cloud-stream-core-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
+++ b/spring-cloud-stream-core-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
@@ -606,7 +606,7 @@ public ApplicationRunner poller(PollableMessageSource destIn, MessageChannel des
 The `PollableMessageSource.poll()` method takes a `MessageHandler` argument (often a lambda expression, as shown here).
 It returns `true` if the message was received and successfully processed.
 
-As with message-driven consumers, if the `MessageHandler` throws an exception, messages are published to error channels, as discussed in "`<<binder-error-channels>>`".
+As with message-driven consumers, if the `MessageHandler` throws an exception, messages are published to error channels, as discussed in "`<<spring-cloud-stream-overview-error-handling>>`".
 
 Normally, the `poll()` method acknowledges the message when the `MessageHandler` exits.
 If the method exits abnormally, the message is rejected (not re-queued).
@@ -748,6 +748,15 @@ spring.cloud.stream.bindings.error.destination=myErrors.
 
 NOTE: The ability to bridge global error channel to a broker destination essentially provides a mechanism which connects
 the _application-level_ error handling with the _system-level_ error handling.
+
+Some binders support reporting asynchronous send failures.
+Error channels are not enabled for producers by default; see the `errorChannelEnabled` producer property.
+Producer channels do not include the `group` component (e.g. `mydest.errors`).
+Producer error channels are also bridged to the global error channel.
+
+IMPORTANT: It is possible to configure multiple bindings to the same destination on both the producer and consumer sides.
+Since the error channels and supporting infrastructure are registered as beans, they must have unique names.
+The `qualifier` property is provided for both producers and consumers; when qualified, producer error channels are named `<qualifier>.<destination>.errors` and consumer error channels are named `<qualifier>.<destination>.<group>.errors`.
 
 ===== System Error Handling
 
@@ -1415,6 +1424,11 @@ Also, when native encoding and decoding is used, the `headerMode=embeddedHeaders
 See the producer property `useNativeEncoding`.
 +
 Default: `false`.
+qualifier::
+When using multiple bindings with the same destination and group, set a qualifier that is used to prefix error infrastructure bean names to provide unique beans for each binding.
+See "`<<spring-cloud-stream-overview-error-handling>>`" for more information.
++
+Default: `none`.
 
 
 ==== Producer Properties
@@ -1476,10 +1490,15 @@ See the consumer property `useNativeDecoding`.
 +
 Default: `false`.
 errorChannelEnabled::
-When set to `true`, if the binder supports asynchroous send results, send failures are sent to an error channel for the destination.
-See "`<<binder-error-channels>>`" for more information.
+When set to `true`, if the binder supports asynchronous send results, send failures are sent to an error channel for the destination.
+See "`<<spring-cloud-stream-overview-error-handling>>`" for more information.
 +
 Default: `false`.
+qualifier::
+When using multiple bindings with the same destination, set a qualifier that is used to prefix error infrastructure bean names to provide unique beans for each binding.
+See "`<<spring-cloud-stream-overview-error-handling>>`" for more information.
++
+Default: `none`.
 
 [[dynamicdestination]]
 === Using Dynamically Bound Destinations

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ConsumerProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ConsumerProperties.java
@@ -135,6 +135,14 @@ public class ConsumerProperties {
 	 */
 	private boolean multiplex;
 
+	/**
+	 * When using multiple bindings that reference the same destination and use the same
+	 * group, set a different qualifier for each binding so that beans created for the
+	 * binder (error channels, etc) will get a unique bean name with this value as a
+	 * prefix followed by ".".
+	 */
+	private String qualifier;
+
 	@Min(value = 1, message = "Concurrency should be greater than zero.")
 	public int getConcurrency() {
 		return concurrency;
@@ -229,4 +237,13 @@ public class ConsumerProperties {
 	public void setMultiplex(boolean multiplex) {
 		this.multiplex = multiplex;
 	}
+
+	public String getQualifier() {
+		return this.qualifier;
+	}
+
+	public void setQualifier(String qualifier) {
+		this.qualifier = qualifier;
+	}
+
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ProducerProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ProducerProperties.java
@@ -80,6 +80,13 @@ public class ProducerProperties {
 
 	private boolean errorChannelEnabled = false;
 
+	/**
+	 * When using multiple bindings that reference the same destination, set a different
+	 * qualifier for each binding so that beans created for the binder (error channels,
+	 * etc) will get a unique bean name with this value as a prefix followed by ".".
+	 */
+	private String qualifier;
+
 	public Expression getPartitionKeyExpression() {
 		return partitionKeyExpression;
 	}
@@ -186,6 +193,14 @@ public class ProducerProperties {
 
 	public void setPartitionSelectorName(String partitionSelectorName) {
 		this.partitionSelectorName = partitionSelectorName;
+	}
+
+	public String getQualifier() {
+		return this.qualifier;
+	}
+
+	public void setQualifier(String qualifier) {
+		this.qualifier = qualifier;
 	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-stream/issues/1385

Avoid bean name collision when using multiple bindings to the destination/group.

Add a new property `qualifier`.