### PR TITLE
GH-1384 Set application's context as binder context once the binder is initialized

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
@@ -233,7 +233,15 @@ public class DefaultBinderFactory implements BinderFactory, DisposableBean, Appl
 			}
 			ConfigurableApplicationContext binderProducingContext = springApplicationBuilder
 					.run(args.toArray(new String[args.size()]));
+
 			Binder<T, ?, ?> binder = binderProducingContext.getBean(Binder.class);
+			/*
+			 * This will ensure that application defined errorChannel and other beans are accessible within binder's context
+			 * (see https://github.com/spring-cloud/spring-cloud-stream/issues/1384)
+			 */
+			if (this.context != null && binder instanceof ApplicationContextAware) {
+				((ApplicationContextAware)binder).setApplicationContext(this.context);
+			}
 			if (!CollectionUtils.isEmpty(this.listeners)) {
 				for (Listener binderFactoryListener : listeners) {
 					binderFactoryListener.afterBinderContextInitialized(configurationName, binderProducingContext);


### PR DESCRIPTION
Set application's context as binder context once the binder is initialized to ensure identical behavior in i multi-environment scenarios.
Resolves #1384
Resolves #1357