### PR TITLE
Autoconfigure optimization

### DIFF
--- a/spring-cloud-stream-reactive/pom.xml
+++ b/spring-cloud-stream-reactive/pom.xml
@@ -33,6 +33,11 @@
 			<artifactId>spring-cloud-stream-test-support-internal</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/spring-cloud-stream/pom.xml
+++ b/spring-cloud-stream/pom.xml
@@ -66,6 +66,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Add spring-boot-autoconfigure-processor to spring-cloud-stream
and spring-cloud-stream-reactive modules for auto configuration optimization.

Resolves #1410