### PR TITLE
GH-1412 Ensured SpelExpressionConverterConfiguration present in multi…

### DIFF
--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/MessageChannelConfigurerTests.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/MessageChannelConfigurerTests.java
@@ -53,7 +53,7 @@ import static org.junit.Assert.assertNull;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = { MessageChannelConfigurerTests.TestSink.class,
-		MessageChannelConfigurerTests.TestSource.class })
+		MessageChannelConfigurerTests.TestSource.class, SpelExpressionConverterConfiguration.class})
 public class MessageChannelConfigurerTests {
 
 	@Autowired
@@ -64,8 +64,6 @@ public class MessageChannelConfigurerTests {
 
 	@Autowired
 	private CompositeMessageConverterFactory messageConverterFactory;
-
-	private ObjectMapper objectMapper = new ObjectMapper();
 
 	@Autowired
 	private MessageCollector messageCollector;

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/annotation/EnableBinding.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/annotation/EnableBinding.java
@@ -44,8 +44,7 @@ import org.springframework.integration.config.EnableIntegration;
 @Documented
 @Inherited
 @Configuration
-@Import({ BindingServiceConfiguration.class, BindingBeansRegistrar.class, BinderFactoryConfiguration.class,
-		SpelExpressionConverterConfiguration.class })
+@Import({ BindingServiceConfiguration.class, BindingBeansRegistrar.class, BinderFactoryConfiguration.class})
 @EnableIntegration
 public @interface EnableBinding {
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.DisposableBean;
 import org.springframework.boot.Banner.Mode;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.cloud.stream.config.SpelExpressionConverterConfiguration;
 import org.springframework.cloud.stream.reflection.GenericsUtils;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -209,8 +210,7 @@ public class DefaultBinderFactory implements BinderFactory, DisposableBean, Appl
 			ConfigurableEnvironment environment = this.context != null ? this.context.getEnvironment() : null;
 			String defaultDomain = environment != null ? environment.getProperty("spring.jmx.default-domain") : "";
 			args.add("--spring.jmx.default-domain=" + defaultDomain + "binder." + configurationName);
-			args.add("--spring.main.applicationContextClass=" + AnnotationConfigApplicationContext.class.getName());
-			SpringApplicationBuilder springApplicationBuilder = new SpringApplicationBuilder()
+			SpringApplicationBuilder springApplicationBuilder = new SpringApplicationBuilder(SpelExpressionConverterConfiguration.class)
 					.sources(binderType.getConfigurationClasses())
 					.bannerMode(Mode.OFF)
 					.logStartupInfo(false)
@@ -226,6 +226,7 @@ public class DefaultBinderFactory implements BinderFactory, DisposableBean, Appl
 			if (useApplicationContextAsParent) {
 				springApplicationBuilder.parent(this.context);
 			}
+
 			if (environment != null && (useApplicationContextAsParent || binderConfiguration.isInheritEnvironment())) {
 				StandardEnvironment binderEnvironment = new StandardEnvironment();
 				binderEnvironment.merge(environment);

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/SourceBindingWithGlobalPropertiesOnlyTest.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/SourceBindingWithGlobalPropertiesOnlyTest.java
@@ -27,6 +27,7 @@ import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
 import org.springframework.cloud.stream.config.BindingProperties;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
+import org.springframework.cloud.stream.config.SpelExpressionConverterConfiguration;
 import org.springframework.cloud.stream.messaging.Source;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -35,9 +36,9 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Ilayaperumal Gopinathan
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(classes = {TestChannelBinderConfiguration.class, SourceBindingWithGlobalPropertiesOnlyTest.TestSource.class}, properties = {
-		"spring.cloud.stream.default.contentType=application/json",
-		"spring.cloud.stream.default.producer.partitionKeyExpression=key" })
+@SpringBootTest(classes = {TestChannelBinderConfiguration.class, SourceBindingWithGlobalPropertiesOnlyTest.TestSource.class, SpelExpressionConverterConfiguration.class},
+				properties = {"spring.cloud.stream.default.contentType=application/json",
+							  "spring.cloud.stream.default.producer.partitionKeyExpression=key" })
 public class SourceBindingWithGlobalPropertiesOnlyTest {
 
 	@Autowired

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/utils/MockBinderRegistryConfiguration.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/utils/MockBinderRegistryConfiguration.java
@@ -21,8 +21,10 @@ import java.util.Collections;
 import org.springframework.cloud.stream.binder.BinderType;
 import org.springframework.cloud.stream.binder.BinderTypeRegistry;
 import org.springframework.cloud.stream.binder.DefaultBinderTypeRegistry;
+import org.springframework.cloud.stream.config.SpelExpressionConverterConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 /**
  * A simple configuration that creates mock
@@ -30,6 +32,7 @@ import org.springframework.context.annotation.Configuration;
  * @author Marius Bogoevici
  */
 @Configuration
+@Import(SpelExpressionConverterConfiguration.class)
 public class MockBinderRegistryConfiguration {
 
 	@Bean


### PR DESCRIPTION
…-binder

Ensured that SpelExpressionConverterConfiguration is always present in the AC regardless of single or multi-binder application configuration
Resolves #1412