### PR TITLE
Properties propagation in custom environment

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
@@ -55,8 +55,6 @@ import org.springframework.util.StringUtils;
  */
 public class DefaultBinderFactory implements BinderFactory, DisposableBean, ApplicationContextAware {
 
-	private static ConfigurableApplicationContext OUTER_CONTEXT;
-
 	private final Map<String, BinderConfiguration> binderConfigurations;
 
 	private final Map<String, Entry<Binder<?, ?, ?>, ConfigurableApplicationContext>> binderInstanceCache = new HashMap<>();

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
@@ -35,6 +35,7 @@ import org.springframework.cloud.stream.config.SpelExpressionConverterConfigurat
 import org.springframework.cloud.stream.reflection.GenericsUtils;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.StandardEnvironment;
@@ -50,8 +51,11 @@ import org.springframework.util.StringUtils;
  * @author Ilayaperumal Gopinathan
  * @author Gary Russell
  * @author Oleg Zhurakousky
+ * @author Soby Chacko
  */
 public class DefaultBinderFactory implements BinderFactory, DisposableBean, ApplicationContextAware {
+
+	private static ConfigurableApplicationContext OUTER_CONTEXT;
 
 	private final Map<String, BinderConfiguration> binderConfigurations;
 
@@ -88,8 +92,8 @@ public class DefaultBinderFactory implements BinderFactory, DisposableBean, Appl
 	}
 
 	@Override
-	public void destroy() throws Exception {
-		this.binderInstanceCache.values().stream().map(e -> e.getValue()).forEach(ctx -> ctx.close());
+	public void destroy() {
+		this.binderInstanceCache.values().stream().map(Entry::getValue).forEach(ConfigurableApplicationContext::close);
 		this.defaultBinderForBindingTargetType.clear();
 	}
 
@@ -229,6 +233,11 @@ public class DefaultBinderFactory implements BinderFactory, DisposableBean, Appl
 			if (useApplicationContextAsParent) {
 				springApplicationBuilder.parent(this.context);
 			}
+			// If the current application context is not set as parent and the environment is set,
+			// provide the current context as an additional bean in the BeanFactory.
+			if (environment != null && !useApplicationContextAsParent){
+				springApplicationBuilder.initializers(new InitializerWithOuterContext(this.context));
+			}
 
 			if (environment != null && (useApplicationContextAsParent || binderConfiguration.isInheritEnvironment())) {
 				StandardEnvironment binderEnvironment = new StandardEnvironment();
@@ -288,4 +297,18 @@ public class DefaultBinderFactory implements BinderFactory, DisposableBean, Appl
 		void afterBinderContextInitialized(String configurationName,
 				ConfigurableApplicationContext binderContext);
 	}
+
+	private static class InitializerWithOuterContext implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+		private final ApplicationContext context;
+
+		InitializerWithOuterContext(ApplicationContext context) {
+			this.context = context;
+		}
+
+		@Override
+		public void initialize(ConfigurableApplicationContext applicationContext) {
+			applicationContext.getBeanFactory().registerSingleton("outerContext", context);
+		}
+	}
+
 }

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/stub1/StubBinder1.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/stub1/StubBinder1.java
@@ -20,14 +20,26 @@ import org.springframework.cloud.stream.binder.Binder;
 import org.springframework.cloud.stream.binder.Binding;
 import org.springframework.cloud.stream.binder.ConsumerProperties;
 import org.springframework.cloud.stream.binder.ProducerProperties;
+import org.springframework.context.ConfigurableApplicationContext;
 
 /**
  * @author Marius Bogoevici
  * @author Mark Fisher
+ * @author Soby Chacko
  */
 public class StubBinder1 implements Binder<Object, ConsumerProperties, ProducerProperties> {
 
 	private String name;
+
+	private ConfigurableApplicationContext outerContext;
+
+	public ConfigurableApplicationContext getOuterContext() {
+		return outerContext;
+	}
+
+	public void setOuterContext(ConfigurableApplicationContext outerContext) {
+		this.outerContext = outerContext;
+	}
 
 	public String getName() {
 		return this.name;

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/stub1/StubBinder1Configuration.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/stub1/StubBinder1Configuration.java
@@ -16,16 +16,20 @@
 
 package org.springframework.cloud.stream.binder.stub1;
 
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.boot.actuate.health.ApplicationHealthIndicator;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.binder.Binder;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
  * @author Marius Bogoevici
+ * @author Soby Chacko
  */
 @Configuration
 @EnableConfigurationProperties
@@ -33,8 +37,19 @@ public class StubBinder1Configuration {
 
 	@Bean
 	@ConfigurationProperties("binder1")
-	public Binder<?, ?, ?> binder() {
-		return new StubBinder1();
+	public Binder<?, ?, ?> binder(BeanFactory beanFactory) {
+		StubBinder1 stubBinder1 = new StubBinder1();
+		ConfigurableApplicationContext outerContext = null;
+		try {
+			outerContext = (ConfigurableApplicationContext) beanFactory.getBean("outerContext");
+		}
+		catch (BeansException be) {
+			//Pass through
+		}
+		if (outerContext != null) {
+			stubBinder1.setOuterContext(outerContext);
+		}
+		return stubBinder1;
 	}
 
 	@Bean


### PR DESCRIPTION
Currently when the binder configuration provide properties in a custom environment,
Spring Cloud Stream does not include any beans from the outer context.
This change will ensure that in such cases, the binder context will have access
to the outer context as a non-parent bean.

Resolves #1420