### PR TITLE
Revert ContentTypeConfiguration changes

### DIFF
--- a/spring-cloud-stream/pom.xml
+++ b/spring-cloud-stream/pom.xml
@@ -30,6 +30,7 @@
 		<dependency>
 			<groupId>org.springframework.integration</groupId>
 			<artifactId>spring-integration-core</artifactId>
+			<version>5.1.0.BUILD-SNAPSHOT</version> <!--TODO until the next Spring Boot Milestone to pick up next SI milestone-->
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.integration</groupId>

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/annotation/StreamMessageConverter.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/annotation/StreamMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,12 +25,16 @@ import java.lang.annotation.Target;
 import org.springframework.beans.factory.annotation.Qualifier;
 
 /**
- * Marker to tag {@link org.springframework.messaging.converter.MessageConverter} beans that will be added to the {@link org.springframework.cloud.stream.converter.CompositeMessageConverterFactory}
+ * Marker to tag {@link org.springframework.messaging.converter.MessageConverter} beans
+ * that will be added to the {@link org.springframework.cloud.stream.converter.CompositeMessageConverterFactory}.
+ *
  * @author Vinicius Carvalho
+ * @author Arten Bilan
  */
-@Target({ElementType.FIELD,ElementType.METHOD})
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Qualifier
 public @interface StreamMessageConverter {
+
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ContentTypeConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ContentTypeConfiguration.java
@@ -16,84 +16,43 @@
 
 package org.springframework.cloud.stream.config;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.BeanDefinition;
-import org.springframework.beans.factory.support.BeanDefinitionBuilder;
-import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.cloud.stream.annotation.StreamMessageConverter;
 import org.springframework.cloud.stream.converter.CompositeMessageConverterFactory;
-import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Role;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.support.converter.ConfigurableCompositeMessageConverter;
 import org.springframework.messaging.converter.MessageConverter;
-import org.springframework.util.CollectionUtils;
 
 /**
  * @author Vinicius Carvalho
+ * @author Artem Bilan
  */
 @Configuration
 @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
-public class ContentTypeConfiguration implements InitializingBean {
-
-	@Autowired(required = false)
-	private ObjectMapper objectMapper;
-
-	@Autowired
-	private ConfigurableApplicationContext context;
-
-	/**
-	 * User defined custom message converters
-	 */
-	@Autowired(required = false)
-	@StreamMessageConverter
-	private List<MessageConverter> customMessageConverters;
-
-	@Override
-	public void afterPropertiesSet() throws Exception {
-		if (context.getBeanFactory().containsBean(IntegrationContextUtils.ARGUMENT_RESOLVER_MESSAGE_CONVERTER_BEAN_NAME)) {
-			BeanDefinitionRegistry beanDefinitionRegistry =
-					(BeanDefinitionRegistry) context.getAutowireCapableBeanFactory();
-			beanDefinitionRegistry.removeBeanDefinition(IntegrationContextUtils.ARGUMENT_RESOLVER_MESSAGE_CONVERTER_BEAN_NAME);
-		}
-	}
+public class ContentTypeConfiguration {
 
 	@Bean
-	@SuppressWarnings("unchecked")
-	public CompositeMessageConverterFactory compositeMessageConverterFactory() {
-		List<MessageConverter> messageConverters = new ArrayList<>();
-		if (!CollectionUtils.isEmpty(this.customMessageConverters)) {
-			messageConverters.addAll(Collections.unmodifiableCollection(this.customMessageConverters));
-		}
-		CompositeMessageConverterFactory compositeMessageConverterFactory = new CompositeMessageConverterFactory(messageConverters, this.objectMapper);
+	public CompositeMessageConverterFactory compositeMessageConverterFactory(
+			ObjectProvider<ObjectMapper> objectMapperObjectProvider,
+			@StreamMessageConverter List<MessageConverter> customMessageConverters) {
 
-		// Manually register a bean named as `integrationArgumentResolverMessageConverter`
-		// in order to avoid bean name overriding exceptions. This name exists in Spring Integration.
-		// The afterProperties method should have removed the bean from the registry and then
-		// we are re-registering it again through a different bean definition.
-		BeanDefinitionRegistry beanDefinitionRegistry =
-				(BeanDefinitionRegistry) context.getAutowireCapableBeanFactory();
+		return new CompositeMessageConverterFactory(customMessageConverters,
+				objectMapperObjectProvider.getIfAvailable(ObjectMapper::new));
+	}
 
-		ConfigurableCompositeMessageConverter configurableCompositeMessageConverter =
-				new ConfigurableCompositeMessageConverter(compositeMessageConverterFactory.getMessageConverterForAllRegistered().getConverters());
+	@Bean(name = IntegrationContextUtils.ARGUMENT_RESOLVER_MESSAGE_CONVERTER_BEAN_NAME)
+	public ConfigurableCompositeMessageConverter configurableCompositeMessageConverter(
+			CompositeMessageConverterFactory factory) {
 
-		BeanDefinition configurableCompositeMessageConverterDefn =
-				BeanDefinitionBuilder.genericBeanDefinition((Class<ConfigurableCompositeMessageConverter>) configurableCompositeMessageConverter.getClass(),
-						() -> configurableCompositeMessageConverter)
-						.getRawBeanDefinition();
-
-		beanDefinitionRegistry.registerBeanDefinition(IntegrationContextUtils.ARGUMENT_RESOLVER_MESSAGE_CONVERTER_BEAN_NAME, configurableCompositeMessageConverterDefn);
-
-		return compositeMessageConverterFactory;
+		return new ConfigurableCompositeMessageConverter(factory.getMessageConverterForAllRegistered().getConverters());
 	}
 
 }


### PR DESCRIPTION
After fixing https://jira.spring.io/browse/INT-4517 we don't need
a hack in the `ContentTypeConfiguration` about removal of the
`IntegrationContextUtils.ARGUMENT_RESOLVER_MESSAGE_CONVERTER_BEAN_NAME`
`BeanDefinition` and registering our own later
* Provide some code polishing for the `ContentTypeConfiguration`
removing some redundant code and providing consistency with
components it uses
* Add `ElementType.PARAMETER` target for the `StreamMessageConverter`
annotation to let the list of appropriate converters to be inject
via method parameters in the `@Bean` definition
* Tentative use SI `5.1.0.BUILD-SNAPSHOT` until Spring Boot 2.1 M2