### PR TITLE
Support extended default properties

### DIFF
--- a/spring-cloud-stream-core-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
+++ b/spring-cloud-stream-core-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
@@ -1445,6 +1445,8 @@ The `<channelName>` represents the name of the channel being configured (for exa
 
 To avoid repetition, Spring Cloud Stream supports setting values for all channels, in the format of `spring.cloud.stream.default.<property>=<value>`.
 
+When it comes to avoiding repetitions for extended binding properties, this format should be used - `spring.cloud.stream.<binder-type>.default.<producer|consumer>.<property>=<value>`.
+
 In what follows, we indicate where we have omitted the `spring.cloud.stream.bindings.<channelName>.` prefix and focus just on the property name, with the understanding that the prefix ise included at runtime.
 
 ==== Common Binding Properties

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ExtendedBindingProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ExtendedBindingProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,10 +22,38 @@ package org.springframework.cloud.stream.binder;
  *
  * @author Marius Bogoevici
  * @author Mark Fisher
+ * @author Soby Chacko
  */
 public interface ExtendedBindingProperties<C, P> {
 
 	C getExtendedConsumerProperties(String channelName);
 
 	P getExtendedProducerProperties(String channelName);
+
+	/**
+	 * Extended binding properties can define a default prefix to place all the extended
+	 * common producer and consumer properties. For example, if the binder type is foo
+	 * it is convenient to specify common extended properties for the producer or consumer
+	 * across multiple bindings in the form of `spring.cloud.stream.foo.default.producer.x=y`
+	 * or `spring.cloud.stream.foo.default.consumer.x=y`.
+	 *
+	 * The binding process will use this defaults prefix to resolve any common extended
+	 * producer and consumer properties.
+	 *
+	 * @return default prefix for extended properties
+	 * @since 2.1.0
+	 */
+	String getDefaultsPrefix();
+
+	/**
+	 *
+	 * Extended properties class against which default extended producer and consumer properties
+	 * are resolved. It is expected that this class has two properties - one called producer
+	 * and another called consumer that contains the extended properties for producer and
+	 * consumer respectively.
+	 *
+	 * @return extended properties class that contains extended producer/consumer properties
+	 * @since 2.1.0
+	 */
+	Class<?> getExtendedPropertiesEntryClass();
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceConfiguration.java
@@ -47,6 +47,7 @@ import org.springframework.cloud.stream.binding.StreamListenerAnnotationBeanPost
 import org.springframework.cloud.stream.function.StreamFunctionProperties;
 import org.springframework.cloud.stream.micrometer.DestinationPublishingMetricsAutoConfiguration;
 import org.springframework.context.ApplicationListener;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
@@ -163,9 +164,10 @@ public class BindingServiceConfiguration {
 	// already exists).
 	@ConditionalOnMissingBean(search = SearchStrategy.CURRENT)
 	public BindingService bindingService(BindingServiceProperties bindingServiceProperties,
-			BinderFactory binderFactory, TaskScheduler taskScheduler) {
+										BinderFactory binderFactory, TaskScheduler taskScheduler,
+										ConfigurableApplicationContext applicationContext) {
 
-		return new BindingService(bindingServiceProperties, binderFactory, taskScheduler);
+		return new BindingService(bindingServiceProperties, binderFactory, taskScheduler, applicationContext);
 	}
 
 	@Bean

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/MergableProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/MergableProperties.java
@@ -19,6 +19,8 @@ package org.springframework.cloud.stream.config;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.Collection;
+import java.util.Map;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.BeansException;
@@ -26,6 +28,7 @@ import org.springframework.beans.FatalBeanException;
 import org.springframework.cloud.stream.binder.ConsumerProperties;
 import org.springframework.cloud.stream.binder.ProducerProperties;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
 
 /**
@@ -36,6 +39,7 @@ import org.springframework.util.ObjectUtils;
  * @see ConsumerProperties
  *
  * @author Oleg Zhurakousky
+ * @author Soby Chacko
  */
 public interface MergableProperties {
 
@@ -69,7 +73,7 @@ public interface MergableProperties {
 								}
 								else {
 									Object v = readMethod.invoke(mergable);
-									if (v == null || (ObjectUtils.isArray(v) && ObjectUtils.isEmpty(v))) {
+									if (isMergable(v)) {
 										if (!Modifier.isPublic(writeMethod.getDeclaringClass().getModifiers())) {
 											writeMethod.setAccessible(true);
 										}
@@ -86,6 +90,13 @@ public interface MergableProperties {
 				}
 			}
 		}
+	}
+
+	static boolean isMergable(Object v) {
+		return v == null ||
+				((((ObjectUtils.isArray(v) && ObjectUtils.isEmpty(v))) ||
+				(Collection.class.isAssignableFrom(v.getClass()) && CollectionUtils.isEmpty((Collection)v)) ||
+				(Map.class.isAssignableFrom(v.getClass()) && CollectionUtils.isEmpty((Map)v))));
 	}
 
 	default void copyProperties(Object source, Object target) throws BeansException {

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/utils/FooBindingProperties.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/utils/FooBindingProperties.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.utils;
+
+/**
+ * @author Soby Chacko
+ */
+public class FooBindingProperties {
+
+	private FooExtendedProducerProperties producer = new FooExtendedProducerProperties();
+
+	private FooExtendedConsumerProperties consumer = new FooExtendedConsumerProperties();
+
+	public FooExtendedProducerProperties getProducer() {
+		return producer;
+	}
+
+	public void setProducer(FooExtendedProducerProperties producer) {
+		this.producer = producer;
+	}
+
+	public FooExtendedConsumerProperties getConsumer() {
+		return consumer;
+	}
+
+	public void setConsumer(FooExtendedConsumerProperties consumer) {
+		this.consumer = consumer;
+	}
+}

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/utils/FooExtendedConsumerProperties.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/utils/FooExtendedConsumerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,21 +16,20 @@
 
 package org.springframework.cloud.stream.utils;
 
-import org.mockito.Mockito;
-
-import org.springframework.cloud.stream.binder.Binder;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.cloud.stream.config.MergableProperties;
 
 /**
- * @author Marius Bogoevici
+ * @author Soby Chacko
  */
-@Configuration
-public class MockBinderConfiguration {
+public class FooExtendedConsumerProperties implements MergableProperties {
 
-	@Bean
-	public Binder<?, ?, ?> binder() {
-		return Mockito.mock(Binder.class, Mockito.withSettings().defaultAnswer(Mockito.RETURNS_MOCKS));
+	String extendedProperty;
+
+	public String getExtendedProperty() {
+		return extendedProperty;
 	}
 
+	public void setExtendedProperty(String extendedProperty) {
+		this.extendedProperty = extendedProperty;
+	}
 }

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/utils/FooExtendedProducerProperties.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/utils/FooExtendedProducerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,21 +16,20 @@
 
 package org.springframework.cloud.stream.utils;
 
-import org.mockito.Mockito;
-
-import org.springframework.cloud.stream.binder.Binder;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.cloud.stream.config.MergableProperties;
 
 /**
- * @author Marius Bogoevici
+ * @author Soby Chacko
  */
-@Configuration
-public class MockBinderConfiguration {
+public class FooExtendedProducerProperties implements MergableProperties {
 
-	@Bean
-	public Binder<?, ?, ?> binder() {
-		return Mockito.mock(Binder.class, Mockito.withSettings().defaultAnswer(Mockito.RETURNS_MOCKS));
+	String extendedProperty;
+
+	public String getExtendedProperty() {
+		return extendedProperty;
 	}
 
+	public void setExtendedProperty(String extendedProperty) {
+		this.extendedProperty = extendedProperty;
+	}
 }

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/utils/MockExtendedBinderConfiguration.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/utils/MockExtendedBinderConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.utils;
+
+import org.mockito.Mockito;
+
+import org.springframework.cloud.stream.binder.Binder;
+import org.springframework.cloud.stream.binder.ExtendedPropertiesBinder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Soby Chacko
+ */
+@Configuration
+public class MockExtendedBinderConfiguration {
+
+	@Bean
+	public Binder<?, ?, ?> extendedPropertiesBinder() {
+		Binder mock = Mockito.mock(Binder.class, Mockito.withSettings().defaultAnswer(Mockito.RETURNS_MOCKS)
+				.extraInterfaces(ExtendedPropertiesBinder.class));
+		when (((ExtendedPropertiesBinder)mock).getExtendedProducerProperties("output"))
+				.thenReturn(new FooExtendedProducerProperties());
+		when (((ExtendedPropertiesBinder)mock).getExtendedConsumerProperties("input"))
+				.thenReturn(new FooExtendedConsumerProperties());
+		when (((ExtendedPropertiesBinder)mock).getDefaultsPrefix())
+				.thenReturn("spring.cloud.stream.foo.default");
+		when (((ExtendedPropertiesBinder)mock).getExtendedPropertiesEntryClass())
+				.thenReturn(FooBindingProperties.class);
+		return mock;
+	}
+
+}


### PR DESCRIPTION
Currenlty, we only support default properties for core producer/consumer (spring.cloud.stream.default.producer|consumer...).
These changes add support for configuring default properties for extended producer and consumer properties.

For example, if the binder type is foo, then this allows the applications to configure default properties across
multiple producer or consumer bindings in the form of spring.cloud.stream.foo.default.producer|consumer.property.

The default prefixes for the extended properties are dictated by the respective binder implementations.

Resolves #1360