### PR TITLE
Add (javax.)Validation Support for Stream Listener

### DIFF
--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerHandlerMethodTests.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerHandlerMethodTests.java
@@ -46,6 +46,8 @@ import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.util.Assert;
 
+import javax.validation.Valid;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 import static org.springframework.cloud.stream.binding.StreamListenerErrorMessages.AMBIGUOUS_MESSAGE_HANDLER_METHOD_ARGUMENTS;
@@ -578,4 +580,5 @@ public class StreamListenerHandlerMethodTests {
 			});
 		}
 	}
+
 }

--- a/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerTestUtils.java
+++ b/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/config/StreamListenerTestUtils.java
@@ -21,6 +21,8 @@ import org.springframework.cloud.stream.annotation.Output;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.SubscribableChannel;
 
+import javax.validation.constraints.NotBlank;
+
 /**
  * @author Ilayaperumal Gopinathan
  */
@@ -85,4 +87,16 @@ public class StreamListenerTestUtils {
 			return sb.toString();
 		}
 	}
+
+	public static class PojoWithValidation {
+
+		@NotBlank
+		private String foo;
+
+		public String getFoo() { return this.foo; }
+
+		public void setFoo(String foo) { this.foo = foo; }
+
+	}
+
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BinderFactoryConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BinderFactoryConfiguration.java
@@ -57,12 +57,14 @@ import org.springframework.messaging.handler.annotation.support.DefaultMessageHa
 import org.springframework.messaging.handler.annotation.support.MessageHandlerMethodFactory;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
+import org.springframework.validation.Validator;
 
 /**
  * @author Marius Bogoevici
  * @author Ilayaperumal Gopinathan
  * @author Oleg Zhurakousky
  * @author Soby Chacko
+ * @author David Harrigan
  *
  * @deprecated since it really represents 'auto-configuration' it will be renamed/restructured in the next release.
  */
@@ -157,10 +159,12 @@ public class BinderFactoryConfiguration {
 
 	@Bean
 	public static MessageHandlerMethodFactory messageHandlerMethodFactory(CompositeMessageConverterFactory compositeMessageConverterFactory,
-																		@Qualifier(IntegrationContextUtils.ARGUMENT_RESOLVERS_BEAN_NAME) HandlerMethodArgumentResolversHolder ahmar) {
+																		@Qualifier(IntegrationContextUtils.ARGUMENT_RESOLVERS_BEAN_NAME) HandlerMethodArgumentResolversHolder ahmar,
+																		Validator validator) {
 		DefaultMessageHandlerMethodFactory messageHandlerMethodFactory = new DefaultMessageHandlerMethodFactory();
 		messageHandlerMethodFactory.setMessageConverter(compositeMessageConverterFactory.getMessageConverterForAllRegistered());
 		messageHandlerMethodFactory.setCustomArgumentResolvers(ahmar.getResolvers());
+		messageHandlerMethodFactory.setValidator(validator);
 		return messageHandlerMethodFactory;
 	}
 


### PR DESCRIPTION
This change allows StreamListener method arguments annotated with @Valid to be
validated against a registered Validator.

An example of its usage can be found here:

https://github.com/dharrigan/gh1382

-=david=-