### PR TITLE
Fix a few broken links

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -18,7 +18,7 @@ The following binder implementations are currently available:
 
 === Documentation
 
-The latest documentation for the project can be found http://docs.spring.io/spring-cloud-stream/docs/current-SNAPSHOT/reference/htmlsingle/[here].
+The latest documentation for the project can be found http://docs.spring.io/spring-cloud-stream/docs/current-snapshot/reference/htmlsingle/[here].
 
 === Samples
 

--- a/spring-cloud-stream-core-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-stream-core-docs/src/main/asciidoc/index.adoc
@@ -12,8 +12,8 @@ Sabby Anandan; Marius Bogoevici; Eric Bottard; Mark Fisher; Ilayaperumal Gopinat
 :github-tag: master
 :spring-cloud-stream-docs-version: current
 :spring-cloud-stream-docs: http://docs.spring.io/spring-cloud-stream/docs/{spring-cloud-stream-docs-version}/reference
-:spring-cloud-stream-docs-current: http://docs.spring.io/spring-cloud-stream/docs/current-SNAPSHOT/reference/html/
-:spring-cloud-stream-javadoc-current: https://docs.spring.io/spring-cloud-stream/docs/current-SNAPSHOT/api/
+:spring-cloud-stream-docs-current: http://docs.spring.io/spring-cloud-stream/docs/current-snapshot/reference/html/
+:spring-cloud-stream-javadoc-current: https://docs.spring.io/spring-cloud-stream/docs/current-snapshot/api/
 :github-repo: spring-cloud/spring-cloud-stream
 :github-raw: http://raw.github.com/{github-repo}/{github-tag}
 :github-code: http://github.com/{github-repo}/tree/{github-tag}


### PR DESCRIPTION
Some links were pointing to <http://docs.spring.io/spring-cloud-stream/docs/current-SNAPSHOT/reference/htmlsingle/>. But `SNAPSHOT` needs to be lowercase for these links.