### PR TITLE
Polish around default binding IllegalStateException

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
@@ -122,8 +122,12 @@ public class DefaultBinderFactory implements BinderFactory, DisposableBean, Appl
 						this.defaultBinderForBindingTargetType.put(bindingTargetType.getName(), configurationName);
 					}
 					else {
-						throw new IllegalStateException("A default binder has been requested, but there is more than "
-								+ "one binder available for '" + bindingTargetType.getName() + "' : "
+						String countMsg = (candidatesForBindableType.size() == 0)
+								? "are no binders"
+								: "is more than one binder";
+						throw new IllegalStateException(
+								"A default binder has been requested, but there " + countMsg
+								+ " available for '" + bindingTargetType.getName() + "' : "
 								+ StringUtils.collectionToCommaDelimitedString(candidatesForBindableType)
 								+ ", and no default binder has been set.");
 					}


### PR DESCRIPTION
If no binders were found the exception should reflect that instead of indicating that multiple binders were found.

Use case:

- `spring-cloud-stream-test-support` is on the classpath
- An `@Configuration` class contains `@EnableBinding` that comes into play in the test
- Either auto configuration is disabled altogether or via a test slice, like in my case with `@DataMongoTest`

In this case the fix is that you need to manually `@Import(TestSupportBinderAutoConfiguration.class)`. But the `IllegalStateException` that you get is confusing:

```console
...
...
Caused by: java.lang.IllegalStateException: A default binder has been requested, but there is more than one binder available for 'org.springframework.integration.channel.DirectChannel' : , and no default binder has been set.
	at org.springframework.cloud.stream.binder.DefaultBinderFactory.getBinder(DefaultBinderFactory.java:127)
	at org.springframework.cloud.stream.binding.BindingService.getBinder(BindingService.java:308)
	at org.springframework.cloud.stream.binding.BindingService.bindProducer(BindingService.java:208)

```