### PR TITLE
Simplify exception handling in DefaultPollableMessageSource

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultPollableMessageSource.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultPollableMessageSource.java
@@ -237,10 +237,6 @@ public class DefaultPollableMessageSource implements PollableMessageSource, Life
 		}
 		catch (Exception e) {
 			AckUtils.autoNack(ackCallback);
-			if (e instanceof MessageHandlingException
-					&& ((MessageHandlingException) e).getFailedMessage().equals(message)) {
-				throw (MessageHandlingException) e;
-			}
 			throw new MessageHandlingException(message, e);
 		}
 		finally {


### PR DESCRIPTION
Simplify catch all block as earlier catch block
handles `MessagingException` which is a super class
of `MessageHandlingException`