### PR TITLE
[GH-1511] RetryTemplate per binding

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-stream.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-stream.adoc
@@ -1024,6 +1024,14 @@ public RetryTemplate myRetryTemplate() {
 ----
 As you can see from the above example you don't need to annotate it with `@Bean` since `@StreamRetryTemplate` is a qualified `@Bean`.
 
+If you need to be more precise with your `RetryTemplate`, you can specify the bean by name in your `ConsumerProperties` to associate
+the specific retry bean per binding.
+
+[source]
+----
+spring.cloud.stream.bindings.<foo>.retry-template=<your-retry-template-bean-name>
+----
+
 [[spring-cloud-stream-overview-reactive-programming-support]]
 === Reactive Programming Support
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
@@ -181,8 +181,8 @@ public abstract class AbstractBinder<T, C extends ConsumerProperties, P extends 
 	protected RetryTemplate buildRetryTemplate(ConsumerProperties properties) {
 		RetryTemplate rt = this.consumerBindingRetryTemplate;
 		rt = properties.getRetryTemplate() == null ?
-        rt :
-        getBeanFactory().getBean(properties.getRetryTemplate(), RetryTemplate.class);
+				rt :
+				getBeanFactory().getBean(properties.getRetryTemplate(), RetryTemplate.class);
 
 		if (rt == null) {
 			rt = new RetryTemplate();

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
@@ -180,6 +180,10 @@ public abstract class AbstractBinder<T, C extends ConsumerProperties, P extends 
 	 */
 	protected RetryTemplate buildRetryTemplate(ConsumerProperties properties) {
 		RetryTemplate rt = this.consumerBindingRetryTemplate;
+		rt = properties.getRetryTemplate() == null ?
+        rt :
+        getBeanFactory().getBean(properties.getRetryTemplate(), RetryTemplate.class);
+
 		if (rt == null) {
 			rt = new RetryTemplate();
 			SimpleRetryPolicy retryPolicy = CollectionUtils.isEmpty(properties.getRetryableExceptions())

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ConsumerProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ConsumerProperties.java
@@ -73,6 +73,8 @@ public class ConsumerProperties {
 	 * Default: 3. Set to 1 to disable retry. You can also provide custom RetryTemplate
 	 * in the event you want to take complete control of the RetryTemplate. Simply configure
 	 * it as @Bean inside your application configuration.
+	 * If you need to be binding specific, then you can reference a specific RetryTemplate by name
+	 * with the retry-template configuration.
 	 */
 	private int maxAttempts = 3;
 
@@ -113,6 +115,13 @@ public class ConsumerProperties {
 	private boolean defaultRetryable = true;
 
 	/**
+	 * Instead of relying on the framework default or global RetryTemplate specified by
+	 * StreamRetryTemplate, you can provide the framework a bean by name to look up in the
+	 * ApplicationContext.
+	 */
+	private String retryTemplate = null;
+
+	/**
 	 * A map of Throwable class names in the key and a boolean in the value.
 	 * Specify those exceptions (and subclasses) that will or won't be retried.
 	 */
@@ -150,6 +159,14 @@ public class ConsumerProperties {
 	 * not expected to enable or disable this property directly.
 	 */
 	private boolean multiplex;
+
+	public String getRetryTemplate(){
+		return retryTemplate;
+	}
+
+	public void setRetryTemplate(String retryTemplate){
+		this.retryTemplate = retryTemplate;
+	}
 
 	@Min(value = 1, message = "Concurrency should be greater than zero.")
 	public int getConcurrency() {


### PR DESCRIPTION
Allow end users to optionally specify a retry template bean by name in their consumer properties so that different bindings can point to different retry templates.