### PR TITLE
GH-1593: Fix Typesetting misplacement

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/StreamFunctionProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/StreamFunctionProperties.java
@@ -30,7 +30,7 @@ public class StreamFunctionProperties {
 
 	/**
 	 * Definition of functions to bind. If several functions need to be composed into one,
-	 * use pipes (e.g., 'fooFunc|barFunc')
+	 * use pipes (e.g., 'fooFunc\|barFunc')
 	 */
 	private String definition;
 


### PR DESCRIPTION
This may be caused by the functionality of the asciidoc generation plugin, which needs to be escaped at build time. But I didn't find the relevant script and code content, so I modified it directly on javadoc.