### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-== Spring Cloud Stream image:https://build.spring.io/plugins/servlet/buildStatusImage/SCS-SMJLE[Build Status, link=https://build.spring.io/browse/SCS-SMJLE] image:https://badge.waffle.io/spring-cloud/spring-cloud-stream.svg?label=ready&title=Ready[Stories Ready, link=http://waffle.io/spring-cloud/spring-cloud-stream] image:https://badge.waffle.io/spring-cloud/spring-cloud-stream.svg?label=In%20Progress&title=In%20Progress[Stores In Progress, link=http://waffle.io/spring-cloud/spring-cloud-stream] image:https://badges.gitter.im/spring-cloud/spring-cloud-stream.svg[link="https://gitter.im/spring-cloud/spring-cloud-stream?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"]
+== Spring Cloud Stream image:https://build.spring.io/plugins/servlet/buildStatusImage/SCS-SMJLE[Build Status, link=https://build.spring.io/browse/SCS-SMJLE] image:https://badge.waffle.io/spring-cloud/spring-cloud-stream.svg?label=ready&title=Ready[Stories Ready, link=https://waffle.io/spring-cloud/spring-cloud-stream] image:https://badge.waffle.io/spring-cloud/spring-cloud-stream.svg?label=In%20Progress&title=In%20Progress[Stores In Progress, link=https://waffle.io/spring-cloud/spring-cloud-stream] image:https://badges.gitter.im/spring-cloud/spring-cloud-stream.svg[link="https://gitter.im/spring-cloud/spring-cloud-stream?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"]
 
 This project allows a user to develop and run messaging microservices using Spring Integration and run them locally or in the cloud. Just add `@EnableBinding` and run your app as a Spring Boot app (single application context).
 
@@ -18,7 +18,7 @@ The following binder implementations are currently available:
 
 === Documentation
 
-The latest documentation for the project can be found http://docs.spring.io/spring-cloud-stream/docs/current-SNAPSHOT/reference/htmlsingle/[here].
+The latest documentation for the project can be found https://docs.spring.io/spring-cloud-stream/docs/current-SNAPSHOT/reference/htmlsingle/[here].
 
 === Samples
 
@@ -31,7 +31,7 @@ The project team is happy to receive feedback from the community and answer ques
 We use Git Hub issues for tracking bugs and feature requests. 
 If you would like to report a bug or to suggest a feature, please open a Git Hub issue.
 
-Any question that is not a bug or an issue should be asked on Stack Overflow, using the tag http://stackoverflow.com/questions/tagged/spring-cloud-stream[`spring-cloud-stream`].
+Any question that is not a bug or an issue should be asked on Stack Overflow, using the tag https://stackoverflow.com/questions/tagged/spring-cloud-stream[`spring-cloud-stream`].
 
 === Contributing
 

--- a/spring-cloud-stream-core-docs/src/main/asciidoc/building.adoc
+++ b/spring-cloud-stream-core-docs/src/main/asciidoc/building.adoc
@@ -35,7 +35,7 @@ source control.
 
 The projects that require middleware generally include a
 `docker-compose.yml`, so consider using
-http://compose.docker.io/[Docker Compose] to run the middeware servers
+https://compose.docker.io/[Docker Compose] to run the middeware servers
 in Docker containers. See the README in the
 https://github.com/spring-cloud-samples/scripts[scripts demo
 repository] for specific instructions about the common cases of mongo,
@@ -47,13 +47,13 @@ There is a "full" profile that will generate documentation.
 
 === Working with the code
 If you don't have an IDE preference we would recommend that you use
-http://www.springsource.com/developer/sts[Spring Tools Suite] or
-http://eclipse.org[Eclipse] when working with the code. We use the
-http://eclipse.org/m2e/[m2eclipe] eclipse plugin for maven support. Other IDEs and tools
+https://www.springsource.com/developer/sts[Spring Tools Suite] or
+https://eclipse.org[Eclipse] when working with the code. We use the
+https://eclipse.org/m2e/[m2eclipe] eclipse plugin for maven support. Other IDEs and tools
 should also work without issue.
 
 ==== Importing into eclipse with m2eclipse
-We recommend the http://eclipse.org/m2e/[m2eclipe] eclipse plugin when working with
+We recommend the https://eclipse.org/m2e/[m2eclipe] eclipse plugin when working with
 eclipse. If you don't already have m2eclipse installed it is available from the "eclipse
 marketplace".
 

--- a/spring-cloud-stream-core-docs/src/main/asciidoc/contributing.adoc
+++ b/spring-cloud-stream-core-docs/src/main/asciidoc/contributing.adoc
@@ -24,7 +24,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://github.com/spring-cloud/build/tree/master/eclipse-coding-conventions.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -37,6 +37,6 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).

--- a/spring-cloud-stream-core-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-stream-core-docs/src/main/asciidoc/index.adoc
@@ -11,13 +11,13 @@ Sabby Anandan; Marius Bogoevici; Eric Bottard; Mark Fisher; Ilayaperumal Gopinat
 :spring-cloud-stream-repo: snapshot
 :github-tag: master
 :spring-cloud-stream-docs-version: current
-:spring-cloud-stream-docs: http://docs.spring.io/spring-cloud-stream/docs/{spring-cloud-stream-docs-version}/reference
-:spring-cloud-stream-docs-current: http://docs.spring.io/spring-cloud-stream/docs/current-SNAPSHOT/reference/html/
+:spring-cloud-stream-docs: https://docs.spring.io/spring-cloud-stream/docs/{spring-cloud-stream-docs-version}/reference
+:spring-cloud-stream-docs-current: https://docs.spring.io/spring-cloud-stream/docs/current-SNAPSHOT/reference/html/
 :github-repo: spring-cloud/spring-cloud-stream
-:github-raw: http://raw.github.com/{github-repo}/{github-tag}
-:github-code: http://github.com/{github-repo}/tree/{github-tag}
-:github-wiki: http://github.com/{github-repo}/wiki
-:github-master-code: http://github.com/{github-repo}/tree/master
+:github-raw: https://raw.github.com/{github-repo}/{github-tag}
+:github-code: https://github.com/{github-repo}/tree/{github-tag}
+:github-wiki: https://github.com/{github-repo}/wiki
+:github-master-code: https://github.com/{github-repo}/tree/master
 :sc-ext: java
 // ======================================================================================
 

--- a/spring-cloud-stream-core-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
+++ b/spring-cloud-stream-core-docs/src/main/asciidoc/spring-cloud-stream-overview.adoc
@@ -1518,7 +1518,7 @@ The `spring.cloud.stream.schema.server.allowSchemaDeletion` boolean setting enab
 
 The schema registry server uses a relational database to store the schemas.
  By default, it uses an embedded database.
-You can customize the schema storage using the http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql[Spring Boot SQL database and JDBC configuration options].
+You can customize the schema storage using the https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-sql[Spring Boot SQL database and JDBC configuration options].
 
 A Spring Boot application enabling the schema registry looks as follows:
 

--- a/spring-cloud-stream-core-docs/src/main/docbook/xsl/common.xsl
+++ b/spring-cloud-stream-core-docs/src/main/docbook/xsl/common.xsl
@@ -20,7 +20,7 @@
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl d"
 		version='1.0'>

--- a/spring-cloud-stream-core-docs/src/main/docbook/xsl/epub.xsl
+++ b/spring-cloud-stream-core-docs/src/main/docbook/xsl/epub.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl d"
 		version='1.0'>

--- a/spring-cloud-stream-core-docs/src/main/docbook/xsl/html.xsl
+++ b/spring-cloud-stream-core-docs/src/main/docbook/xsl/html.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl"
 		version='1.0'>

--- a/spring-cloud-stream-core-docs/src/main/docbook/xsl/pdf.xsl
+++ b/spring-cloud-stream-core-docs/src/main/docbook/xsl/pdf.xsl
@@ -22,7 +22,7 @@ under the License.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 				xmlns:d="http://docbook.org/ns/docbook"
 				xmlns:fo="http://www.w3.org/1999/XSL/Format"
-				xmlns:xslthl="http://xslthl.sf.net"
+				xmlns:xslthl="http://xslthl.sourceforge.net/"
 				xmlns:xlink='http://www.w3.org/1999/xlink'
 				xmlns:exsl="http://exslt.org/common"
 				exclude-result-prefixes="exsl xslthl d xlink"


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://xslthl.sf.net (301) with 4 occurrences could not be migrated:  
   ([https](https://xslthl.sf.net) result AnnotatedConnectException).
* [ ] http://exslt.org/common (404) with 1 occurrences could not be migrated:  
   ([https](https://exslt.org/common) result SSLHandshakeException).
* [ ] http://www.us.apache.org/dist/kafka/0.8.2.1/kafka_2.10-0.8.2.1.tgz (404) with 1 occurrences could not be migrated:  
   ([https](https://www.us.apache.org/dist/kafka/0.8.2.1/kafka_2.10-0.8.2.1.tgz) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://compose.docker.io/ (UnknownHostException) with 1 occurrences migrated to:  
  https://compose.docker.io/ ([https](https://compose.docker.io/) result UnknownHostException).
* [ ] http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/ ([https](https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/) result 404).
* [ ] http://docs.spring.io/spring-cloud-stream/docs/current-SNAPSHOT/reference/html/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-stream/docs/current-SNAPSHOT/reference/html/ ([https](https://docs.spring.io/spring-cloud-stream/docs/current-SNAPSHOT/reference/html/) result 404).
* [ ] http://docs.spring.io/spring-cloud-stream/docs/current-SNAPSHOT/reference/htmlsingle/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-stream/docs/current-SNAPSHOT/reference/htmlsingle/ ([https](https://docs.spring.io/spring-cloud-stream/docs/current-SNAPSHOT/reference/htmlsingle/) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-cloud-stream/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-stream/docs/ ([https](https://docs.spring.io/spring-cloud-stream/docs/) result 200).
* [ ] http://github.com/ with 3 occurrences migrated to:  
  https://github.com/ ([https](https://github.com/) result 200).
* [ ] http://stackoverflow.com/questions/tagged/spring-cloud-stream with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/tagged/spring-cloud-stream ([https](https://stackoverflow.com/questions/tagged/spring-cloud-stream) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://waffle.io/spring-cloud/spring-cloud-stream with 2 occurrences migrated to:  
  https://waffle.io/spring-cloud/spring-cloud-stream ([https](https://waffle.io/spring-cloud/spring-cloud-stream) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://plugins.jetbrains.com/plugin/6546 with 1 occurrences migrated to:  
  https://plugins.jetbrains.com/plugin/6546 ([https](https://plugins.jetbrains.com/plugin/6546) result 301).
* [ ] http://raw.github.com/ with 1 occurrences migrated to:  
  https://raw.github.com/ ([https](https://raw.github.com/) result 301).
* [ ] http://eclipse.org with 1 occurrences migrated to:  
  https://eclipse.org ([https](https://eclipse.org) result 302).
* [ ] http://eclipse.org/m2e/ with 2 occurrences migrated to:  
  https://eclipse.org/m2e/ ([https](https://eclipse.org/m2e/) result 302).
* [ ] http://www.springsource.com/developer/sts with 1 occurrences migrated to:  
  https://www.springsource.com/developer/sts ([https](https://www.springsource.com/developer/sts) result 302).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 4 occurrences
* http://docbook.sourceforge.net/xmlns/l10n/1.0 with 2 occurrences
* http://localhost:8080/customers with 1 occurrences
* http://localhost:8080/orders with 1 occurrences
* http://localhost:8081 with 1 occurrences
* http://localhost:8990 with 1 occurrences
* http://localhost:8990/ with 15 occurrences
* http://localhost:8990/foo/avro/v42 with 1 occurrences
* http://localhost:8990/schemas/1 with 2 occurrences
* http://localhost:8990/test with 2 occurrences
* http://localhost:8990/test/avro with 1 occurrences
* http://localhost:8990/test/avro/1 with 2 occurrences
* http://localhost:8990/test/avro/v1 with 6 occurrences
* http://localhost:8990/test/avro/v2 with 2 occurrences
* http://maven.apache.org/POM/4.0.0 with 1 occurrences
* http://www.w3.org/1999/XSL/Format with 2 occurrences
* http://www.w3.org/1999/XSL/Transform with 7 occurrences
* http://www.w3.org/1999/xlink with 1 occurrences