### PR TITLE
Fix BindingServiceConfiguration for SI-5.2

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceConfiguration.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -246,7 +247,8 @@ public class BindingServiceConfiguration {
 	@ConditionalOnMissingBean
 	public org.springframework.cloud.stream.binding.BinderAwareRouterBeanPostProcessor binderAwareRouterBeanPostProcessor(
 			@Autowired(required = false) AbstractMappingMessageRouter[] routers,
-			@Autowired(required = false) DestinationResolver<MessageChannel> channelResolver) {
+			@Autowired(required = false) @Qualifier("binderAwareChannelResolver")
+				DestinationResolver<MessageChannel> channelResolver) {
 
 		return new org.springframework.cloud.stream.binding.BinderAwareRouterBeanPostProcessor(
 				routers, channelResolver);


### PR DESCRIPTION
Starting with version 5.2 Spring Integration provides a global
`DestinationResolver` bean for some runtime optimization using a single
object.
With that the `binderAwareRouterBeanPostProcessor` bean can't resolve
a single `DestinationResolver` bean any more since there is now two
instances of that.

* Fix `BindingServiceConfiguration.binderAwareRouterBeanPostProcessor()`
to use `@Qualifier("binderAwareChannelResolver")` for an explicit bean
resolution for injection.