### PR TITLE
Make class public

### DIFF
--- a/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/OriginalContentTypeResolver.java
+++ b/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/OriginalContentTypeResolver.java
@@ -31,7 +31,7 @@ import org.springframework.util.MimeType;
  * returns the contentType
  *
  */
-class OriginalContentTypeResolver implements ContentTypeResolver {
+public class OriginalContentTypeResolver implements ContentTypeResolver {
 
 	private ConcurrentMap<String, MimeType> mimeTypeCache = new ConcurrentHashMap<>();
 


### PR DESCRIPTION
I'd like to implement my own avro msg converter but I can't reuse OriginalContentTypeResolver