### PR TITLE
Support for multiple event types in the same topic when using GenericRecord

### DIFF
--- a/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/AvroSchemaServiceManagerImpl.java
+++ b/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/AvroSchemaServiceManagerImpl.java
@@ -135,6 +135,11 @@ public class AvroSchemaServiceManagerImpl implements AvroSchemaServiceManager {
 					reader = new GenericDatumReader<>(schema);
 				}
 			}
+			else {
+				if (writerSchema != null) {
+					reader = new GenericDatumReader(writerSchema);
+				}
+			}
 		}
 		else {
 			reader = new ReflectDatumReader(type);


### PR DESCRIPTION
As seen in this pull request, from this comment on, https://github.com/spring-cloud/spring-cloud-stream-samples/pull/146#issuecomment-487228096, when using `GenericRecord` to retrieve a message, if we don't specify a reader schema we would get a: `org.springframework.messaging.converter.MessageConversionException: No schema can be inferred from type org.apache.avro.generic.GenericRecord and no schema has been explicitly configured.
`

To solve it we need to indicate something like:

```
spring:
  cloud:
      schema:
        avro:
          reader-schema: classpath:avro/some-type.avsc
```

The problem is this approach doesn't allow us to read multiple events (different message types) from the same topic, which is a [perfectly valid use case](https://www.confluent.io/blog/put-several-event-types-kafka-topic/), and which is perfectly doable with a pure Kafka Streams API.

This pull request addresses it by replicating the behaviour of SpecificRecord into the GenericRecord, using the writer schema when no reader schema is specified.