### PR TITLE
[DO NOT MERGE UNTIL RELEVANT KAFKA/RABBIT/SI changes are available]GH-1729 Added support for DLQ to functional programming model

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.stream.function;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -58,7 +59,8 @@ public class FunctionConfiguration {
 			FunctionCatalog functionCatalog, FunctionInspector functionInspector,
 			CompositeMessageConverterFactory messageConverterFactory,
 			StreamFunctionProperties functionProperties,
-			BindingServiceProperties bindingServiceProperties) {
+			BindingServiceProperties bindingServiceProperties,
+			BeanFactory beanFactory) {
 		((SmartInitializingSingleton) functionCatalog).afterSingletonsInstantiated();
 
 //		if (functionCatalog.size() > 0) {
@@ -70,7 +72,7 @@ public class FunctionConfiguration {
 //		}
 
 		return new IntegrationFlowFunctionSupport(functionCatalog, functionInspector,
-				messageConverterFactory, functionProperties, bindingServiceProperties);
+				messageConverterFactory, functionProperties, bindingServiceProperties, beanFactory);
 	}
 
 	/**

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/IntegrationFlowFunctionSupport.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/IntegrationFlowFunctionSupport.java
@@ -24,7 +24,7 @@ import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.cloud.function.context.FunctionCatalog;
 import org.springframework.cloud.function.context.FunctionType;
 import org.springframework.cloud.function.context.catalog.FunctionInspector;
@@ -56,14 +56,14 @@ public class IntegrationFlowFunctionSupport {
 
 	private final StreamFunctionProperties functionProperties;
 
-	@Autowired
-	private MessageChannel errorChannel;
+	private final BeanFactory beanFactory;
 
 	IntegrationFlowFunctionSupport(FunctionCatalog functionCatalog,
 			FunctionInspector functionInspector,
 			CompositeMessageConverterFactory messageConverterFactory,
 			StreamFunctionProperties functionProperties,
-			BindingServiceProperties bindingServiceProperties) {
+			BindingServiceProperties bindingServiceProperties,
+			BeanFactory beanFactory) {
 		Assert.notNull(functionCatalog, "'functionCatalog' must not be null");
 		Assert.notNull(functionInspector, "'functionInspector' must not be null");
 		Assert.notNull(messageConverterFactory,
@@ -73,6 +73,7 @@ public class IntegrationFlowFunctionSupport {
 		this.functionInspector = functionInspector;
 		this.messageConverterFactory = messageConverterFactory;
 		this.functionProperties = functionProperties;
+		this.beanFactory = beanFactory;
 		this.functionProperties.setBindingServiceProperties(bindingServiceProperties);
 	}
 
@@ -220,7 +221,7 @@ public class IntegrationFlowFunctionSupport {
 		}
 		FunctionInvoker<I, O> functionInvoker = new FunctionInvoker<>(functionProperties,
 				this.functionCatalog, this.functionInspector,
-				this.messageConverterFactory, this.errorChannel);
+				this.messageConverterFactory, this.beanFactory);
 
 		if (outputChannel != null) {
 			subscribeToInput(functionInvoker, publisher, outputChannel::send);


### PR DESCRIPTION
- Change FunctionInvoker.onError() to send to binding error channel instead of global one
- Binders contain relevant changes as well

Resolves #1729