### PR TITLE
QualifiedSubjectNamingStrategy uses lowercase

### DIFF
--- a/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/QualifiedSubjectNamingStrategy.java
+++ b/spring-cloud-stream-schema/src/main/java/org/springframework/cloud/stream/schema/avro/QualifiedSubjectNamingStrategy.java
@@ -26,7 +26,7 @@ public class QualifiedSubjectNamingStrategy implements SubjectNamingStrategy {
 
 	@Override
 	public String toSubject(Schema schema) {
-		return schema.getFullName();
+		return schema.getFullName().toLowerCase();
 	}
 
 }


### PR DESCRIPTION
Currently `QualifiedSubjectNamingStrategy` generates a subject name that repects the uppercase letters of the schema, producing strings such as `org.company.events.SomeEvent`.

This subject name is used to register the schema in the schema registry. 

The problem is when the consumer is receiving a message, `MessageConverterConfigurer.doPreSend()` changes the contentType, lowerCasing it here:

```
headersMap.put(MessageHeaders.CONTENT_TYPE, MimeType.valueOf(
						(String) message.getHeaders().get(MessageHeaders.CONTENT_TYPE)));
```

Then when the consumer asks the schema registry for a schema `application/vnd.org.company.events.someevent.v1+avro` it fails since it doesn't exactly match the capital letters.

With this change the schema will be registered with lower case so this won't fail anymore.