### PR TITLE
Support Batch Listeners in Core (Function)

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-stream.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-stream.adoc
@@ -587,6 +587,8 @@ support.
 [[spring_cloud_function]]
 ==== Spring Cloud Function support
 
+===== Overview
+
 Since Spring Cloud Stream v2.1, another alternative for defining _stream handlers_ and _sources_ is to use build-in
 support for https://cloud.spring.io/spring-cloud-function/[Spring Cloud Function] where they can be expressed as beans of
  type `java.util.function.[Supplier/Function/Consumer]`.
@@ -712,7 +714,19 @@ For example, the above composition could be defined as such (if both functions p
 --spring.cloud.stream.function.definition=reactiveUpperCase|wrapInQuotes
 ----
 
+===== Batch Consumers
 
+When using a `MessageChannelBinder` that supports batch listeners, and the feature is enabled for the consumer binding, you can set `spring.cloud.stream.function.definition` to `true` to enable the entire batch of messages to be passed to the function in a `List`.
+
+====
+[source, java]
+----
+@Bean
+public Function<List<Person>, Person> findFirstPerson() {
+    return persons -> persons.get(0);
+}
+----
+====
 
 [[spring-cloud-streams-overview-using-polled-consumers]]
 ==== Using Polled Consumers

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ConsumerProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ConsumerProperties.java
@@ -17,11 +17,14 @@
 package org.springframework.cloud.stream.binder;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.validation.constraints.Min;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+
+import org.springframework.messaging.Message;
 
 /**
  * Common consumer properties - spring.cloud.stream.bindings.[destinationName].consumer.
@@ -157,6 +160,15 @@ public class ConsumerProperties {
 	 */
 	private boolean multiplex;
 
+	/**
+	 * When set to true, if the binder supports it, the messages emitted will have a {@link List}
+	 * payload; When used in conjunction with functions, the function can receive a list of
+	 * objects (or {@link Message}s) with the payloads converted if necessary.
+	 *
+	 * @since 3.0
+	 */
+	private boolean batchMode;
+
 	public String getRetryTemplateName() {
 		return retryTemplateName;
 	}
@@ -283,6 +295,14 @@ public class ConsumerProperties {
 
 	public void setAutoStartup(boolean autoStartup) {
 		this.autoStartup = autoStartup;
+	}
+
+	public boolean isBatchMode() {
+		return this.batchMode;
+	}
+
+	public void setBatchMode(boolean batchMode) {
+		this.batchMode = batchMode;
 	}
 
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionInvoker.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionInvoker.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -134,7 +135,7 @@ class FunctionInvoker<I, O> implements Function<Flux<Message<I>>, Flux<Message<O
 				.getConsumerProperties(functionProperties.getInputDestinationName());
 		this.producerProperties = this.bindingServiceProperties
 				.getProducerProperties(functionProperties.getOutputDestinationName());
-		this.batchMode = functionProperties.isBatchMode();
+		this.batchMode = this.consumerProperties.isBatchMode();
 		Type type = functionType.getType();
 		ParameterizedType functionInputParameterizedType = null;
 		Type listContainsType = null;

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionInvoker.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionInvoker.java
@@ -17,10 +17,14 @@
 package org.springframework.cloud.stream.function;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -50,6 +54,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Oleg Zhurakousky
  * @author David Turanski
  * @author Tolga Kavukcu
+ * @author Gary Russell
  * @since 2.1
  */
 class FunctionInvoker<I, O> implements Function<Flux<Message<I>>, Flux<Message<O>>> {
@@ -66,6 +71,8 @@ class FunctionInvoker<I, O> implements Function<Flux<Message<I>>, Flux<Message<O
 
 	private final Class<?> inputClass;
 
+	private final ParameterizedType inputParameterizedType;
+
 	private final Class<?> outputClass;
 
 	private final Function<Flux<?>, Flux<?>> userFunction;
@@ -76,6 +83,10 @@ class FunctionInvoker<I, O> implements Function<Flux<Message<I>>, Flux<Message<O
 
 	private final boolean isInputArgumentMessage;
 
+	private final Class<?> messagePayloadClass;
+
+	private final Type messagePayloadType;
+
 	private final ConsumerProperties consumerProperties;
 
 	private final ProducerProperties producerProperties;
@@ -83,6 +94,12 @@ class FunctionInvoker<I, O> implements Function<Flux<Message<I>>, Flux<Message<O
 	private final BindingServiceProperties bindingServiceProperties;
 
 	private final StreamFunctionProperties functionProperties;
+
+	private final boolean batchMode;
+
+	private final Type listContentParameterizedType;
+
+	private final Class<?> listContentClass;
 
 	FunctionInvoker(StreamFunctionProperties functionProperties,
 			FunctionCatalog functionCatalog, FunctionInspector functionInspector,
@@ -117,6 +134,57 @@ class FunctionInvoker<I, O> implements Function<Flux<Message<I>>, Flux<Message<O
 				.getConsumerProperties(functionProperties.getInputDestinationName());
 		this.producerProperties = this.bindingServiceProperties
 				.getProducerProperties(functionProperties.getOutputDestinationName());
+		this.batchMode = functionProperties.isBatchMode();
+		Type type = functionType.getType();
+		ParameterizedType functionInputParameterizedType = null;
+		Type listContainsType = null;
+		Type payloadType = null;
+		if (type instanceof ParameterizedType) {
+			Type functionInputType = ((ParameterizedType) type).getActualTypeArguments()[0];
+			if (functionInputType instanceof ParameterizedType) {
+				functionInputParameterizedType = (ParameterizedType) functionInputType;
+				Type rawType = ((ParameterizedType) functionInputType).getRawType();
+				if (rawType.equals(List.class)) {
+					listContainsType = ((ParameterizedType) functionInputType).getActualTypeArguments()[0];
+				}
+				else if (rawType.equals(Message.class)) {
+					payloadType = determinePayloadType(functionInputType);
+				}
+			}
+		}
+		if (listContainsType instanceof Class) {
+			this.listContentClass = (Class<?>) listContainsType;
+			this.listContentParameterizedType = null;
+		}
+		else {
+			this.listContentClass = Object.class;
+			this.listContentParameterizedType = listContainsType;
+		}
+		if ((functionInputParameterizedType != null && functionInputParameterizedType.getRawType().equals(Flux.class))
+				|| payloadType != null) {
+			functionInputParameterizedType = null;
+		}
+		this.inputParameterizedType = functionInputParameterizedType;
+		if (payloadType instanceof Class) {
+			this.messagePayloadClass = (Class<?>) payloadType;
+			this.messagePayloadType = null;
+		}
+		else {
+			this.messagePayloadClass = Object.class;
+			this.messagePayloadType = payloadType;
+		}
+	}
+
+	private Type determinePayloadType(Type functionInputType) {
+		Type payloadType;
+		payloadType = ((ParameterizedType) functionInputType).getActualTypeArguments()[0];
+		if (payloadType instanceof ParameterizedType) {
+			Type payloadRawType = ((ParameterizedType) payloadType).getRawType();
+			if (payloadRawType.equals(List.class)) {
+				payloadType = ((ParameterizedType) payloadType).getActualTypeArguments()[0];
+			}
+		}
+		return payloadType;
 	}
 
 	@Override
@@ -125,7 +193,8 @@ class FunctionInvoker<I, O> implements Function<Flux<Message<I>>, Flux<Message<O
 
 		return input.concatMap(message -> {
 			return Flux.just(message).doOnNext(originalMessageRef::set)
-					.map(this::resolveArgument).transform(this.userFunction::apply)
+					.map(this::resolveArgument)
+					.transform(this.userFunction::apply)
 					.retryBackoff(this.consumerProperties.getMaxAttempts(),
 							Duration.ofMillis(
 									this.consumerProperties.getBackOffInitialInterval()),
@@ -142,7 +211,7 @@ class FunctionInvoker<I, O> implements Function<Flux<Message<I>>, Flux<Message<O
 
 	private void onError(Throwable t, Message<I> originalMessage) {
 		if (this.errorChannel != null) {
-			ErrorMessage em = new ErrorMessage(t, (Message<?>) originalMessage);
+			ErrorMessage em = new ErrorMessage(t, originalMessage);
 			logger.error(em);
 			this.errorChannel.send(em);
 		}
@@ -210,17 +279,47 @@ class FunctionInvoker<I, O> implements Function<Flux<Message<I>>, Flux<Message<O
 		}
 
 		T argument = (T) (shouldConvertFromMessage(message)
-				? this.messageConverter.fromMessage(message, this.inputClass) : message);
+				? this.messageConverter.fromMessage(message, this.inputClass, this.inputParameterizedType) : message);
 		Assert.notNull(argument, "Failed to resolve argument type '" + this.inputClass
 				+ "' from message: " + message);
-		if (this.isInputArgumentMessage && !(argument instanceof Message)) {
+		if (this.batchMode
+				&& this.messagePayloadClass != null
+				&& this.isInputArgumentMessage
+				&& argument instanceof Message
+				&& ((Message<?>) argument).getPayload() instanceof List
+				&& this.messagePayloadClass != null
+				&& !this.messagePayloadClass.isAssignableFrom(((Message<?>) argument).getPayload().getClass())) {
+			argument = (T) MessageBuilder
+					.withPayload(convertListContents(message.getPayload(), this.messagePayloadClass,
+							this.messagePayloadType))
+					.build();
+		}
+		else if (this.isInputArgumentMessage && !(argument instanceof Message)) {
+			if (shouldBatchConvert(argument)) {
+				argument = convertListContents(argument, this.messagePayloadClass, this.messagePayloadType);
+			}
 			argument = (T) MessageBuilder.withPayload(argument)
 					.copyHeaders(message.getHeaders()).build();
 		}
 		else if (!this.isInputArgumentMessage && argument instanceof Message) {
 			argument = ((Message<T>) argument).getPayload();
+			if (shouldBatchConvert(argument)) {
+				argument = convertListContents(argument, this.listContentClass, this.listContentParameterizedType);
+			}
 		}
 		return argument;
+	}
+
+	private <T> boolean shouldBatchConvert(T argument) {
+		return this.batchMode && argument instanceof List && this.listContentClass != null;
+	}
+
+	@SuppressWarnings("unchecked")
+	private <T> T convertListContents(T argument, Class<?> targetClass, Type hint) {
+		return (T) ((List<?>) argument).stream()
+				.map(payload -> this.messageConverter.fromMessage(MessageBuilder.withPayload(payload).build(),
+						targetClass, hint))
+				.collect(Collectors.toList());
 	}
 
 	private boolean shouldConvertFromMessage(Message<?> message) {

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionInvoker.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionInvoker.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionInvoker.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionInvoker.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -287,7 +288,6 @@ class FunctionInvoker<I, O> implements Function<Flux<Message<I>>, Flux<Message<O
 				&& this.isInputArgumentMessage
 				&& argument instanceof Message
 				&& ((Message<?>) argument).getPayload() instanceof List
-				&& this.messagePayloadClass != null
 				&& !this.messagePayloadClass.isAssignableFrom(((Message<?>) argument).getPayload().getClass())) {
 			argument = (T) MessageBuilder
 					.withPayload(convertListContents(message.getPayload(), this.messagePayloadClass,

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/StreamFunctionProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/StreamFunctionProperties.java
@@ -40,8 +40,6 @@ public class StreamFunctionProperties {
 
 	private String outputDestinationName = Processor.OUTPUT;
 
-	private boolean batchMode;
-
 	public String getDefinition() {
 		return this.definition;
 	}
@@ -72,14 +70,6 @@ public class StreamFunctionProperties {
 
 	void setOutputDestinationName(String outputDestinationName) {
 		this.outputDestinationName = outputDestinationName;
-	}
-
-	public boolean isBatchMode() {
-		return this.batchMode;
-	}
-
-	public void setBatchMode(boolean batchMode) {
-		this.batchMode = batchMode;
 	}
 
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/StreamFunctionProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/StreamFunctionProperties.java
@@ -40,6 +40,8 @@ public class StreamFunctionProperties {
 
 	private String outputDestinationName = Processor.OUTPUT;
 
+	private boolean batchMode;
+
 	public String getDefinition() {
 		return this.definition;
 	}
@@ -70,6 +72,14 @@ public class StreamFunctionProperties {
 
 	void setOutputDestinationName(String outputDestinationName) {
 		this.outputDestinationName = outputDestinationName;
+	}
+
+	public boolean isBatchMode() {
+		return this.batchMode;
+	}
+
+	public void setBatchMode(boolean batchMode) {
+		this.batchMode = batchMode;
 	}
 
 }

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/test/InputDestination.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/test/InputDestination.java
@@ -33,7 +33,7 @@ public class InputDestination extends AbstractDestination {
 	 * destination (e.g., Processor.INPUT).
 	 * @param message message to send
 	 */
-	public void send(Message<byte[]> message) {
+	public void send(Message<?> message) {
 		this.getChannel().send(message);
 	}
 

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/function/FunctionInvokerTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/function/FunctionInvokerTests.java
@@ -23,6 +23,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.junit.Test;
+
 import reactor.core.publisher.Flux;
 
 import org.springframework.boot.WebApplicationType;
@@ -78,6 +79,7 @@ public class FunctionInvokerTests {
 			inputDestination.send(inputMessage);
 
 			Message<byte[]> outputMessage = outputDestination.receive();
+			assertThat(outputMessage).isNotNull();
 			assertThat(outputMessage.getPayload())
 					.isEqualTo("{\"name\":\"bob\"}".getBytes());
 
@@ -102,6 +104,7 @@ public class FunctionInvokerTests {
 			inputDestination.send(inputMessage);
 
 			Message<byte[]> outputMessage = outputDestination.receive();
+			assertThat(outputMessage).isNotNull();
 			assertThat(outputMessage.getPayload()).isEqualTo("Person: bob".getBytes());
 
 		}
@@ -125,6 +128,7 @@ public class FunctionInvokerTests {
 			inputDestination.send(inputMessage);
 
 			Message<byte[]> outputMessage = outputDestination.receive();
+			assertThat(outputMessage).isNotNull();
 			assertThat(outputMessage.getPayload()).isEqualTo("Person: bob".getBytes());
 		}
 	}
@@ -149,6 +153,7 @@ public class FunctionInvokerTests {
 			inputDestination.send(inputMessage);
 
 			Message<byte[]> outputMessage = outputDestination.receive();
+			assertThat(outputMessage).isNotNull();
 			assertThat(outputMessage.getHeaders().get(MessageHeaders.CONTENT_TYPE)
 					.toString()).isEqualTo("text/plain");
 
@@ -175,6 +180,7 @@ public class FunctionInvokerTests {
 			inputDestination.send(inputMessage);
 
 			Message<byte[]> outputMessage = outputDestination.receive();
+			assertThat(outputMessage).isNotNull();
 			assertThat(outputMessage.getHeaders().get(MessageHeaders.CONTENT_TYPE)
 					.toString()).isEqualTo("ping/pong");
 
@@ -305,6 +311,7 @@ public class FunctionInvokerTests {
 					context.getBean(CompositeMessageConverterFactory.class));
 			Message<Baz> outputMessage = pojoToPojoSameType.apply(Flux.just(inputMessage))
 					.blockFirst();
+			assertThat(outputMessage).isNotNull();
 			assertThat(inputMessage.getPayload())
 					.isNotEqualTo(outputMessage.getPayload());
 
@@ -355,6 +362,7 @@ public class FunctionInvokerTests {
 			inputDestination.send(inputMessage);
 
 			Message<byte[]> outputMessage = outputDestination.receive();
+			assertThat(outputMessage).isNotNull();
 			assertThat(outputMessage.getPayload())
 					.isEqualTo("{\"name\":\"bob\"}".getBytes());
 
@@ -368,7 +376,7 @@ public class FunctionInvokerTests {
 						SimpleBatchConfiguration.class)).web(WebApplicationType.NONE).run(
 								"--spring.jmx.enabled=false",
 								"--spring.cloud.stream.function.definition=func",
-								"--spring.cloud.stream.function.batch-mode=true")) {
+								"--spring.cloud.stream.bindings.input.consumer.batch-mode=true")) {
 
 			InputDestination inputDestination = context.getBean(InputDestination.class);
 			OutputDestination outputDestination = context
@@ -383,34 +391,7 @@ public class FunctionInvokerTests {
 			inputDestination.send(inputMessage);
 
 			Message<byte[]> outputMessage = outputDestination.receive();
-			assertThat(outputMessage.getPayload())
-					.isEqualTo("{\"name\":\"bob\"}".getBytes());
-
-		}
-	}
-
-	@Test
-	public void testMessageBatchConfiguration() {
-		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
-				TestChannelBinderConfiguration.getCompleteConfiguration(
-						MessageBatchConfiguration.class)).web(WebApplicationType.NONE).run(
-								"--spring.jmx.enabled=false",
-								"--spring.cloud.stream.function.definition=func",
-								"--spring.cloud.stream.function.batch-mode=true")) {
-
-			InputDestination inputDestination = context.getBean(InputDestination.class);
-			OutputDestination outputDestination = context
-					.getBean(OutputDestination.class);
-
-			List<byte[]> list = new ArrayList<>();
-			list.add("{\"name\":\"bob\"}".getBytes());
-			list.add("{\"name\":\"jill\"}".getBytes());
-			Message<List<byte[]>> inputMessage = MessageBuilder
-					.withPayload(list)
-					.build();
-			inputDestination.send(inputMessage);
-
-			Message<byte[]> outputMessage = outputDestination.receive();
+			assertThat(outputMessage).isNotNull();
 			assertThat(outputMessage.getPayload())
 					.isEqualTo("{\"name\":\"bob\"}".getBytes());
 
@@ -424,7 +405,7 @@ public class FunctionInvokerTests {
 						NestedBatchConfiguration.class)).web(WebApplicationType.NONE).run(
 								"--spring.jmx.enabled=false",
 								"--spring.cloud.stream.function.definition=func",
-								"--spring.cloud.stream.function.batch-mode=true")) {
+								"--spring.cloud.stream.bindings.input.consumer.batch-mode=true")) {
 
 			InputDestination inputDestination = context.getBean(InputDestination.class);
 			OutputDestination outputDestination = context
@@ -438,6 +419,36 @@ public class FunctionInvokerTests {
 			inputDestination.send(inputMessage);
 
 			Message<byte[]> outputMessage = outputDestination.receive();
+			assertThat(outputMessage).isNotNull();
+			assertThat(outputMessage.getPayload())
+					.isEqualTo("{\"name\":\"bob\"}".getBytes());
+
+		}
+	}
+
+	@Test
+	public void testMessageBatchConfiguration() {
+		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
+				TestChannelBinderConfiguration.getCompleteConfiguration(
+						MessageBatchConfiguration.class)).web(WebApplicationType.NONE).run(
+								"--spring.jmx.enabled=false",
+								"--spring.cloud.stream.function.definition=func",
+								"--spring.cloud.stream.bindings.input.consumer.batch-mode=true")) {
+
+			InputDestination inputDestination = context.getBean(InputDestination.class);
+			OutputDestination outputDestination = context
+					.getBean(OutputDestination.class);
+
+			List<byte[]> list = new ArrayList<>();
+			list.add("{\"name\":\"bob\"}".getBytes());
+			list.add("{\"name\":\"jill\"}".getBytes());
+			Message<List<byte[]>> inputMessage = MessageBuilder
+					.withPayload(list)
+					.build();
+			inputDestination.send(inputMessage);
+
+			Message<byte[]> outputMessage = outputDestination.receive();
+			assertThat(outputMessage).isNotNull();
 			assertThat(outputMessage.getPayload())
 					.isEqualTo("{\"name\":\"bob\"}".getBytes());
 

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/function/FunctionInvokerTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/function/FunctionInvokerTests.java
@@ -23,7 +23,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.junit.Test;
-
 import reactor.core.publisher.Flux;
 
 import org.springframework.boot.WebApplicationType;


### PR DESCRIPTION
- Support `batchMode` in function properties so, for binders that support batch listeners, a message
  payload of `List<byte[]>` can be properly converted.
- In batch mode, handle
    `public Function<List<Person>, Person> func()`
    `public Function<List<List<Person>>, Person> func()`
    `Function<Message<List<Person>>, Person> func()`
- Also use `ParameterizedType` as a conversion hint for `public Function<List<Person>, Person> func()`
  when not in batch mode (json: `[{\"name\":\"bob\"},{\"name\":\"jill\"}]`). Previously, just the'
  class was used without generic type information.

Resolves https://github.com/spring-cloud/spring-cloud-stream/issues/1742.