### PR TITLE
Bypassing target type binding 

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/AbstractBindableProxyFactory.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/AbstractBindableProxyFactory.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2019-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binding;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.stream.binder.Binding;
+import org.springframework.cloud.stream.internal.InternalPropertyNames;
+import org.springframework.util.StringUtils;
+
+/**
+ * Base class for bindable proxy factories. This class is mainly refactored from the
+ * {@link BindableProxyFactory} so that other downstream binders who want to bind their own
+ * targets can make use of it.
+ *
+ * Original authors in {@link BindableProxyFactory}
+ * @author Soby Chacko
+ * @since 3.0.0
+ */
+public class AbstractBindableProxyFactory implements Bindable {
+
+	private static Log log = LogFactory.getLog(AbstractBindableProxyFactory.class);
+
+	@Value("${" + InternalPropertyNames.NAMESPACE_PROPERTY_NAME + ":}")
+	private String namespace;
+
+	@Autowired
+	protected Map<String, BindingTargetFactory> bindingTargetFactories;
+
+	protected Map<String, BoundTargetHolder> inputHolders = new LinkedHashMap<>();
+
+	protected Map<String, BoundTargetHolder> outputHolders = new LinkedHashMap<>();
+
+	protected Class<?> type;
+
+	public AbstractBindableProxyFactory(Class<?> type) {
+		this.type = type;
+	}
+
+	protected BindingTargetFactory getBindingTargetFactory(Class<?> bindingTargetType) {
+		List<String> candidateBindingTargetFactories = new ArrayList<>();
+		for (Map.Entry<String, BindingTargetFactory> bindingTargetFactoryEntry : this.bindingTargetFactories
+			.entrySet()) {
+			if (bindingTargetFactoryEntry.getValue().canCreate(bindingTargetType)) {
+				candidateBindingTargetFactories.add(bindingTargetFactoryEntry.getKey());
+			}
+		}
+		if (candidateBindingTargetFactories.size() == 1) {
+			return this.bindingTargetFactories
+				.get(candidateBindingTargetFactories.get(0));
+		}
+		else {
+			if (candidateBindingTargetFactories.size() == 0) {
+				throw new IllegalStateException(
+					"No factory found for binding target type: "
+						+ bindingTargetType.getName()
+						+ " among registered factories: "
+						+ StringUtils.collectionToCommaDelimitedString(
+						this.bindingTargetFactories.keySet()));
+			}
+			else {
+				throw new IllegalStateException(
+					"Multiple factories found for binding target type: "
+						+ bindingTargetType.getName() + ": "
+						+ StringUtils.collectionToCommaDelimitedString(
+						candidateBindingTargetFactories));
+			}
+		}
+	}
+
+	@Override
+	public Collection<Binding<Object>> createAndBindInputs(
+		BindingService bindingService) {
+		List<Binding<Object>> bindings = new ArrayList<>();
+		if (log.isDebugEnabled()) {
+			log.debug(
+				String.format("Binding inputs for %s:%s", this.namespace, this.type));
+		}
+		for (Map.Entry<String, BoundTargetHolder> boundTargetHolderEntry : this.inputHolders
+			.entrySet()) {
+			String inputTargetName = boundTargetHolderEntry.getKey();
+			BoundTargetHolder boundTargetHolder = boundTargetHolderEntry.getValue();
+			if (boundTargetHolder.isBindable()) {
+				if (log.isDebugEnabled()) {
+					log.debug(String.format("Binding %s:%s:%s", this.namespace, this.type,
+						inputTargetName));
+				}
+				bindings.addAll(bindingService.bindConsumer(
+					boundTargetHolder.getBoundTarget(), inputTargetName));
+			}
+		}
+		return bindings;
+	}
+
+	@Override
+	public Collection<Binding<Object>> createAndBindOutputs(
+		BindingService bindingService) {
+		List<Binding<Object>> bindings = new ArrayList<>();
+		if (log.isDebugEnabled()) {
+			log.debug(String.format("Binding outputs for %s:%s", this.namespace,
+				this.type));
+		}
+		for (Map.Entry<String, BoundTargetHolder> boundTargetHolderEntry : this.outputHolders
+			.entrySet()) {
+			BoundTargetHolder boundTargetHolder = boundTargetHolderEntry.getValue();
+			String outputTargetName = boundTargetHolderEntry.getKey();
+			if (boundTargetHolderEntry.getValue().isBindable()) {
+				if (log.isDebugEnabled()) {
+					log.debug(String.format("Binding %s:%s:%s", this.namespace, this.type,
+						outputTargetName));
+				}
+				bindings.add(bindingService.bindProducer(
+					boundTargetHolder.getBoundTarget(), outputTargetName));
+			}
+		}
+		return bindings;
+	}
+
+	@Override
+	public void unbindInputs(BindingService bindingService) {
+		if (log.isDebugEnabled()) {
+			log.debug(String.format("Unbinding inputs for %s:%s", this.namespace,
+				this.type));
+		}
+		for (Map.Entry<String, BoundTargetHolder> boundTargetHolderEntry : this.inputHolders
+			.entrySet()) {
+			if (boundTargetHolderEntry.getValue().isBindable()) {
+				if (log.isDebugEnabled()) {
+					log.debug(String.format("Unbinding %s:%s:%s", this.namespace,
+						this.type, boundTargetHolderEntry.getKey()));
+				}
+				bindingService.unbindConsumers(boundTargetHolderEntry.getKey());
+			}
+		}
+	}
+
+	@Override
+	public void unbindOutputs(BindingService bindingService) {
+		if (log.isDebugEnabled()) {
+			log.debug(String.format("Unbinding outputs for %s:%s", this.namespace,
+				this.type));
+		}
+		for (Map.Entry<String, BoundTargetHolder> boundTargetHolderEntry : this.outputHolders
+			.entrySet()) {
+			if (boundTargetHolderEntry.getValue().isBindable()) {
+				if (log.isDebugEnabled()) {
+					log.debug(String.format("Binding %s:%s:%s", this.namespace, this.type,
+						boundTargetHolderEntry.getKey()));
+				}
+				bindingService.unbindProducers(boundTargetHolderEntry.getKey());
+			}
+		}
+	}
+
+	@Override
+	public Set<String> getInputs() {
+		return this.inputHolders.keySet();
+	}
+
+	@Override
+	public Set<String> getOutputs() {
+		return this.outputHolders.keySet();
+	}
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BoundTargetHolder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BoundTargetHolder.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binding;
+
+/**
+ * Holds information about the binding targets exposed by the interface proxy, as well
+ * as their status.
+ *
+ * Refactored from {@link BindableProxyFactory}.
+ *
+ * @author Original authors in {@link BindableProxyFactory}
+ * @author Soby Chacko
+ * @since 3.0.0
+ */
+public final class BoundTargetHolder {
+
+	private Object boundTarget;
+
+	private boolean bindable;
+
+	public BoundTargetHolder(Object boundTarget, boolean bindable) {
+		this.boundTarget = boundTarget;
+		this.bindable = bindable;
+	}
+
+	public Object getBoundTarget() {
+		return this.boundTarget;
+	}
+
+	public boolean isBindable() {
+		return this.bindable;
+	}
+
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindableProvider.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindableProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.config;
+
+/**
+ * If downstream binders want to take over the responsibility of binding the target types (such as the Kafka Streams binder),
+ * then they can implement this functional interface to signal the core framework to bypass any binding.
+ *
+ * @author Soby Chacko
+ * @since 3.0.0
+ */
+@FunctionalInterface
+public interface BindableProvider {
+
+	/**
+	 * Based on the type provided, the implementation can determine whether it is capable of
+	 * binding this target type.
+	 *
+	 * @param clazz target type to bind
+	 * @return true if capable of binding
+	 */
+	boolean canBind(Class<?> clazz);
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/StreamFunctionProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/StreamFunctionProperties.java
@@ -16,6 +16,10 @@
 
 package org.springframework.cloud.stream.function;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.cloud.stream.messaging.Processor;
@@ -23,6 +27,7 @@ import org.springframework.cloud.stream.messaging.Processor;
 /**
  * @author Oleg Zhurakousky
  * @author Tolga Kavukcu
+ * @author Soby Chacko
  * @since 2.1
  */
 @ConfigurationProperties("spring.cloud.stream.function")
@@ -39,6 +44,10 @@ public class StreamFunctionProperties {
 	private String inputDestinationName = Processor.INPUT;
 
 	private String outputDestinationName = Processor.OUTPUT;
+
+	private Map<String, List<String>> inputBindings = new HashMap<>();
+
+	private Map<String, List<String>> outputBindings = new HashMap<>();
 
 	public String getDefinition() {
 		return this.definition;
@@ -72,4 +81,21 @@ public class StreamFunctionProperties {
 		this.outputDestinationName = outputDestinationName;
 	}
 
+	public Map<String, List<String>> getInputBindings() {
+		return inputBindings;
+	}
+
+	public Map<String, List<String>> getOutputBindings() {
+		return outputBindings;
+	}
+
+	public void setOutputBindings(Map<String, List<String>> outputBindings) {
+		this.outputBindings = outputBindings;
+	}
+
+	public void setInputBindings(Map<String, List<String>> inputBindings) {
+		this.inputBindings = inputBindings;
+
+
+	}
 }


### PR DESCRIPTION
When functional model is used and no EnableBinding is provided, this PR allows
core Spring Cloud Stream to skip any target type binding if the downstream
binder is capable of such binding on the target type. In that case, the target
binders provide their own BindableTargetProxyFactory.

Introduce additional properties in StreamFunction properties to allow overriding the
input/output bindings.

Resolves #1751