### PR TITLE
Publishing template customizer

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-stream.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-stream.adoc
@@ -1952,6 +1952,23 @@ See `<<spring-cloud-stream-overview-error-handling>>` for more information.
 +
 Default: `false`.
 
+==== Advanced Producer Configuration
+
+For advanced configuration of the underlying publishing template, add a single `PublishingTemplateCustomizer` bean to the application context.
+It will be invoked after the above properties have been applied and can be used to set additional properties.
+
+The following is an example for the RabbitMQ binder:
+
+====
+[source, java]
+----
+@Bean
+public PublishingTemplateCustomizer<RabbitTemplate> templateCustomizer() {
+    return (template, dest) -> template.addBeforePublishPostProcessors(postProcessor);
+}
+----
+====
+
 [[dynamicdestination]]
 === Using Dynamically Bound Destinations
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.support.DefaultSingletonBeanRegistry;
 import org.springframework.cloud.stream.config.ListenerContainerCustomizer;
 import org.springframework.cloud.stream.config.MessageSourceCustomizer;
+import org.springframework.cloud.stream.config.PublishingTemplateCustomizer;
 import org.springframework.cloud.stream.provisioning.ConsumerDestination;
 import org.springframework.cloud.stream.provisioning.ProducerDestination;
 import org.springframework.cloud.stream.provisioning.ProvisioningException;
@@ -113,6 +114,8 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 
 	private MessageSourceCustomizer<?> sourceCustomizer;
 
+	private final PublishingTemplateCustomizer<?> templateCustomizer;
+
 	private ApplicationEventPublisher applicationEventPublisher;
 
 //	@Autowired(required = false)
@@ -131,6 +134,13 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 	public AbstractMessageChannelBinder(String[] headersToEmbed, PP provisioningProvider,
 			@Nullable ListenerContainerCustomizer<?> containerCustomizer,
 			@Nullable MessageSourceCustomizer<?> sourceCustomizer) {
+		this(headersToEmbed, provisioningProvider, containerCustomizer, sourceCustomizer, null);
+	}
+
+	public AbstractMessageChannelBinder(String[] headersToEmbed, PP provisioningProvider,
+			@Nullable ListenerContainerCustomizer<?> containerCustomizer,
+			@Nullable MessageSourceCustomizer<?> sourceCustomizer,
+			@Nullable PublishingTemplateCustomizer<?> templateCustomizer) {
 
 		SimpleModule module = new SimpleModule();
 		module.addSerializer(Expression.class, new ExpressionSerializer(Expression.class));
@@ -138,6 +148,8 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 
 		this.headersToEmbed = headersToEmbed == null ? new String[0] : headersToEmbed;
 		this.provisioningProvider = provisioningProvider;
+		this.templateCustomizer = templateCustomizer == null ? (t, q) -> {
+		} : templateCustomizer;
 		this.containerCustomizer = containerCustomizer == null ? (c, q, g) -> {
 		} : containerCustomizer;
 		this.sourceCustomizer = sourceCustomizer == null ? (s, q, g) -> {
@@ -152,6 +164,11 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 	public void setApplicationEventPublisher(
 			ApplicationEventPublisher applicationEventPublisher) {
 		this.applicationEventPublisher = applicationEventPublisher;
+	}
+
+	@SuppressWarnings("unchecked")
+	protected <T> PublishingTemplateCustomizer<T> getTemplateCustomizer() {
+		return (PublishingTemplateCustomizer<T>) this.templateCustomizer;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
@@ -112,7 +112,7 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 
 	private final ListenerContainerCustomizer<?> containerCustomizer;
 
-	private MessageSourceCustomizer<?> sourceCustomizer;
+	private final MessageSourceCustomizer<?> sourceCustomizer;
 
 	private final PublishingTemplateCustomizer<?> templateCustomizer;
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/PublishingTemplateCustomizer.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/PublishingTemplateCustomizer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.config;
+
+/**
+ * If a single bean of this type is in the application context, producer template
+ * created by the binder can be further customized after all the properties are set.
+ * For example, to configure less-common properties.
+ *
+ * @param <T> template type
+ * @author Artyom Gabeev
+ * @since 3.0
+ */
+@FunctionalInterface
+public interface PublishingTemplateCustomizer<T> {
+
+	/**
+	 * Configure the template that is being created by binder for the supplied
+	 * destination name.
+	 * @param template the template.
+	 * @param destinationName the destination name.
+	 */
+	void configure(T template, String destinationName);
+
+}


### PR DESCRIPTION
Add PublishingTemplateCustomizer which should be used to customize underlying template, e.g. RabbitTemplate to add sleuth post processor (https://github.com/spring-cloud/spring-cloud-stream-binder-rabbit/issues/265).

As I understand this PR needs to be merged first, before we can integrate customizer into specific binders implementations.