### PR TITLE
Add `ProducerMessageHandlerCustomizer` support

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ProducerMessageHandlerCustomizer.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/ProducerMessageHandlerCustomizer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.config;
+
+import org.springframework.messaging.MessageHandler;
+
+/**
+ * If a single bean of this type is in the application context, producing message handler
+ * created by the binder can be further customized after all the properties are set. For
+ * example, to configure less-common properties.
+ *
+ * @param <H> {@link MessageHandler} type
+ *
+ * @author Artem Bilan
+ *
+ * @since 3.0
+ */
+@FunctionalInterface
+public interface ProducerMessageHandlerCustomizer<H extends MessageHandler> {
+
+	/**
+	 * Configure a provided {@link MessageHandler} by the binder
+	 * that is being created for the provided destination name.
+	 * @param handler the {@link MessageHandler} from the binder.
+	 * @param destinationName the bound destination name.
+	 */
+	void configure(H handler, String destinationName);
+
+}


### PR DESCRIPTION
Related to https://github.com/spring-cloud/spring-cloud-stream-binder-aws-kinesis/issues/107

In some cases there is not enough configuration properties to setup
a producing `MessageHandler` in the binder.
Or we just can't do that via properties because some real object is
required for particular MH option.
For example in the AWS Kinesis Binder end-user would like to provide
a custom `AsyncHandler` which definitely cannot be expressed via properties

* Introduce a `ProducerMessageHandlerCustomizer` similar to existing
`MessageSourceCustomizer` and `ListenerContainerCustomizer`
* Add an `AbstractMessageChannelBinder.setProducerMessageHandlerCustomizer()`
to avoid breaking changes with an additional constructor arg
* Use a provided `handlerCustomizer` in the `customizeProducerMessageHandler()`
called from the `doBindProducer()` on the current `MH` before its
`afterPropertiesSet()`
* It is a target binder configuration responsibility to inject a
`ProducerMessageHandlerCustomizer` into the binder bean