### PR TITLE
Fixing functional binding

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -159,7 +159,7 @@ You should see following output:
 
 Go to the RabbitMQ management console or any other RabbitMQ client and send a message to `input.anonymous.CbMIwdkJSBO1ZoPDOtHtCg`.
 The `anonymous.CbMIwdkJSBO1ZoPDOtHtCg` part represents the group name and is generated, so it is bound to be different in your environment.
-For something more predictable, you can use an explicit group name by setting `spring.cloud.stream.bindings.input.group=hello` (or whatever name you like).
+For something more predictable, you can use an explicit group name by setting `spring.cloud.stream.bindings.log-in-0.group=hello` (or whatever name you like).
 
 The contents of the message should be a JSON representation of the `Person` class, as follows:
 


### PR DESCRIPTION
The functional binding requires the binding to be "log-in-0" rather than "input"