### PR TITLE
Implement isPaused method on DefaultBinding

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinding.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinding.java
@@ -118,6 +118,11 @@ public class DefaultBinding<T> implements Binding<T> {
 	}
 
 	@Override
+	public boolean isPaused() {
+		return this.paused;
+	}
+
+	@Override
 	public final synchronized void start() {
 		if (!this.isRunning()) {
 			if (this.lifecycle != null && this.restartable) {

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinding.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinding.java
@@ -38,6 +38,7 @@ import org.springframework.util.StringUtils;
  * @author Gary Russell
  * @author Marius Bogoevici
  * @author Oleg Zhurakousky
+ * @author Myeonghyeon Lee
  * @see org.springframework.cloud.stream.annotation.EnableBinding
  */
 

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/DefaultBinderTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/DefaultBinderTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ *
+ * @author Myeonghyeon Lee
+ *
+ */
+public class DefaultBinderTests {
+
+    @Test
+    public void testDefaultBinderIsPaused() {
+        @SuppressWarnings({ "rawtypes" })
+        DefaultBinding<?> binding = new DefaultBinding<>("foo", "bar", "target", (Binding) () -> {
+        });
+
+        assertThat(binding.isPaused()).isFalse();
+
+        binding.pause();
+
+        assertThat(binding.isPaused()).isTrue();
+    }
+}


### PR DESCRIPTION
Implement `Pausable#isPaused` method.

it added at spring-integration 5.4.1
https://github.com/spring-projects/spring-integration/commit/3de0445aaab99ad96c655918851e0974e6457ce9#diff-81ed9294fa988781a8127fc6166dfdc1266314dc2a3b48eefcbad75ab4aa7463R52

The default method of the Pausable interface throws an UnsupportedOperationException.

Because of this, an error occurs when executing `BindingEndpoint#queryStates`.
https://github.com/spring-cloud/spring-cloud-stream/blob/562a025cda500bd31b2e48d180290deae80cb235/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/endpoint/BindingsEndpoint.java#L88

Implement the isPausable method on DefaultBinding.