### PR TITLE
Fix test binder usage examples in the documentation

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-stream.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-stream.adoc
@@ -2752,12 +2752,12 @@ public void testMultipleFunctions() {
 
 		Message<byte[]> inputMessage = MessageBuilder.withPayload("Hello".getBytes()).build();
 		inputDestination.send(inputMessage, "uppercase-in-0");
-		inputDestination.send(inputMessage, "uppercase-in-0");
+		inputDestination.send(inputMessage, "reverse-in-0");
 
 		Message<byte[]> outputMessage = outputDestination.receive(0, "uppercase-out-0");
 		assertThat(outputMessage.getPayload()).isEqualTo("HELLO".getBytes());
 
-		outputMessage = outputDestination.receive(0, "uppercase-out-0");
+		outputMessage = outputDestination.receive(0, "reverse-out-0");
 		assertThat(outputMessage.getPayload()).isEqualTo("olleH".getBytes());
 	}
 }
@@ -2775,7 +2775,7 @@ public void testMultipleFunctions() {
 							.run(
 							"--spring.cloud.function.definition=uppercase;reverse",
 							"--spring.cloud.stream.bindings.uppercase-in-0.destination=myInput",
-							"--spring.cloud.stream.bindings.uppercase-out-0.destination=myOutput",
+							"--spring.cloud.stream.bindings.uppercase-out-0.destination=myOutput"
 							)) {
 
 		InputDestination inputDestination = context.getBean(InputDestination.class);
@@ -2783,12 +2783,12 @@ public void testMultipleFunctions() {
 
 		Message<byte[]> inputMessage = MessageBuilder.withPayload("Hello".getBytes()).build();
 		inputDestination.send(inputMessage, "myInput");
-		inputDestination.send(inputMessage, "myInput");
+		inputDestination.send(inputMessage, "reverse-in-0");
 
 		Message<byte[]> outputMessage = outputDestination.receive(0, "myOutput");
 		assertThat(outputMessage.getPayload()).isEqualTo("HELLO".getBytes());
 
-		outputMessage = outputDestination.receive(0, "myOutput");
+		outputMessage = outputDestination.receive(0, "reverse-out-0");
 		assertThat(outputMessage.getPayload()).isEqualTo("olleH".getBytes());
 	}
 }


### PR DESCRIPTION
The examples for testing Spring Cloud Stream in the presence of multiple
bindings contain some mistakes that make the tests fail.