### PR TITLE
Fixed spring-cloud-stream.adoc documentation rendering

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-stream.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-stream.adoc
@@ -1694,22 +1694,23 @@ The user must check for the binder type and then apply the necessary customizati
 
 Here is an example of providing a `BinderCustomizer` bean.
 
-```
+[source, java]
+----
 @Bean
 public BinderCustomizer binderCustomizer() {
     return (binder, binderName) -> {
         if (binder instanceof KafkaMessageChannelBinder) {
-            ((KafkaMessageChannelBinder) binder).setRebalanceListener(...);
+            ((KafkaMessageChannelBinder) binder).setRebalanceListener(/*...*/);
         }
         else if (binder instanceof KStreamBinder) {
-            ...
+            // ...
         }
         else if (binder instanceof RabbitMessageChannelBinder) {
-            ...
+            // ...
         }
     };
 }
-```
+----
 
 Note that, when there are more than one instance of the same type of the binder, the binder name can be used to filter customization.
 
@@ -1731,8 +1732,10 @@ BindingsLifecycleController bindingsController = context.getBean(BindingsLifecyc
 Binding binding = bindingsController.queryState("echo-in-0");
 assertThat(binding.isRunning()).isTrue();
 bindingsController.changeState("echo-in-0", State.STOPPED);
-//bindingsController.stop("echo-in-0") alternative way of changing state. For convenience we expose start/stop and pause/resume operations.
+//Alternative way of changing state. For convenience we expose start/stop and pause/resume operations.
+//bindingsController.stop("echo-in-0")
 assertThat(binding.isRunning()).isFalse();
+----
 
 ==== Actuator
 Since actuator and web are optional, you must first add one of the web dependencies as well as add the actuator dependency manually.
@@ -2685,7 +2688,7 @@ Below is the example of the required Maven POM entries.
 Or for build.gradle.kts
 
 [source,kotlin]
----
+----
 testImplementation("org.springframework.cloud:spring-cloud-stream") {
 	artifact {
 		name = "spring-cloud-stream"
@@ -2694,7 +2697,7 @@ testImplementation("org.springframework.cloud:spring-cloud-stream") {
 		classifier = "test-binder"
 	}
 }
----
+----
 
 
 
@@ -2891,7 +2894,7 @@ public static class SamplePolledConfiguration {
 
 The above (very rudimentary) example will produce 3 messages in 2 second intervals sending them to the output destination of `Source`
 which this binder sends to `OutputDestination` where we retrieve them (for any assertions).
-Currently it prints the following:
+Currently, it prints the following:
 [source, text]
 ----
 Message 1: POLLED DATA


### PR DESCRIPTION
Hello there! 

I was reading docs and saw that the rendering went wrong. (Image attached below)
There was a problem in the code block, so I fixed it. One error caused everything else below to be broken too.

- Fixed a few ADOC lines 
- Added punctuation mark 
 May be removed, it was IDEA's autocorrection, I'm not native speaker myself, so I may be wrong here

<img width="1295" alt="image" src="https://user-images.githubusercontent.com/18665585/114584101-faad1880-9c8a-11eb-85a2-02b4cba77410.png">