### PR TITLE
Fixed typo in spring-cloud-stream.adoc

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-stream.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-stream.adoc
@@ -1749,6 +1749,7 @@ assertThat(binding.isRunning()).isTrue();
 bindingsController.changeState("echo-in-0", State.STOPPED);
 //bindingsController.stop("echo-in-0") alternative way of changing state. For convenience we expose start/stop and pause/resume operations.
 assertThat(binding.isRunning()).isFalse();
+----
 
 ==== Actuator
 Since actuator and web are optional, you must first add one of the web dependencies as well as add the actuator dependency manually.


### PR DESCRIPTION
Fixing typo in documentation that caused a broken view.

See https://docs.spring.io/spring-cloud-stream/docs/3.0.12.RELEASE/reference/html/spring-cloud-stream.html#_programmatic_way
![image](https://user-images.githubusercontent.com/27017678/117903224-b9e40600-b301-11eb-8786-e819abee29ba.png)
