### PR TITLE
StreamBridge partitioning fix

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/StreamBridge.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/StreamBridge.java
@@ -271,14 +271,15 @@ public final class StreamBridge implements SmartInitializingSingleton {
 				binder = binderFactory.getBinder(binderName, messageChannel.getClass());
 			}
 
-			this.bindingService.bindProducer(messageChannel, destinationName, false, binder);
-			this.channelCache.put(destinationName, messageChannel);
 			if (producerProperties.isPartitioned()) {
 				BindingProperties bindingProperties = this.bindingServiceProperties.getBindingProperties(destinationName);
 				((AbstractMessageChannel) messageChannel)
 					.addInterceptor(new DefaultPartitioningInterceptor(bindingProperties, this.applicationContext.getBeanFactory()));
 			}
 			this.addInterceptors((AbstractMessageChannel) messageChannel, destinationName);
+
+			this.bindingService.bindProducer(messageChannel, destinationName, false, binder);
+			this.channelCache.put(destinationName, messageChannel);
 		}
 
 		return messageChannel;


### PR DESCRIPTION
Fix the order in applying partitioning interceptor in StreamBridge.
The interceptor must be added before the call for binding the producer.

Related to resolving https://github.com/spring-cloud/spring-cloud-stream/issues/2245

Specifically for this: https://github.com/spring-cloud/spring-cloud-stream/issues/2245#issuecomment-977663452