### PR TITLE
Initial commit for reactive binding support

### DIFF
--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
@@ -274,6 +274,9 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 			reactiveStreamsConsumerRef.set(reactiveStreamsConsumer);
 			reactiveStreamsConsumer.start();
 		}
+		else {
+			throw new IllegalStateException("No capable binding targets found.");
+		}
 
 		Binding<MessageChannel> binding = new DefaultBinding<MessageChannel>(destination,
 				outputChannel, producerMessageHandler instanceof Lifecycle

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,7 @@ import org.springframework.core.convert.support.GenericConversionService;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.StandardEnvironment;
+import org.springframework.integration.channel.FluxMessageChannel;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.util.Assert;
@@ -192,7 +193,7 @@ public class DefaultBinderFactory implements BinderFactory, DisposableBean, Appl
 						Class<?> binderType = GenericsUtils.getParameterType(
 								binderInstance.getClass(), Binder.class, 0);
 						if (binderType.isAssignableFrom(bindingTargetType)) {
-							candidatesForBindableType.add(defaultCandidateConfiguration);
+							populateCandidatesForBindableType(bindingTargetType, candidatesForBindableType, defaultCandidateConfiguration);
 						}
 					}
 					if (candidatesForBindableType.size() == 1) {
@@ -225,6 +226,22 @@ public class DefaultBinderFactory implements BinderFactory, DisposableBean, Appl
 				"The binder '" + configurationName + "' cannot bind a "
 						+ bindingTargetType.getName());
 		return binderInstance;
+	}
+
+	private <T> void populateCandidatesForBindableType(Class<? extends T> bindingTargetType, List<String> candidatesForBindableType,
+													String defaultCandidateConfiguration) {
+		if (FluxMessageChannel.class.isAssignableFrom(bindingTargetType)) {
+			// Going by the convention of proper reactor based binders start with the key literal - reactor
+			if (defaultCandidateConfiguration.startsWith("reactor")) {
+				candidatesForBindableType.add(defaultCandidateConfiguration);
+			}
+		}
+		else {
+			// Only add if it is not a reactor based binder
+			if (!defaultCandidateConfiguration.startsWith("reactor")) {
+				candidatesForBindableType.add(defaultCandidateConfiguration);
+			}
+		}
 	}
 
 	/**

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
@@ -230,17 +230,12 @@ public class DefaultBinderFactory implements BinderFactory, DisposableBean, Appl
 
 	private <T> void populateCandidatesForBindableType(Class<? extends T> bindingTargetType, List<String> candidatesForBindableType,
 													String defaultCandidateConfiguration) {
-		if (FluxMessageChannel.class.isAssignableFrom(bindingTargetType)) {
-			// Going by the convention of proper reactor based binders start with the key literal - reactor
-			if (defaultCandidateConfiguration.startsWith("reactor")) {
-				candidatesForBindableType.add(defaultCandidateConfiguration);
-			}
+		// Going by the convention of proper reactor based binders start with the key literal - reactor
+		if (FluxMessageChannel.class.isAssignableFrom(bindingTargetType) && defaultCandidateConfiguration.startsWith("reactor")) {
+			candidatesForBindableType.add(defaultCandidateConfiguration);
 		}
-		else {
-			// Only add if it is not a reactor based binder
-			if (!defaultCandidateConfiguration.startsWith("reactor")) {
-				candidatesForBindableType.add(defaultCandidateConfiguration);
-			}
+		else if (!defaultCandidateConfiguration.startsWith("reactor")) {
+			candidatesForBindableType.add(defaultCandidateConfiguration);
 		}
 	}
 

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/FluxMessageChannelBindingTargetFactory.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/FluxMessageChannelBindingTargetFactory.java
@@ -59,10 +59,6 @@ public class FluxMessageChannelBindingTargetFactory extends AbstractBindingTarge
 			}
 			catch (BeanCreationException e) {
 				// ignore
-				/*
-				 * Since we still support annotation-based programming model, this exception happens
-				 * because of proxies related to @Input @Output
-				 */
 			}
 		}
 		if (fluxMessageChannel == null) {

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/FluxMessageChannelBindingTargetFactory.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/FluxMessageChannelBindingTargetFactory.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binding;
+
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.integration.channel.FluxMessageChannel;
+
+/**
+ * @author Soby Chacko
+ * @since 4.0.0
+ */
+public class FluxMessageChannelBindingTargetFactory extends AbstractBindingTargetFactory<FluxMessageChannel> {
+
+	private final MessageChannelConfigurer messageChannelConfigurer;
+
+	@Autowired
+	private GenericApplicationContext context;
+
+	public FluxMessageChannelBindingTargetFactory(MessageChannelConfigurer messageChannelConfigurer) {
+		super(FluxMessageChannel.class);
+		this.messageChannelConfigurer = messageChannelConfigurer;
+	}
+
+	@Override
+	public FluxMessageChannel createInput(String name) {
+		FluxMessageChannel fluxMessageChannel = null;
+		if (context != null && context.containsBean(name)) {
+			try {
+				fluxMessageChannel = context.getBean(name, FluxMessageChannel.class);
+			}
+			catch (BeanCreationException e) {
+				// ignore
+				/*
+				 * Since we still support annotation-based programming model, this exception happens
+				 * because of proxies related to @Input @Output
+				 */
+			}
+		}
+		if (fluxMessageChannel == null) {
+			FluxMessageChannel channel = new FluxMessageChannel();
+			channel.setComponentName(name);
+			if (context != null && !context.containsBean(name)) {
+				context.registerBean(name, FluxMessageChannel.class, () -> channel);
+			}
+			fluxMessageChannel = channel;
+			this.messageChannelConfigurer.configureInputChannel(fluxMessageChannel, name);
+		}
+		return fluxMessageChannel;
+	}
+
+	@Override
+	public FluxMessageChannel createOutput(String name) {
+		FluxMessageChannel fluxMessageChannel = null;
+		if (context != null && context.containsBean(name)) {
+			try {
+				fluxMessageChannel = context.getBean(name, FluxMessageChannel.class);
+			}
+			catch (BeanCreationException e) {
+				// ignore
+			}
+		}
+		if (fluxMessageChannel == null) {
+			FluxMessageChannel channel = new FluxMessageChannel();
+			channel.setComponentName(name);
+			if (context != null && !context.containsBean(name)) {
+				context.registerBean(name, FluxMessageChannel.class, () -> channel);
+			}
+			fluxMessageChannel = channel;
+			this.messageChannelConfigurer.configureOutputChannel(fluxMessageChannel, name);
+		}
+		return fluxMessageChannel;
+	}
+}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/FluxMessageChannelBindingTargetFactory.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/FluxMessageChannelBindingTargetFactory.java
@@ -17,7 +17,6 @@
 package org.springframework.cloud.stream.binding;
 
 import org.springframework.beans.factory.BeanCreationException;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.integration.channel.FluxMessageChannel;
 
@@ -29,16 +28,30 @@ public class FluxMessageChannelBindingTargetFactory extends AbstractBindingTarge
 
 	private final MessageChannelConfigurer messageChannelConfigurer;
 
-	@Autowired
-	private GenericApplicationContext context;
+	private final GenericApplicationContext context;
 
-	public FluxMessageChannelBindingTargetFactory(MessageChannelConfigurer messageChannelConfigurer) {
+	public FluxMessageChannelBindingTargetFactory(MessageChannelConfigurer messageChannelConfigurer,
+												GenericApplicationContext context) {
 		super(FluxMessageChannel.class);
 		this.messageChannelConfigurer = messageChannelConfigurer;
+		this.context = context;
 	}
 
 	@Override
 	public FluxMessageChannel createInput(String name) {
+		FluxMessageChannel fluxMessageChannel = fluxMessageChannel(name);
+		this.messageChannelConfigurer.configureInputChannel(fluxMessageChannel, name);
+		return fluxMessageChannel;
+	}
+
+	@Override
+	public FluxMessageChannel createOutput(String name) {
+		FluxMessageChannel fluxMessageChannel = fluxMessageChannel(name);
+		this.messageChannelConfigurer.configureOutputChannel(fluxMessageChannel, name);
+		return fluxMessageChannel;
+	}
+
+	public FluxMessageChannel fluxMessageChannel(String name) {
 		FluxMessageChannel fluxMessageChannel = null;
 		if (context != null && context.containsBean(name)) {
 			try {
@@ -59,30 +72,6 @@ public class FluxMessageChannelBindingTargetFactory extends AbstractBindingTarge
 				context.registerBean(name, FluxMessageChannel.class, () -> channel);
 			}
 			fluxMessageChannel = channel;
-			this.messageChannelConfigurer.configureInputChannel(fluxMessageChannel, name);
-		}
-		return fluxMessageChannel;
-	}
-
-	@Override
-	public FluxMessageChannel createOutput(String name) {
-		FluxMessageChannel fluxMessageChannel = null;
-		if (context != null && context.containsBean(name)) {
-			try {
-				fluxMessageChannel = context.getBean(name, FluxMessageChannel.class);
-			}
-			catch (BeanCreationException e) {
-				// ignore
-			}
-		}
-		if (fluxMessageChannel == null) {
-			FluxMessageChannel channel = new FluxMessageChannel();
-			channel.setComponentName(name);
-			if (context != null && !context.containsBean(name)) {
-				context.registerBean(name, FluxMessageChannel.class, () -> channel);
-			}
-			fluxMessageChannel = channel;
-			this.messageChannelConfigurer.configureOutputChannel(fluxMessageChannel, name);
 		}
 		return fluxMessageChannel;
 	}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/SupportedBindableFeatures.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/SupportedBindableFeatures.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.stream.function;
+package org.springframework.cloud.stream.binding;
 
 /**
  * Internal abstraction for the supported bindable features.
@@ -22,22 +22,25 @@ package org.springframework.cloud.stream.function;
  * @author Soby Chacko
  * @since 4.0.0
  */
-class SupportedBindableFeatures {
+public class SupportedBindableFeatures {
 
-	private final boolean pollable;
+	private boolean pollable;
 
-	private final boolean reactive;
+	private boolean reactive;
 
-	SupportedBindableFeatures(boolean pollable, boolean reactive) {
+	public void setPollable(boolean pollable) {
 		this.pollable = pollable;
+	}
+
+	public void setReactive(boolean reactive) {
 		this.reactive = reactive;
 	}
 
-	boolean isPollable() {
+	public boolean isPollable() {
 		return pollable;
 	}
 
-	boolean isReactive() {
+	public boolean isReactive() {
 		return reactive;
 	}
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BinderFactoryAutoConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BinderFactoryAutoConfiguration.java
@@ -52,6 +52,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Role;
+import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 import org.springframework.core.io.support.PropertiesLoaderUtils;
@@ -227,9 +228,9 @@ public class BinderFactoryAutoConfiguration {
 	@Bean
 	@ConditionalOnProperty(value = "spring.cloud.stream.reactive", havingValue = "true")
 	public FluxMessageChannelBindingTargetFactory fluxMessageChannelBindingTargetFactory(
-		CompositeMessageChannelConfigurer compositeMessageChannelConfigurer) {
+		CompositeMessageChannelConfigurer compositeMessageChannelConfigurer, GenericApplicationContext context) {
 		return new FluxMessageChannelBindingTargetFactory(
-			compositeMessageChannelConfigurer);
+			compositeMessageChannelConfigurer, context);
 	}
 
 	@Bean

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BinderFactoryAutoConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BinderFactoryAutoConfiguration.java
@@ -35,7 +35,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.binder.BinderType;
 import org.springframework.cloud.stream.binder.BinderTypeRegistry;
@@ -218,7 +217,6 @@ public class BinderFactoryAutoConfiguration {
 
 
 	@Bean
-	@ConditionalOnProperty(name = "spring.cloud.stream.reactive", havingValue = "false", matchIfMissing = true)
 	public SubscribableChannelBindingTargetFactory channelFactory(
 			CompositeMessageChannelConfigurer compositeMessageChannelConfigurer) {
 		return new SubscribableChannelBindingTargetFactory(
@@ -226,7 +224,6 @@ public class BinderFactoryAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnProperty(value = "spring.cloud.stream.reactive", havingValue = "true")
 	public FluxMessageChannelBindingTargetFactory fluxMessageChannelBindingTargetFactory(
 		CompositeMessageChannelConfigurer compositeMessageChannelConfigurer, GenericApplicationContext context) {
 		return new FluxMessageChannelBindingTargetFactory(

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BinderFactoryAutoConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BinderFactoryAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,11 +35,13 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.binder.BinderType;
 import org.springframework.cloud.stream.binder.BinderTypeRegistry;
 import org.springframework.cloud.stream.binder.DefaultBinderTypeRegistry;
 import org.springframework.cloud.stream.binding.CompositeMessageChannelConfigurer;
+import org.springframework.cloud.stream.binding.FluxMessageChannelBindingTargetFactory;
 import org.springframework.cloud.stream.binding.MessageChannelConfigurer;
 import org.springframework.cloud.stream.binding.MessageConverterConfigurer;
 import org.springframework.cloud.stream.binding.MessageSourceBindingTargetFactory;
@@ -215,10 +217,19 @@ public class BinderFactoryAutoConfiguration {
 
 
 	@Bean
+	@ConditionalOnProperty(name = "spring.cloud.stream.reactive", havingValue = "false", matchIfMissing = true)
 	public SubscribableChannelBindingTargetFactory channelFactory(
 			CompositeMessageChannelConfigurer compositeMessageChannelConfigurer) {
 		return new SubscribableChannelBindingTargetFactory(
 				compositeMessageChannelConfigurer);
+	}
+
+	@Bean
+	@ConditionalOnProperty(value = "spring.cloud.stream.reactive", havingValue = "true")
+	public FluxMessageChannelBindingTargetFactory fluxMessageChannelBindingTargetFactory(
+		CompositeMessageChannelConfigurer compositeMessageChannelConfigurer) {
+		return new FluxMessageChannelBindingTargetFactory(
+			compositeMessageChannelConfigurer);
 	}
 
 	@Bean

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/BindableFunctionProxyFactory.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/BindableFunctionProxyFactory.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.FactoryBean;
 import org.springframework.cloud.stream.binder.PollableMessageSource;
 import org.springframework.cloud.stream.binding.BindableProxyFactory;
 import org.springframework.cloud.stream.binding.BoundTargetHolder;
+import org.springframework.cloud.stream.binding.SupportedBindableFeatures;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.support.GenericApplicationContext;
@@ -60,7 +61,7 @@ public class BindableFunctionProxyFactory extends BindableProxyFactory implement
 	private GenericApplicationContext context;
 
 	BindableFunctionProxyFactory(String functionDefinition, int inputCount, int outputCount, StreamFunctionProperties functionProperties) {
-		this(functionDefinition, inputCount, outputCount, functionProperties, new SupportedBindableFeatures(false, false));
+		this(functionDefinition, inputCount, outputCount, functionProperties, new SupportedBindableFeatures());
 	}
 
 	BindableFunctionProxyFactory(String functionDefinition, int inputCount, int outputCount, StreamFunctionProperties functionProperties,

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/BindableFunctionProxyFactory.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/BindableFunctionProxyFactory.java
@@ -25,7 +25,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.integration.channel.FluxMessageChannel;
-import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.SubscribableChannel;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
@@ -179,7 +178,7 @@ public class BindableFunctionProxyFactory extends BindableProxyFactory implement
 		}
 		else {
 			this.outputHolders.put(name,
-				new BoundTargetHolder(getBindingTargetFactory(MessageChannel.class)
+				new BoundTargetHolder(getBindingTargetFactory(SubscribableChannel.class)
 					.createOutput(name), true));
 		}
 	}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/BindableFunctionProxyFactory.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/BindableFunctionProxyFactory.java
@@ -24,6 +24,7 @@ import org.springframework.cloud.stream.binding.BoundTargetHolder;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.integration.channel.FluxMessageChannel;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.SubscribableChannel;
 import org.springframework.util.Assert;
@@ -55,22 +56,22 @@ public class BindableFunctionProxyFactory extends BindableProxyFactory implement
 
 	private final StreamFunctionProperties functionProperties;
 
-	private final boolean pollable;
+	private final SupportedBindableFeatures supportedBindableFeatures;
 
 	private GenericApplicationContext context;
 
 	BindableFunctionProxyFactory(String functionDefinition, int inputCount, int outputCount, StreamFunctionProperties functionProperties) {
-		this(functionDefinition, inputCount, outputCount, functionProperties, false);
+		this(functionDefinition, inputCount, outputCount, functionProperties, new SupportedBindableFeatures(false, false));
 	}
 
 	BindableFunctionProxyFactory(String functionDefinition, int inputCount, int outputCount, StreamFunctionProperties functionProperties,
-			boolean pollable) {
+			SupportedBindableFeatures supportedBindableFeatures) {
 		super(null);
 		this.inputCount = inputCount;
 		this.outputCount = outputCount;
 		this.functionDefinition = functionDefinition;
 		this.functionProperties = functionProperties;
-		this.pollable = pollable;
+		this.supportedBindableFeatures = supportedBindableFeatures;
 	}
 
 	@Override
@@ -148,12 +149,17 @@ public class BindableFunctionProxyFactory extends BindableProxyFactory implement
 		if (this.functionProperties.getBindings().containsKey(name)) {
 			name = this.functionProperties.getBindings().get(name);
 		}
-		if (this.pollable) {
+		if (this.supportedBindableFeatures.isPollable()) {
 			PollableMessageSource pollableSource = (PollableMessageSource) getBindingTargetFactory(PollableMessageSource.class).createInput(name);
 			if (context != null && !context.containsBean(name)) {
 				context.registerBean(name, PollableMessageSource.class, () -> pollableSource);
 			}
 			this.inputHolders.put(name, new BoundTargetHolder(pollableSource, true));
+		}
+		else if (this.supportedBindableFeatures.isReactive()) {
+			this.inputHolders.put(name,
+				new BoundTargetHolder(getBindingTargetFactory(FluxMessageChannel.class)
+					.createInput(name), true));
 		}
 		else {
 			this.inputHolders.put(name,
@@ -166,9 +172,16 @@ public class BindableFunctionProxyFactory extends BindableProxyFactory implement
 		if (this.functionProperties.getBindings().containsKey(name)) {
 			name = this.functionProperties.getBindings().get(name);
 		}
-		this.outputHolders.put(name,
+		if (this.supportedBindableFeatures.isReactive()) {
+			this.outputHolders.put(name,
+				new BoundTargetHolder(getBindingTargetFactory(FluxMessageChannel.class)
+					.createOutput(name), true));
+		}
+		else {
+			this.outputHolders.put(name,
 				new BoundTargetHolder(getBindingTargetFactory(MessageChannel.class)
-						.createOutput(name), true));
+					.createOutput(name), true));
+		}
 	}
 
 	@Override

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
@@ -487,11 +487,8 @@ public class FunctionConfiguration {
 					}
 					MessageChannel inputChannel = null;
 					final String reactive = environment.getProperty("spring.cloud.stream.reactive");
-					if (StringUtils.hasText(reactive)) {
-						boolean reactiveFn = Boolean.parseBoolean(reactive);
-						if (reactiveFn) {
-							inputChannel = this.applicationContext.getBean(inputBindingName, FluxMessageChannel.class);
-						}
+					if (Boolean.parseBoolean(reactive)) {
+						inputChannel = this.applicationContext.getBean(inputBindingName, FluxMessageChannel.class);
 					}
 					else {
 						inputChannel = this.applicationContext.getBean(inputBindingName, SubscribableChannel.class);

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
@@ -88,7 +88,6 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.type.MethodMetadata;
 import org.springframework.integration.channel.AbstractMessageChannel;
 import org.springframework.integration.channel.AbstractSubscribableChannel;
-import org.springframework.integration.channel.FluxMessageChannel;
 import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlowBuilder;
@@ -485,14 +484,7 @@ public class FunctionConfiguration {
 								+ "consumer, given that project reactor maintains its own concurrency mechanism. Was '..."
 								+ inputBindingName + ".consumer.concurrency=" + consumerProperties.getConcurrency() + "'");
 					}
-					MessageChannel inputChannel = null;
-					final String reactive = environment.getProperty("spring.cloud.stream.reactive");
-					if (Boolean.parseBoolean(reactive)) {
-						inputChannel = this.applicationContext.getBean(inputBindingName, FluxMessageChannel.class);
-					}
-					else {
-						inputChannel = this.applicationContext.getBean(inputBindingName, SubscribableChannel.class);
-					}
+					MessageChannel inputChannel = this.applicationContext.getBean(inputBindingName, MessageChannel.class);
 					return IntegrationReactiveUtils.messageChannelToFlux(inputChannel).map(m -> {
 						if (m instanceof Message) {
 							m = sanitize(m);

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,6 +69,7 @@ import org.springframework.cloud.stream.binder.ConsumerProperties;
 import org.springframework.cloud.stream.binder.ProducerProperties;
 import org.springframework.cloud.stream.binding.BindableProxyFactory;
 import org.springframework.cloud.stream.binding.NewDestinationBindingCallback;
+import org.springframework.cloud.stream.binding.SupportedBindableFeatures;
 import org.springframework.cloud.stream.config.BinderFactoryAutoConfiguration;
 import org.springframework.cloud.stream.config.BindingProperties;
 import org.springframework.cloud.stream.config.BindingServiceConfiguration;
@@ -785,7 +786,10 @@ public class FunctionConfiguration {
 					functionBindableProxyDefinition.getConstructorArgumentValues().addGenericArgumentValue(1);
 					functionBindableProxyDefinition.getConstructorArgumentValues().addGenericArgumentValue(0);
 					functionBindableProxyDefinition.getConstructorArgumentValues().addGenericArgumentValue(new StreamFunctionProperties());
-					functionBindableProxyDefinition.getConstructorArgumentValues().addGenericArgumentValue(new SupportedBindableFeatures(true, false));
+					final SupportedBindableFeatures supportedBindableFeatures = new SupportedBindableFeatures();
+					supportedBindableFeatures.setPollable(true);
+					supportedBindableFeatures.setReactive(false);
+					functionBindableProxyDefinition.getConstructorArgumentValues().addGenericArgumentValue(supportedBindableFeatures);
 					((BeanDefinitionRegistry) beanFactory).registerBeanDefinition(sourceName + "_binding", functionBindableProxyDefinition);
 				}
 			}
@@ -853,7 +857,10 @@ public class FunctionConfiguration {
 						final Map<String, Boolean> reactiveFunctions = streamFunctionProperties.getReactive();
 						final boolean reactiveFn = reactiveFunctions.get(functionDefinition) != null;
 						if (reactiveFn) {
-							functionBindableProxyDefinition.getConstructorArgumentValues().addGenericArgumentValue(new SupportedBindableFeatures(false, true));
+							final SupportedBindableFeatures supportedBindableFeatures = new SupportedBindableFeatures();
+							supportedBindableFeatures.setPollable(false);
+							supportedBindableFeatures.setReactive(true);
+							functionBindableProxyDefinition.getConstructorArgumentValues().addGenericArgumentValue(supportedBindableFeatures);
 						}
 						registry.registerBeanDefinition(functionDefinition + "_binding", functionBindableProxyDefinition);
 					}

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/StreamFunctionProperties.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/StreamFunctionProperties.java
@@ -50,6 +50,8 @@ public class StreamFunctionProperties {
 
 	private boolean composeFrom;
 
+	private Map<String, Boolean> reactive = new HashMap<>();
+
 	public boolean isComposeTo() {
 		return composeTo;
 	}
@@ -110,5 +112,13 @@ public class StreamFunctionProperties {
 				.map(bKey -> bindings.get(bKey))
 				.collect(Collectors.toList());
 		return list;
+	}
+
+	public Map<String, Boolean> getReactive() {
+		return this.reactive;
+	}
+
+	public void setReactive(Map<String, Boolean> reactive) {
+		this.reactive = reactive;
 	}
 }

--- a/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/SupportedBindableFeatures.java
+++ b/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/SupportedBindableFeatures.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.function;
+
+/**
+ * Internal abstraction for the supported bindable features.
+ *
+ * @author Soby Chacko
+ * @since 4.0.0
+ */
+class SupportedBindableFeatures {
+
+	private final boolean pollable;
+
+	private final boolean reactive;
+
+	SupportedBindableFeatures(boolean pollable, boolean reactive) {
+		this.pollable = pollable;
+		this.reactive = reactive;
+	}
+
+	boolean isPollable() {
+		return pollable;
+	}
+
+	boolean isReactive() {
+		return reactive;
+	}
+}

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binding/FluxMessageChannelBindingTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binding/FluxMessageChannelBindingTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binding;
+
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.channel.FluxMessageChannel;
+import org.springframework.messaging.MessageChannel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Soby Chacko
+ */
+public class FluxMessageChannelBindingTests {
+
+	@Test
+	public void testFluxMessageChannelBindingWhenReactiveOptIn() {
+		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
+			TestChannelBinderConfiguration.getCompleteConfiguration(ReactiveFunctionConfiguration.class))
+			.web(WebApplicationType.NONE)
+			.run("--spring.jmx.enabled=false",
+				"--spring.cloud.stream.reactive=true")) {
+			assertThat(context.getBean("uppercase-in-0", MessageChannel.class)).isInstanceOf(FluxMessageChannel.class);
+			assertThat(context.getBean("uppercase-out-0", MessageChannel.class)).isInstanceOf(FluxMessageChannel.class);
+		}
+	}
+
+	@EnableAutoConfiguration
+	@Configuration
+	public static class ReactiveFunctionConfiguration {
+
+		@Bean
+		public Function<Flux<String>, Flux<String>> uppercase() {
+			return s -> s.map(String::toUpperCase);
+		}
+	}
+}

--- a/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binding/FluxMessageChannelBindingTests.java
+++ b/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binding/FluxMessageChannelBindingTests.java
@@ -44,7 +44,7 @@ public class FluxMessageChannelBindingTests {
 			TestChannelBinderConfiguration.getCompleteConfiguration(ReactiveFunctionConfiguration.class))
 			.web(WebApplicationType.NONE)
 			.run("--spring.jmx.enabled=false",
-				"--spring.cloud.stream.reactive=true")) {
+				"--spring.cloud.stream.function.reactive.uppercase=true")) {
 			assertThat(context.getBean("uppercase-in-0", MessageChannel.class)).isInstanceOf(FluxMessageChannel.class);
 			assertThat(context.getBean("uppercase-out-0", MessageChannel.class)).isInstanceOf(FluxMessageChannel.class);
 		}


### PR DESCRIPTION
 *  New binding target factory for FluxMessageChannel
 *  Introduce a new property to activate reactive binding -- spring.cloud.stream.reactive
 *  Refactoring BindableFunctionProxyFactory for FluxMessageChannel target binding
 *  Similar refactoring in FunctionConfiguration
 *  Test to verify FluxMessageChannel binding