### PR TITLE
GH-2307: Fix Problems with Rabbit Declarables

### DIFF
--- a/binders/rabbit-binder/spring-cloud-stream-binder-rabbit-core/pom.xml
+++ b/binders/rabbit-binder/spring-cloud-stream-binder-rabbit-core/pom.xml
@@ -36,6 +36,11 @@
 			<artifactId>spring-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-stream-binder-rabbit-test-support</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
     		<groupId>org.apache.httpcomponents</groupId>
     		<artifactId>httpclient</artifactId>
 		</dependency>

--- a/binders/rabbit-binder/spring-cloud-stream-binder-rabbit-core/src/test/java/org/springframework/cloud/stream/binder/rabbit/provisioning/RabbitExchangeQueueProvisionerTests.java
+++ b/binders/rabbit-binder/spring-cloud-stream-binder-rabbit-core/src/test/java/org/springframework/cloud/stream/binder/rabbit/provisioning/RabbitExchangeQueueProvisionerTests.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.rabbit.provisioning;
+
+import java.io.IOException;
+import java.util.Set;
+
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.impl.AMQImpl.Queue.DeclareOk;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.amqp.core.Declarable;
+import org.springframework.amqp.rabbit.connection.Connection;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.utils.test.TestUtils;
+import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
+import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
+import org.springframework.cloud.stream.binder.rabbit.properties.RabbitConsumerProperties;
+import org.springframework.cloud.stream.binder.rabbit.properties.RabbitProducerProperties;
+import org.springframework.cloud.stream.provisioning.ConsumerDestination;
+import org.springframework.cloud.stream.provisioning.ProducerDestination;
+import org.springframework.context.ApplicationContext;
+import org.springframework.expression.common.LiteralExpression;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Gary Russell
+ * @since 3.2.3
+ *
+ */
+public class RabbitExchangeQueueProvisionerTests {
+
+	@Test
+	void consumerDeclarationsWithDlq() throws IOException {
+		ConnectionFactory cf = mock(ConnectionFactory.class);
+		Connection conn = mock(Connection.class);
+		given(cf.createConnection()).willReturn(conn);
+		Channel channel = mock(Channel.class);
+		willReturn(new DeclareOk("x", 0, 0))
+				.given(channel).queueDeclare(any(), eq(Boolean.TRUE), eq(Boolean.FALSE), eq(Boolean.FALSE), any());
+		given(conn.createChannel(anyBoolean())).willReturn(channel);
+		RabbitExchangeQueueProvisioner provisioner = new RabbitExchangeQueueProvisioner(cf);
+
+		RabbitConsumerProperties props = new RabbitConsumerProperties();
+		props.setAutoBindDlq(true);
+		ExtendedConsumerProperties<RabbitConsumerProperties> properties =
+				new ExtendedConsumerProperties<RabbitConsumerProperties>(props);
+		ConsumerDestination dest = provisioner.provisionConsumerDestination("foo", "group", properties);
+		ApplicationContext ctx =
+				TestUtils.getPropertyValue(provisioner, "autoDeclareContext", ApplicationContext.class);
+		Set<String> declarables = ctx.getBeansOfType(Declarable.class).keySet();
+		assertThat(declarables).contains("foo.group.exchange", "foo.group", "foo.group.binding", "foo.group.dlq",
+				"DLX.group.exchange", "foo.group.dlq.binding", "foo.group.dlq.2.binding");
+		provisioner.cleanAutoDeclareContext(dest, properties);
+		assertThat(ctx.getBeansOfType(Declarable.class)).isEmpty();
+	}
+
+	@Test
+	void consumerDeclarationsWithDlqQueueNameIsGroup() throws IOException {
+		ConnectionFactory cf = mock(ConnectionFactory.class);
+		Connection conn = mock(Connection.class);
+		given(cf.createConnection()).willReturn(conn);
+		Channel channel = mock(Channel.class);
+		willReturn(new DeclareOk("x", 0, 0))
+				.given(channel).queueDeclare(any(), eq(Boolean.TRUE), eq(Boolean.FALSE), eq(Boolean.FALSE), any());
+		given(conn.createChannel(anyBoolean())).willReturn(channel);
+		RabbitExchangeQueueProvisioner provisioner = new RabbitExchangeQueueProvisioner(cf);
+
+		RabbitConsumerProperties props = new RabbitConsumerProperties();
+		props.setAutoBindDlq(true);
+		props.setQueueNameGroupOnly(true);
+		ExtendedConsumerProperties<RabbitConsumerProperties> properties =
+				new ExtendedConsumerProperties<RabbitConsumerProperties>(props);
+		ConsumerDestination dest = provisioner.provisionConsumerDestination("fiz", "group", properties);
+		ApplicationContext ctx =
+				TestUtils.getPropertyValue(provisioner, "autoDeclareContext", ApplicationContext.class);
+		Set<String> declarables = ctx.getBeansOfType(Declarable.class).keySet();
+		assertThat(declarables).contains("fiz.group.exchange", "group", "group.binding", "group.dlq",
+				"DLX.group.exchange", "group.dlq.binding", "group.dlq.2.binding");
+		provisioner.cleanAutoDeclareContext(dest, properties);
+		assertThat(ctx.getBeansOfType(Declarable.class)).isEmpty();
+	}
+
+	@Test
+	void producerDeclarationsNoGroups() throws IOException {
+		ConnectionFactory cf = mock(ConnectionFactory.class);
+		Connection conn = mock(Connection.class);
+		given(cf.createConnection()).willReturn(conn);
+		Channel channel = mock(Channel.class);
+		willReturn(new DeclareOk("x", 0, 0))
+				.given(channel).queueDeclare(any(), eq(Boolean.TRUE), eq(Boolean.FALSE), eq(Boolean.FALSE), any());
+		given(conn.createChannel(anyBoolean())).willReturn(channel);
+		RabbitExchangeQueueProvisioner provisioner = new RabbitExchangeQueueProvisioner(cf);
+
+		RabbitProducerProperties props = new RabbitProducerProperties();
+		ExtendedProducerProperties<RabbitProducerProperties> properties =
+				new ExtendedProducerProperties<RabbitProducerProperties>(props);
+		ProducerDestination dest = provisioner.provisionProducerDestination("bar", properties);
+		ApplicationContext ctx =
+				TestUtils.getPropertyValue(provisioner, "autoDeclareContext", ApplicationContext.class);
+		Set<String> declarables = ctx.getBeansOfType(Declarable.class).keySet();
+		String qual = TestUtils.getPropertyValue(dest, "beanNameQualifier", String.class);
+		assertThat(declarables).contains("bar." + qual + ".exchange");
+		provisioner.cleanAutoDeclareContext(dest, properties);
+		assertThat(ctx.getBeansOfType(Declarable.class)).isEmpty();
+	}
+
+	@Test
+	void producerDeclarationsWithGroupsAndDlq() throws IOException {
+		ConnectionFactory cf = mock(ConnectionFactory.class);
+		Connection conn = mock(Connection.class);
+		given(cf.createConnection()).willReturn(conn);
+		Channel channel = mock(Channel.class);
+		willReturn(new DeclareOk("x", 0, 0))
+				.given(channel).queueDeclare(any(), eq(Boolean.TRUE), eq(Boolean.FALSE), eq(Boolean.FALSE), any());
+		given(conn.createChannel(anyBoolean())).willReturn(channel);
+		RabbitExchangeQueueProvisioner provisioner = new RabbitExchangeQueueProvisioner(cf);
+
+		RabbitProducerProperties props = new RabbitProducerProperties();
+		props.setAutoBindDlq(true);
+		ExtendedProducerProperties<RabbitProducerProperties> properties =
+				new ExtendedProducerProperties<RabbitProducerProperties>(props);
+		properties.setRequiredGroups("group1", "group2");
+		ProducerDestination dest = provisioner.provisionProducerDestination("baz", properties);
+		ApplicationContext ctx =
+				TestUtils.getPropertyValue(provisioner, "autoDeclareContext", ApplicationContext.class);
+		Set<String> declarables = ctx.getBeansOfType(Declarable.class).keySet();
+		String qual = TestUtils.getPropertyValue(dest, "beanNameQualifier", String.class);
+		assertThat(declarables).contains("baz." + qual + ".exchange", "baz.group1", "baz.group1.binding",
+				"baz.group1.dlq", "DLX.group1.exchange", "baz.group1.dlq.binding", "baz.group2", "baz.group2.binding",
+				"baz.group2.dlq", "DLX.group2.exchange", "baz.group2.dlq.binding");
+		provisioner.cleanAutoDeclareContext(dest, properties);
+		assertThat(ctx.getBeansOfType(Declarable.class)).isEmpty();
+	}
+
+	@Test
+	void producerDeclarationsWithGroupsAndDlqAndPartitions() throws IOException {
+		ConnectionFactory cf = mock(ConnectionFactory.class);
+		Connection conn = mock(Connection.class);
+		given(cf.createConnection()).willReturn(conn);
+		Channel channel = mock(Channel.class);
+		willReturn(new DeclareOk("x", 0, 0))
+				.given(channel).queueDeclare(any(), eq(Boolean.TRUE), eq(Boolean.FALSE), eq(Boolean.FALSE), any());
+		given(conn.createChannel(anyBoolean())).willReturn(channel);
+		RabbitExchangeQueueProvisioner provisioner = new RabbitExchangeQueueProvisioner(cf);
+
+		RabbitProducerProperties props = new RabbitProducerProperties();
+		props.setAutoBindDlq(true);
+		ExtendedProducerProperties<RabbitProducerProperties> properties =
+				new ExtendedProducerProperties<RabbitProducerProperties>(props);
+		properties.setRequiredGroups("group1", "group2");
+		properties.setPartitionKeyExpression(new LiteralExpression("foo"));
+		properties.setPartitionCount(2);
+		ProducerDestination dest = provisioner.provisionProducerDestination("qux", properties);
+		ApplicationContext ctx =
+				TestUtils.getPropertyValue(provisioner, "autoDeclareContext", ApplicationContext.class);
+		Set<String> declarables = ctx.getBeansOfType(Declarable.class).keySet();
+		String qual = TestUtils.getPropertyValue(dest, "beanNameQualifier", String.class);
+		assertThat(declarables).contains("qux." + qual + ".exchange", "qux.group1-0", "qux.group1-0.binding",
+				"qux.group1-1", "qux.group1-1.binding", "qux.group1.dlq", "DLX.group1.exchange",
+				"qux.group1.dlq.binding", "qux.group2-0",
+				"qux.group2-0.binding", "qux.group2-1", "qux.group2-1.binding", "qux.group2.dlq", "DLX.group2.exchange",
+				"qux.group2.dlq.binding");
+		provisioner.cleanAutoDeclareContext(dest, properties);
+		assertThat(ctx.getBeansOfType(Declarable.class)).isEmpty();
+	}
+
+	@Test
+	void producerDeclarationsWithGroupsAndDlqAndPartitionsQueueNameIsGroup() throws IOException {
+		ConnectionFactory cf = mock(ConnectionFactory.class);
+		Connection conn = mock(Connection.class);
+		given(cf.createConnection()).willReturn(conn);
+		Channel channel = mock(Channel.class);
+		willReturn(new DeclareOk("x", 0, 0))
+				.given(channel).queueDeclare(any(), eq(Boolean.TRUE), eq(Boolean.FALSE), eq(Boolean.FALSE), any());
+		given(conn.createChannel(anyBoolean())).willReturn(channel);
+		RabbitExchangeQueueProvisioner provisioner = new RabbitExchangeQueueProvisioner(cf);
+
+		RabbitProducerProperties props = new RabbitProducerProperties();
+		props.setAutoBindDlq(true);
+		props.setQueueNameGroupOnly(true);
+		ExtendedProducerProperties<RabbitProducerProperties> properties =
+				new ExtendedProducerProperties<RabbitProducerProperties>(props);
+		properties.setRequiredGroups("group1", "group2");
+		properties.setPartitionKeyExpression(new LiteralExpression("foo"));
+		properties.setPartitionCount(2);
+		ProducerDestination dest = provisioner.provisionProducerDestination("qux", properties);
+		ApplicationContext ctx =
+				TestUtils.getPropertyValue(provisioner, "autoDeclareContext", ApplicationContext.class);
+		Set<String> declarables = ctx.getBeansOfType(Declarable.class).keySet();
+		String qual = TestUtils.getPropertyValue(dest, "beanNameQualifier", String.class);
+		assertThat(declarables).contains("qux." + qual + ".exchange", "group1-0", "group1-0.binding", "group1-1",
+				"group1-1.binding", "group1.dlq", "DLX.group1.exchange", "group1.dlq.binding", "group2-0",
+				"group2-0.binding", "group2-1", "group2-1.binding", "group2.dlq", "DLX.group2.exchange",
+				"group2.dlq.binding");
+		provisioner.cleanAutoDeclareContext(dest, properties);
+		assertThat(ctx.getBeansOfType(Declarable.class)).isEmpty();
+	}
+
+}

--- a/binders/rabbit-binder/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitMessageChannelBinder.java
+++ b/binders/rabbit-binder/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/RabbitMessageChannelBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -960,11 +960,18 @@ public class RabbitMessageChannelBinder extends
 	}
 
 	@Override
-	protected void afterUnbindConsumer(ConsumerDestination consumerDestination,
-			String group,
+	protected void afterUnbindConsumer(ConsumerDestination consumerDestination, String group,
 			ExtendedConsumerProperties<RabbitConsumerProperties> consumerProperties) {
-		provisioningProvider.cleanAutoDeclareContext(consumerDestination,
+
+		this.provisioningProvider.cleanAutoDeclareContext(consumerDestination,
 				consumerProperties);
+	}
+
+	@Override
+	protected void afterUnbindProducer(ProducerDestination destination,
+			ExtendedProducerProperties<RabbitProducerProperties> producerProperties) {
+
+		this.provisioningProvider.cleanAutoDeclareContext(destination, producerProperties);
 	}
 
 	private RabbitTemplate buildRabbitTemplate(RabbitProducerProperties properties, boolean mandatory) {

--- a/binders/rabbit-binder/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderTests.java
+++ b/binders/rabbit-binder/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitBinderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,7 @@ import org.springframework.amqp.core.AmqpTemplate;
 import org.springframework.amqp.core.AnonymousQueue;
 import org.springframework.amqp.core.Binding.DestinationType;
 import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Declarable;
 import org.springframework.amqp.core.DirectExchange;
 import org.springframework.amqp.core.ExchangeTypes;
 import org.springframework.amqp.core.MessageDeliveryMode;
@@ -241,6 +242,8 @@ public class RabbitBinderTests extends
 		assertThat(event.get()).isNotNull();
 		producerBinding.unbind();
 		consumerBinding.unbind();
+
+		verifyAutoDeclareContextClear(binder);
 	}
 
 	@Test
@@ -322,6 +325,8 @@ public class RabbitBinderTests extends
 		assertThat(nack.getCorrelationData()).isEqualTo(message);
 		assertThat(nack.getFailedMessage()).isEqualTo(message);
 		producerBinding.unbind();
+
+		verifyAutoDeclareContextClear(binder);
 	}
 
 	@Test
@@ -351,6 +356,8 @@ public class RabbitBinderTests extends
 		assertThat(confirmLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(confirm.get().getPayload()).isEqualTo("acksMessage".getBytes());
 		producerBinding.unbind();
+
+		verifyAutoDeclareContextClear(binder);
 	}
 
 	@Test
@@ -375,6 +382,8 @@ public class RabbitBinderTests extends
 		assertThat(confirm.isAck()).isTrue();
 		assertThat(correlation.getReturnedMessage()).isNotNull();
 		producerBinding.unbind();
+
+		verifyAutoDeclareContextClear(binder);
 	}
 
 	@Test
@@ -454,6 +463,8 @@ public class RabbitBinderTests extends
 
 		consumerBinding.unbind();
 		assertThat(endpoint.isRunning()).isFalse();
+
+		verifyAutoDeclareContextClear(binder);
 	}
 
 	@Test
@@ -543,7 +554,10 @@ public class RabbitBinderTests extends
 		assertThat(container.isRunning()).isTrue();
 		consumerBinding.unbind();
 		assertThat(container.isRunning()).isFalse();
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@Test
 	public void testAnonWithBuiltInExchangeCustomPrefix() throws Exception {
@@ -563,7 +577,10 @@ public class RabbitBinderTests extends
 		assertThat(container.isRunning()).isTrue();
 		consumerBinding.unbind();
 		assertThat(container.isRunning()).isFalse();
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@Test
 	public void testConsumerPropertiesWithUserInfrastructureCustomExchangeAndRK()
@@ -611,7 +628,10 @@ public class RabbitBinderTests extends
 		assertThat(exchange.getType()).isEqualTo("direct");
 		assertThat(exchange.isDurable()).isEqualTo(true);
 		assertThat(exchange.isAutoDelete()).isEqualTo(false);
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@Test
 	public void testConsumerPropertiesWithUserInfrastructureCustomQueueArgs()
@@ -738,7 +758,10 @@ public class RabbitBinderTests extends
 
 		consumerBinding.unbind();
 		assertThat(container.isRunning()).isFalse();
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@Test
 	public void testConsumerPropertiesWithHeaderExchanges() throws Exception {
@@ -788,7 +811,10 @@ public class RabbitBinderTests extends
 		assertThat(bindings.get(0).getDestination()).isEqualTo("propsHeader." + group + ".dlq");
 		assertThat(bindings.get(0).getArguments()).hasEntrySatisfying("x-match", v -> assertThat(v).isEqualTo("any"));
 		assertThat(bindings.get(0).getArguments()).hasEntrySatisfying("foo", v -> assertThat(v).isEqualTo("bar"));
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@Test
 	public void testProducerProperties(TestInfo testInfo) throws Exception {
@@ -863,7 +889,10 @@ public class RabbitBinderTests extends
 
 		producerBinding.unbind();
 		assertThat(endpoint.isRunning()).isFalse();
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@Test
 	public void testDurablePubSubWithAutoBindDLQ() throws Exception {
@@ -909,7 +938,10 @@ public class RabbitBinderTests extends
 		consumerBinding.unbind();
 		assertThat(admin.getQueueProperties(TEST_PREFIX + "durabletest.0.tgroup.dlq"))
 				.isNotNull();
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@Test
 	public void testNonDurablePubSubWithAutoBindDLQ() throws Exception {
@@ -940,7 +972,10 @@ public class RabbitBinderTests extends
 		consumerBinding.unbind();
 		assertThat(admin.getQueueProperties(TEST_PREFIX + "nondurabletest.0.dlq"))
 				.isNull();
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@Test
 	public void testAutoBindDLQ() throws Exception {
@@ -1012,7 +1047,10 @@ public class RabbitBinderTests extends
 		assertThat(context.containsBean(TEST_PREFIX + "dlqtest.default.dlq.binding"))
 				.isFalse();
 		assertThat(context.containsBean(TEST_PREFIX + "dlqtest.default.dlq")).isFalse();
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@Test
 	public void testAutoBindDLQManualAcks() throws Exception {
@@ -1087,7 +1125,10 @@ public class RabbitBinderTests extends
 		assertThat(context.containsBean(TEST_PREFIX + "dlqTestManual.default.dlq.binding"))
 				.isFalse();
 		assertThat(context.containsBean(TEST_PREFIX + "dlqTestManual.default.dlq")).isFalse();
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@Test
 	public void testAutoBindDLQPartionedConsumerFirst(TestInfo testInfo) throws Exception {
@@ -1189,7 +1230,10 @@ public class RabbitBinderTests extends
 		defaultConsumerBinding1.unbind();
 		defaultConsumerBinding2.unbind();
 		outputBinding.unbind();
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@Test
 	@Disabled
@@ -1347,6 +1391,8 @@ public class RabbitBinderTests extends
 		defaultConsumerBinding1.unbind();
 		defaultConsumerBinding2.unbind();
 		outputBinding.unbind();
+
+		verifyAutoDeclareContextClear(binder);
 	}
 
 	@Test
@@ -1451,7 +1497,10 @@ public class RabbitBinderTests extends
 		defaultConsumerBinding1.unbind();
 		defaultConsumerBinding2.unbind();
 		outputBinding.unbind();
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@Test
 	public void testAutoBindDLQwithRepublish() throws Exception {
@@ -1519,7 +1568,10 @@ public class RabbitBinderTests extends
 		assertThat(template.receive(TEST_PREFIX + "foo.dlqpubtest2.foo.dlq")).isNull();
 
 		consumerBinding.unbind();
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@SuppressWarnings("unchecked")
 	@Test
@@ -1565,7 +1617,10 @@ public class RabbitBinderTests extends
 		assertThat(TestUtils.getPropertyValue(errorHandler.get(0), "confirmType", ConfirmType.class))
 				.isEqualTo(ConfirmType.NONE);
 		consumerBinding.unbind();
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@SuppressWarnings("unchecked")
 	@Test
@@ -1613,7 +1668,10 @@ public class RabbitBinderTests extends
 		assertThat(TestUtils.getPropertyValue(errorHandler.get(0), "confirmType", ConfirmType.class))
 				.isEqualTo(ConfirmType.SIMPLE);
 		consumerBinding.unbind();
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@SuppressWarnings("unchecked")
 	@Test
@@ -1661,7 +1719,10 @@ public class RabbitBinderTests extends
 		assertThat(TestUtils.getPropertyValue(errorHandler.get(0), "confirmType", ConfirmType.class))
 				.isEqualTo(ConfirmType.CORRELATED);
 		consumerBinding.unbind();
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@SuppressWarnings("unchecked")
 	@Test
@@ -1723,7 +1784,10 @@ public class RabbitBinderTests extends
 
 		producerBinding.unbind();
 		consumerBinding.unbind();
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@SuppressWarnings("unchecked")
 	@Test
@@ -1765,7 +1829,10 @@ public class RabbitBinderTests extends
 
 		producerBinding.unbind();
 		consumerBinding.unbind();
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@SuppressWarnings("unchecked")
 	@Test
@@ -1803,7 +1870,10 @@ public class RabbitBinderTests extends
 
 		producerBinding.unbind();
 		consumerBinding.unbind();
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@SuppressWarnings("unchecked")
 	@Test
@@ -1842,7 +1912,10 @@ public class RabbitBinderTests extends
 		producerBinding.unbind();
 		consumerBinding.unbind();
 		admin.deleteQueue("propagate");
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	/*
 	 * Test late binding due to broker down; queues with and without DLQs, and partitioned
@@ -1980,7 +2053,10 @@ public class RabbitBinderTests extends
 		cf.destroy();
 
 		this.rabbitAvailableRule.getResource().destroy();
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@Test
 	public void testBadUserDeclarationsFatal() throws Exception {
@@ -2019,7 +2095,10 @@ public class RabbitBinderTests extends
 				binding.unbind();
 			}
 		}
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@Test
 	public void testRoutingKeyExpression(TestInfo testInfo) throws Exception {
@@ -2062,7 +2141,10 @@ public class RabbitBinderTests extends
 				.isEqualTo("{\"field\":\"rkeTest\"}");
 
 		producerBinding.unbind();
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@Test
 	public void testRoutingKey(TestInfo testInfo) throws Exception {
@@ -2094,7 +2176,10 @@ public class RabbitBinderTests extends
 
 
 		producerBinding.unbind();
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@Test
 	public void testRoutingKeyExpressionPartitionedAndDelay(TestInfo testInfo) throws Exception {
@@ -2145,7 +2230,10 @@ public class RabbitBinderTests extends
 				.isEqualTo("{\"field\":\"rkepTest\"}");
 
 		producerBinding.unbind();
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@Test
 	public void testPolledConsumer() throws Exception {
@@ -2168,7 +2256,10 @@ public class RabbitBinderTests extends
 		}
 		assertThat(polled).isTrue();
 		binding.unbind();
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@Test
 	public void testPolledConsumerRequeue() throws Exception {
@@ -2199,7 +2290,10 @@ public class RabbitBinderTests extends
 		});
 		assertThat(polled).isTrue();
 		binding.unbind();
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@Test
 	public void testPolledConsumerWithDlq() throws Exception {
@@ -2233,7 +2327,10 @@ public class RabbitBinderTests extends
 				.receive("pollableDlq.group.dlq", 10_000);
 		assertThat(deadLetter).isNotNull();
 		binding.unbind();
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@Test
 	public void testPolledConsumerWithDlqNoRetry() throws Exception {
@@ -2265,7 +2362,10 @@ public class RabbitBinderTests extends
 				.receive("pollableDlqNoRetry.group.dlq", 10_000);
 		assertThat(deadLetter).isNotNull();
 		binding.unbind();
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@Test
 	public void testPolledConsumerWithDlqRePub() throws Exception {
@@ -2295,7 +2395,10 @@ public class RabbitBinderTests extends
 				.receive("pollableDlqRePub.group.dlq", 10_000);
 		assertThat(deadLetter).isNotNull();
 		binding.unbind();
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	@Test
 	public void testCustomBatchingStrategy(TestInfo testInfo) throws Exception {
@@ -2332,7 +2435,10 @@ public class RabbitBinderTests extends
 		assertThat(new String((byte[]) out)).isEqualTo("0\u0000\n1\u0000\n2\u0000\n3\u0000\n4\u0000\n");
 
 		producerBinding.unbind();
+
+		verifyAutoDeclareContextClear(binder);
 	}
+
 
 	private SimpleMessageListenerContainer verifyContainer(Lifecycle endpoint) {
 		SimpleMessageListenerContainer container;
@@ -2445,6 +2551,13 @@ public class RabbitBinderTests extends
 		PrintWriter printWriter = new PrintWriter(stringWriter, true);
 		cause.printStackTrace(printWriter);
 		return stringWriter.getBuffer().toString();
+	}
+
+	private void verifyAutoDeclareContextClear(RabbitTestBinder binder) {
+		ApplicationContext ctx =
+				TestUtils.getPropertyValue(binder, "binder.provisioningProvider.autoDeclareContext",
+						ApplicationContext.class);
+		assertThat(ctx.getBeansOfType(Declarable.class)).isEmpty();
 	}
 
 	public static class TestPartitionKeyExtractorClass


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-stream/issues/2307

- when creating `Declarables` beans for redeclaration after a connetion failure
  2 DLX/DLQ bindings used the same bean name so the second one was never recovered/
- removing consumer `Declarable` beans from the `autoDeclareContext` was incomplete
- removing producer `Declarable` beans was not performed at all

- fix bean names; fix cleanup; add tests for all config scenarios
- check cleanup in all `RabbitBinderTests`

**cherry-pick to 3.2.x when the mono repo is established**