### PR TITLE
Change compression level to integer and only set if not null. Resolve…

### DIFF
--- a/binders/rabbit-binder/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitBinderConfigurationProperties.java
+++ b/binders/rabbit-binder/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitBinderConfigurationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /**
  * @author David Turanski
  * @author Gary Russell
+ * @author Ben Blinebury
  */
 @ConfigurationProperties(prefix = "spring.cloud.stream.rabbit.binder")
 public class RabbitBinderConfigurationProperties {
@@ -38,7 +39,7 @@ public class RabbitBinderConfigurationProperties {
 	/**
 	 * Compression level for compressed bindings; see 'java.util.zip.Deflator'.
 	 */
-	private int compressionLevel;
+	private Integer compressionLevel;
 
 	/**
 	 * Prefix for connection names from this binder.
@@ -76,11 +77,11 @@ public class RabbitBinderConfigurationProperties {
 		this.nodes = nodes;
 	}
 
-	public int getCompressionLevel() {
+	public Integer getCompressionLevel() {
 		return compressionLevel;
 	}
 
-	public void setCompressionLevel(int compressionLevel) {
+	public void setCompressionLevel(Integer compressionLevel) {
 		this.compressionLevel = compressionLevel;
 	}
 

--- a/binders/rabbit-binder/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitMessageChannelBinderConfiguration.java
+++ b/binders/rabbit-binder/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitMessageChannelBinderConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,7 @@ import org.springframework.lang.Nullable;
  * @author Artem Bilan
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Ben Blinebury
  */
 @Configuration
 @Import({ PropertyPlaceholderAutoConfiguration.class })
@@ -112,8 +113,11 @@ public class RabbitMessageChannelBinderConfiguration {
 	@Bean
 	MessagePostProcessor gZipPostProcessor() {
 		GZipPostProcessor gZipPostProcessor = new GZipPostProcessor();
-		gZipPostProcessor
-				.setLevel(this.rabbitBinderConfigurationProperties.getCompressionLevel());
+
+		if (this.rabbitBinderConfigurationProperties.getCompressionLevel() != null) {
+			gZipPostProcessor.setLevel(this.rabbitBinderConfigurationProperties.getCompressionLevel());
+		}
+
 		return gZipPostProcessor;
 	}
 


### PR DESCRIPTION
…s https://github.com/spring-cloud/spring-cloud-stream/issues/2328

In this commit we changed the compression level to an Integer from an int and only set in the configuration if it is not null, as per https://github.com/spring-cloud/spring-cloud-stream/issues/2328.

Thanks for taking time to look at it!