### PR TITLE
Binding name as a consumer/producer property

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
@@ -1157,7 +1157,7 @@ public class KafkaBinderTests extends
 			assertThat(receivedMessage.getHeaders()
 					.get(KafkaMessageChannelBinder.X_EXCEPTION_FQCN)).isNotNull();
 			assertThat(receivedMessage.getHeaders()
-					.get(KafkaHeaders.RECEIVED_KEY)).isEqualTo(expectedDlqPartition);
+					.get(KafkaHeaders.RECEIVED_PARTITION)).isEqualTo(expectedDlqPartition);
 		}
 		else if (!HeaderMode.none.equals(headerMode)) {
 			assertThat(handler.getInvocationCount())
@@ -1205,7 +1205,7 @@ public class KafkaBinderTests extends
 					.get(KafkaMessageChannelBinder.X_EXCEPTION_FQCN)).isNotNull();
 
 			assertThat(receivedMessage.getHeaders()
-					.get(KafkaHeaders.RECEIVED_KEY)).isEqualTo(expectedDlqPartition);
+					.get(KafkaHeaders.RECEIVED_PARTITION)).isEqualTo(expectedDlqPartition);
 		}
 		else {
 			assertThat(receivedMessage.getHeaders()

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ConsumerProperties.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ConsumerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,11 @@ import org.springframework.messaging.Message;
  */
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 public class ConsumerProperties {
+
+	/**
+	 * Binding name for this consumer binding.
+	 */
+	private String bindingName;
 
 	/**
 	 * Signals if this consumer needs to be started automatically.
@@ -174,6 +179,19 @@ public class ConsumerProperties {
 	 * @since 3.0
 	 */
 	private boolean batchMode;
+
+	public String getBindingName() {
+		return bindingName;
+	}
+
+	/**
+	 * This method is not intended as a configuration property to set by the applications.
+	 * Therefore, we are not providing a proper setter method for this.
+	 * @param bindingName binding name populated by the framework.
+	 */
+	public void populateBindingName(String bindingName) {
+		this.bindingName = bindingName;
+	}
 
 	public String getRetryTemplateName() {
 		return retryTemplateName;

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ProducerProperties.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ProducerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,11 @@ import org.springframework.expression.Expression;
 public class ProducerProperties {
 
 	/**
+	 * Binding name for this producer binding.
+	 */
+	private String bindingName;
+
+	/**
 	 * Signals if this producer needs to be started automatically. Default: true
 	 */
 	private boolean autoStartup = true;
@@ -76,6 +81,19 @@ public class ProducerProperties {
 	private boolean errorChannelEnabled = false;
 
 	private PollerProperties poller;
+
+	public String getBindingName() {
+		return bindingName;
+	}
+
+	/**
+	 * This method is not intended as a configuration property to set by the applications.
+	 * Therefore, we are not providing a proper setter method for this.
+	 * @param bindingName binding name populated by the framework.
+	 */
+	public void populateBindingName(String bindingName) {
+		this.bindingName = bindingName;
+	}
 
 	public Expression getPartitionKeyExpression() {
 		return this.partitionKeyExpression;

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindingService.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindingService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -116,7 +116,7 @@ public class BindingService {
 
 			consumerProperties = extendedConsumerProperties;
 		}
-
+		consumerProperties.populateBindingName(inputName);
 		validate(consumerProperties);
 
 		String bindingTarget = this.bindingServiceProperties
@@ -288,6 +288,7 @@ public class BindingService {
 
 			producerProperties = extendedProducerProperties;
 		}
+		producerProperties.populateBindingName(outputName);
 		validate(producerProperties);
 		Binding<T> binding = doBindProducer(output, bindingTarget, binder,
 				producerProperties);

--- a/core/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binding/BindingServiceTests.java
+++ b/core/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binding/BindingServiceTests.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
@@ -538,6 +539,20 @@ public class BindingServiceTests {
 		assertThat(inputBinding.isRunning()).isFalse();
 	}
 
+	@SuppressWarnings("unchecked")
+	@Test
+	void testBindingNameAsTopLevelProperty() throws Exception {
+		ApplicationContext context = new SpringApplicationBuilder(BarConfiguration.class)
+			.web(WebApplicationType.NONE).run();
+
+		final BindingServiceProperties bindingServiceProperties = context.getBean(BindingServiceProperties.class);
+
+		final ConsumerProperties consumerProperties = bindingServiceProperties.getConsumerProperties("myFunction-in-0");
+		assertThat(consumerProperties.getBindingName()).isEqualTo("myFunction-in-0");
+		final ProducerProperties producerProperties = bindingServiceProperties.getProducerProperties("myFunction-out-0");
+		assertThat(producerProperties.getBindingName()).isEqualTo("myFunction-out-0");
+	}
+
 	private DefaultBinderFactory createMockBinderFactory() {
 		BinderTypeRegistry binderTypeRegistry = createMockBinderTypeRegistry();
 		return new DefaultBinderFactory(
@@ -576,6 +591,17 @@ public class BindingServiceTests {
 		@Bean("input")
 		public Consumer<Message<?>> log() {
 			return System.out::println;
+		}
+
+	}
+
+	@Import(TestChannelBinderConfiguration.class)
+	@EnableAutoConfiguration
+	public static class BarConfiguration {
+
+		@Bean
+		public Function<String, String> myFunction() {
+			return s -> s;
 		}
 
 	}


### PR DESCRIPTION
Make binding names available through Consumer/Producer properties.
Currently, the binders use a ThreadLocal to store the binding name for internal use.
These changes introduce the binding name as a property for both producer/consumer bindings.

Resolves https://github.com/spring-cloud/spring-cloud-stream/issues/2380