### PR TITLE
Make confluent-schema-registry-integration sample poms consistent

### DIFF
--- a/samples/confluent-schema-registry-integration/confluent-schema-registry-integration-consumer/pom.xml
+++ b/samples/confluent-schema-registry-integration/confluent-schema-registry-integration-consumer/pom.xml
@@ -6,7 +6,7 @@
     <version>4.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>confluent-schema-registry-integration-consumer</name>
-    <description>Schema Registry Consumer</description>
+    <description>Confluent Schema Registry Consumer</description>
 
 	<parent>
 		<groupId>org.springframework.cloud</groupId>

--- a/samples/confluent-schema-registry-integration/confluent-schema-registry-integration-consumer/pom.xml
+++ b/samples/confluent-schema-registry-integration/confluent-schema-registry-integration-consumer/pom.xml
@@ -15,6 +15,10 @@
 	</parent>
 
     <dependencies>
+	    <dependency>
+		    <groupId>org.springframework.boot</groupId>
+		    <artifactId>spring-boot-starter-web</artifactId>
+	    </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-stream-binder-kafka</artifactId>

--- a/samples/confluent-schema-registry-integration/confluent-schema-registry-integration-consumer/pom.xml
+++ b/samples/confluent-schema-registry-integration/confluent-schema-registry-integration-consumer/pom.xml
@@ -14,42 +14,6 @@
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
-    <dependencies>
-	    <dependency>
-		    <groupId>org.springframework.boot</groupId>
-		    <artifactId>spring-boot-starter-web</artifactId>
-	    </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-stream-binder-kafka</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.avro</groupId>
-            <artifactId>avro</artifactId>
-            <version>${avro.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-avro-serializer</artifactId>
-            <version>${confluent.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-schema-registry-client</artifactId>
-            <version>${confluent.version}</version>
-        </dependency>
-    </dependencies>
-
 	<build>
 		<plugins>
 			<plugin>

--- a/samples/confluent-schema-registry-integration/confluent-schema-registry-integration-producer1/pom.xml
+++ b/samples/confluent-schema-registry-integration/confluent-schema-registry-integration-producer1/pom.xml
@@ -17,22 +17,18 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-actuator</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.avro</groupId>
-            <artifactId>avro</artifactId>
-            <version>${avro.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-stream-binder-kafka</artifactId>
         </dependency>
-        <dependency>
+	    <dependency>
+		    <groupId>org.apache.avro</groupId>
+		    <artifactId>avro</artifactId>
+		    <version>${avro.version}</version>
+	    </dependency>
+	    <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
             <version>${confluent.version}</version>

--- a/samples/confluent-schema-registry-integration/confluent-schema-registry-integration-producer1/pom.xml
+++ b/samples/confluent-schema-registry-integration/confluent-schema-registry-integration-producer1/pom.xml
@@ -14,42 +14,6 @@
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-stream-binder-kafka</artifactId>
-        </dependency>
-	    <dependency>
-		    <groupId>org.apache.avro</groupId>
-		    <artifactId>avro</artifactId>
-		    <version>${avro.version}</version>
-	    </dependency>
-	    <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-avro-serializer</artifactId>
-            <version>${confluent.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-schema-registry-client</artifactId>
-            <version>${confluent.version}</version>
-        </dependency>
-    </dependencies>
-
 	<build>
 		<plugins>
 			<plugin>

--- a/samples/confluent-schema-registry-integration/confluent-schema-registry-integration-producer1/pom.xml
+++ b/samples/confluent-schema-registry-integration/confluent-schema-registry-integration-producer1/pom.xml
@@ -6,7 +6,7 @@
     <version>4.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>confluent-schema-registry-integration-producer1</name>
-    <description>Schema Registry Producer1</description>
+    <description>Confluent Schema Registry Producer1</description>
 
 	<parent>
 		<groupId>org.springframework.cloud</groupId>

--- a/samples/confluent-schema-registry-integration/confluent-schema-registry-integration-producer2/pom.xml
+++ b/samples/confluent-schema-registry-integration/confluent-schema-registry-integration-producer2/pom.xml
@@ -6,7 +6,7 @@
     <version>4.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>confluent-schema-registry-integration-producer2</name>
-    <description>Schema Registry Producer2</description>
+    <description>Confluent Schema Registry Producer2</description>
 
 	<parent>
 		<groupId>org.springframework.cloud</groupId>

--- a/samples/confluent-schema-registry-integration/confluent-schema-registry-integration-producer2/pom.xml
+++ b/samples/confluent-schema-registry-integration/confluent-schema-registry-integration-producer2/pom.xml
@@ -17,21 +17,17 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-actuator</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.avro</groupId>
-            <artifactId>avro</artifactId>
-            <version>${avro.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-stream-binder-kafka</artifactId>
         </dependency>
+	    <dependency>
+		    <groupId>org.apache.avro</groupId>
+		    <artifactId>avro</artifactId>
+		    <version>${avro.version}</version>
+	    </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>

--- a/samples/confluent-schema-registry-integration/confluent-schema-registry-integration-producer2/pom.xml
+++ b/samples/confluent-schema-registry-integration/confluent-schema-registry-integration-producer2/pom.xml
@@ -14,42 +14,6 @@
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-stream-binder-kafka</artifactId>
-        </dependency>
-	    <dependency>
-		    <groupId>org.apache.avro</groupId>
-		    <artifactId>avro</artifactId>
-		    <version>${avro.version}</version>
-	    </dependency>
-        <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-avro-serializer</artifactId>
-            <version>${confluent.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-schema-registry-client</artifactId>
-            <version>${confluent.version}</version>
-        </dependency>
-    </dependencies>
-
 	<build>
 		<plugins>
 			<plugin>

--- a/samples/confluent-schema-registry-integration/pom.xml
+++ b/samples/confluent-schema-registry-integration/pom.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.springframework.cloud</groupId>
 	<artifactId>confluent-schema-registry-integration</artifactId>
 	<version>4.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>confluent-schema-registry-integration</name>
-	<description>confluent-schema-registry-integration</description>
+	<description>Confluent Schema Registry Integration Sample App</description>
 
 	<parent>
 		<groupId>org.springframework.cloud</groupId>

--- a/samples/confluent-schema-registry-integration/pom.xml
+++ b/samples/confluent-schema-registry-integration/pom.xml
@@ -14,9 +14,9 @@
 	</parent>
 
 	<modules>
+		<module>confluent-schema-registry-integration-consumer</module>
 		<module>confluent-schema-registry-integration-producer1</module>
 		<module>confluent-schema-registry-integration-producer2</module>
-		<module>confluent-schema-registry-integration-consumer</module>
 	</modules>
 
 	<build>
@@ -57,6 +57,42 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-stream-binder-kafka</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.avro</groupId>
+			<artifactId>avro</artifactId>
+			<version>${avro.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.confluent</groupId>
+			<artifactId>kafka-avro-serializer</artifactId>
+			<version>${confluent.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>io.confluent</groupId>
+			<artifactId>kafka-schema-registry-client</artifactId>
+			<version>${confluent.version}</version>
+		</dependency>
+	</dependencies>
 
 	<repositories>
 		<repository>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -5,7 +5,7 @@
 	<artifactId>spring-cloud-stream-samples-parent</artifactId>
 	<version>4.0.0-SNAPSHOT</version>
 	<name>spring-cloud-stream-samples</name>
-	<description>spring-cloud-stream-samples-parent</description>
+	<description>Spring Cloud Stream Sample Apps</description>
 	<packaging>pom</packaging>
 
 	<parent>
@@ -18,7 +18,7 @@
 	<properties>
 		<avro.version>1.11.0</avro.version>
 		<confluent.version>7.0.1</confluent.version>
-		<spring-cloud.version>2022.0.0-SNAPSHOT</spring-cloud.version>
+		<spring-cloud.version>2022.0.3-SNAPSHOT</spring-cloud.version>
 	</properties>
 
 	<modules>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -18,7 +18,7 @@
 	<properties>
 		<avro.version>1.11.0</avro.version>
 		<confluent.version>7.0.1</confluent.version>
-		<spring-cloud.version>2022.0.3-SNAPSHOT</spring-cloud.version>
+		<spring-cloud.version>2022.0.0-SNAPSHOT</spring-cloud.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
@sobychacko I noticed when review the Kafka native sample that the Confluent schema registry sample was a bit inconsistent. I believe the original PR had the `avro-samples` intermediate level pom removed for simplicity and I think this may have been a "miss" from that. 

Anyways, comments inline. 