### PR TITLE
Fix compile error in LocalstackContainerTest

### DIFF
--- a/binders/kinesis-binder/spring-cloud-stream-binder-kinesis/src/test/java/org/springframework/cloud/stream/binder/kinesis/LocalstackContainerTest.java
+++ b/binders/kinesis-binder/spring-cloud-stream-binder-kinesis/src/test/java/org/springframework/cloud/stream/binder/kinesis/LocalstackContainerTest.java
@@ -29,8 +29,6 @@ import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
-
-import org.springframework.integration.test.util.TestUtils;
 /**
  *
  * @author Artem Bilan
@@ -43,7 +41,7 @@ public interface LocalstackContainerTest {
 
 	@Container
 	LocalStackContainer localStack =
-			new LocalStackContainer(DockerImageName.parse(TestUtils.dockerRegistryFromEnv() + "localstack/localstack"))
+			new LocalStackContainer(DockerImageName.parse("localstack/localstack"))
 					.withServices(
 							LocalStackContainer.Service.DYNAMODB,
 							LocalStackContainer.Service.KINESIS,


### PR DESCRIPTION
This fixes the compile error introduced by removal of TestUtils method in https://github.com/spring-projects/spring-integration/commit/ed6f26104fea8a76ea03cad72d85050324c409e8
