### PR TITLE
StreamBridge resolveDestination considers binderName in cache hit

### DIFF
--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/StreamBridge.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/StreamBridge.java
@@ -271,7 +271,12 @@ public final class StreamBridge implements SmartInitializingSingleton {
 
 	@SuppressWarnings({ "unchecked"})
 	synchronized MessageChannel resolveDestination(String destinationName, ProducerProperties producerProperties, String binderName) {
-		MessageChannel messageChannel = this.channelCache.get(destinationName);
+		MessageChannel messageChannel = null;
+		if (StringUtils.hasText(binderName)) {
+			messageChannel = this.channelCache.get(binderName + " " + destinationName);
+		} else {
+			messageChannel = this.channelCache.get(destinationName);
+		}
 		if (messageChannel == null) {
 			if (this.applicationContext.containsBean(destinationName)) {
 				messageChannel = this.applicationContext.getBean(destinationName, MessageChannel.class);
@@ -299,7 +304,11 @@ public final class StreamBridge implements SmartInitializingSingleton {
 				this.addInterceptors((AbstractMessageChannel) messageChannel, destinationName);
 
 				this.bindingService.bindProducer(messageChannel, destinationName, false, binder);
-				this.channelCache.put(destinationName, messageChannel);
+				if (StringUtils.hasText(binderName)) {
+					this.channelCache.put(binderName + " " + destinationName, messageChannel);
+				} else {
+					this.channelCache.put(destinationName, messageChannel);
+				}
 			}
 		}
 


### PR DESCRIPTION
When binderName is specified use it as part of the cache lookup for the MessageChannel.
Reference app https://github.com/waroir20/kafka-serializer-publisher.git (main) has example where multiple binders are used potentially for the same topic.
Using debugger to add to the cache and lookup from the cache allows application to publish as expected.