### PR TITLE
Producer config customization and DLQ issues

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -1094,10 +1094,11 @@ public class KafkaMessageChannelBinder extends
 					.getDlqProducerProperties();
 			KafkaAwareTransactionManager<byte[], byte[]> transMan = transactionManager(
 					properties.getExtension().getTransactionManager());
+			final ExtendedProducerProperties<KafkaProducerProperties> producerProperties = new ExtendedProducerProperties<>(dlqProducerProperties);
+			producerProperties.populateBindingName(properties.getBindingName());
 			ProducerFactory<?, ?> producerFactory = transMan != null
 					? transMan.getProducerFactory()
-					: getProducerFactory(null,
-							new ExtendedProducerProperties<>(dlqProducerProperties),
+					: getProducerFactory(null, producerProperties,
 							destination.getName() + ".dlq.producer", destination.getName());
 			final KafkaTemplate<?, ?> kafkaTemplate = new KafkaTemplate<>(
 					producerFactory);


### PR DESCRIPTION
When DLQ is enabled on a consumer binding, the internal producer properties
used by the DLQ mechanism to send to the topic is not populated with the
correct binding name. In the previous version, it was working fine since
we were relying on a ThreadLocal. This is revamped recently to properly
introduce a binding name as a top level property in ProducerProperties.
However, this was not set on the internal producer properties used by the
DLQ. This PR addresses this issue.

Resolves https://github.com/spring-cloud/spring-cloud-stream/issues/2417