### PR TITLE
Fix typo for kafka-streams documentation

### DIFF
--- a/docs/src/main/asciidoc/kafka/kafka-streams.adoc
+++ b/docs/src/main/asciidoc/kafka/kafka-streams.adoc
@@ -355,12 +355,12 @@ Even without the functional composition support in the binder, you can compose t
 
 ```
 @Bean
-pubic Funcion<KStream<String, String>, KStream<String, Long>> composed() {
+public Function<KStream<String, String>, KStream<String, Long>> composed() {
     foo().andThen(bar());
 }
 ```
 
-Then you can provide deefinitions of the form `spring.cloud.stream.function.definition=foo;bar;composed`.
+Then you can provide definitions of the form `spring.cloud.stream.function.definition=foo;bar;composed`.
 With the functional composition support in the binder, you don't need to write this third function in which you are doing explicit function composition.
 
 You can simply do this instead:


### PR DESCRIPTION
Fixes typo in documentation of 3.2.2 of Spring Cloud Stream Kafka Streams.

@pivotal-cla This is an Obvious Fix