### PR TITLE
Make InteractiveQueryService only return used state stores

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/pom.xml
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/pom.xml
@@ -73,6 +73,11 @@
 			<artifactId>kafka_2.13</artifactId>
 			<classifier>test</classifier>
 		</dependency>
+		<dependency>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/InteractiveQueryServiceMultiStateStoreTests.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/InteractiveQueryServiceMultiStateStoreTests.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.kafka.streams;
+
+import java.time.Duration;
+import java.util.function.Consumer;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.errors.UnknownStateStoreException;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.ValueTransformerWithKey;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.Stores;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.CleanupConfig;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.condition.EmbeddedKafkaCondition;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Tests for the {@link InteractiveQueryService} when dealing with multiple KafkaStreams apps and state stores.
+ *
+ * @author Chris Bono
+ */
+@EmbeddedKafka(topics = {"input1", "input2"})
+class InteractiveQueryServiceMultiStateStoreTests {
+
+	private static final String STORE_1_NAME = "store1";
+	private static final String STORE_2_NAME = "store2";
+
+	private static final EmbeddedKafkaBroker embeddedKafka = EmbeddedKafkaCondition.getBroker();
+
+	@Test
+	void stateStoreOnlyAvailableOnKafkaStreamsAppWhereItIsUsed() {
+		try (ConfigurableApplicationContext context = new SpringApplicationBuilder()
+				.sources(MultipleAppsWithUsedStateStoresTestApplication.class)
+				.web(WebApplicationType.NONE)
+				.run("--server.port=0",
+						"--spring.jmx.enabled=false",
+						"--spring.cloud.stream.function.definition=app1;app2",
+						"--spring.cloud.stream.function.bindings.app1-in-0=input1",
+						"--spring.cloud.stream.function.bindings.app2-in-0=input2",
+						"--spring.cloud.stream.kafka.streams.binder.functions.app1.application-id=stateStoreTestApp1",
+						"--spring.cloud.stream.kafka.streams.binder.functions.app2.application-id=stateStoreTestApp2",
+						"--spring.cloud.stream.kafka.streams.binder.configuration.application.server="
+								+ embeddedKafka.getBrokersAsString(),
+						"--spring.cloud.stream.kafka.streams.binder.brokers="
+								+ embeddedKafka.getBrokersAsString())
+		) {
+			waitForRunningStreams(context.getBean(KafkaStreamsRegistry.class));
+			// The KafkaStreams.store() used by query service is non-deterministic so perform the operation multiple times to
+			// surface any possible issues. Also, no need to actually write anything to the stores, the store.get() call will
+			// cause a failure when the state store is invalid.
+			InteractiveQueryService queryService = context.getBean(InteractiveQueryService.class);
+			for (int i = 0; i < 100; i++) {
+				assertThat(queryService.getQueryableStore(STORE_1_NAME, QueryableStoreTypes.keyValueStore())
+						.get("someKey")).isNull();
+				assertThat(queryService.getQueryableStore(STORE_2_NAME, QueryableStoreTypes.keyValueStore())
+						.get("someKey")).isNull();
+			}
+		}
+	}
+
+	@Test
+	void stateStoreNotAvailableThrowsException() {
+		try (ConfigurableApplicationContext context = new SpringApplicationBuilder()
+				.sources(MultipleAppsWithUnusedStateStoresTestApplication.class)
+				.web(WebApplicationType.NONE)
+				.run("--server.port=0",
+						"--spring.jmx.enabled=false",
+						"--spring.cloud.stream.function.definition=app1;app2",
+						"--spring.cloud.stream.function.bindings.app1-in-0=input1",
+						"--spring.cloud.stream.function.bindings.app2-in-0=input2",
+						"--spring.cloud.stream.kafka.streams.binder.functions.app1.application-id=stateStoreTestApp3",
+						"--spring.cloud.stream.kafka.streams.binder.functions.app2.application-id=stateStoreTestApp4",
+						"--spring.cloud.stream.kafka.streams.binder.configuration.application.server="
+								+ embeddedKafka.getBrokersAsString(),
+						"--spring.cloud.stream.kafka.streams.binder.brokers="
+								+ embeddedKafka.getBrokersAsString())
+		) {
+			waitForRunningStreams(context.getBean(KafkaStreamsRegistry.class));
+
+			InteractiveQueryService queryService = context.getBean(InteractiveQueryService.class);
+
+			assertThatThrownBy(() -> queryService.getQueryableStore(STORE_1_NAME, QueryableStoreTypes.keyValueStore()))
+					.isInstanceOf(IllegalStateException.class)
+					.hasMessage("Error retrieving state store: " + STORE_1_NAME)
+					.hasRootCauseInstanceOf(UnknownStateStoreException.class)
+					.hasRootCauseMessage("Store (" + STORE_1_NAME + ") not available to Streams instance");
+			assertThatThrownBy(() -> queryService.getQueryableStore(STORE_2_NAME, QueryableStoreTypes.keyValueStore()))
+					.isInstanceOf(IllegalStateException.class)
+					.hasMessage("Error retrieving state store: " + STORE_2_NAME)
+					.hasRootCauseInstanceOf(UnknownStateStoreException.class)
+					.hasRootCauseMessage("Store (" + STORE_2_NAME + ") not available to Streams instance");
+		}
+	}
+
+	private void waitForRunningStreams(KafkaStreamsRegistry registry) {
+		await().atMost(Duration.ofSeconds(60))
+				.until(() -> registry.streamsBuilderFactoryBeans().stream()
+						.allMatch(x -> x.getKafkaStreams().state().equals(KafkaStreams.State.RUNNING)));
+	}
+
+	@EnableAutoConfiguration
+	@Configuration(proxyBeanMethods = false)
+	static class MultipleAppsWithUsedStateStoresTestApplication {
+
+		private static final Logger log = LoggerFactory.getLogger(MultipleAppsWithUsedStateStoresTestApplication.class);
+
+		public static void main(String[] args) {
+			SpringApplication.run(MultipleAppsWithUsedStateStoresTestApplication.class, args);
+		}
+
+		@Bean
+		public StoreBuilder<KeyValueStore<String, String>> store1() {
+			return Stores.keyValueStoreBuilder(
+					Stores.persistentKeyValueStore(STORE_1_NAME), Serdes.String(), Serdes.String());
+		}
+
+		@Bean
+		public Consumer<KStream<String, String>> app1() {
+			return s -> s
+					.transformValues(EchoTransformer::new, STORE_1_NAME)
+					.foreach((k, v) -> log.info("Echo {} -> {} into {}", k, v, STORE_1_NAME));
+		}
+
+		@Bean
+		public StoreBuilder<KeyValueStore<String, String>> store2() {
+			return Stores.keyValueStoreBuilder(
+					Stores.persistentKeyValueStore(STORE_2_NAME), Serdes.String(), Serdes.String());
+		}
+
+		@Bean
+		public Consumer<KStream<String, String>> app2() {
+			return s -> s
+					.transformValues(EchoTransformer::new, STORE_2_NAME)
+					.foreach((k, v) -> log.info("Echo {} -> {} into {}", k, v, STORE_2_NAME));
+		}
+
+		@Bean
+		public CleanupConfig cleanupConfig() {
+			return new CleanupConfig(false, true);
+		}
+
+	}
+
+	@EnableAutoConfiguration
+	@Configuration(proxyBeanMethods = false)
+	static class MultipleAppsWithUnusedStateStoresTestApplication {
+
+		private static final Logger log = LoggerFactory.getLogger(MultipleAppsWithUnusedStateStoresTestApplication.class);
+
+		public static void main(String[] args) {
+			SpringApplication.run(MultipleAppsWithUnusedStateStoresTestApplication.class, args);
+		}
+
+		@Bean
+		public StoreBuilder<KeyValueStore<String, String>> store1() {
+			return Stores.keyValueStoreBuilder(
+					Stores.persistentKeyValueStore(STORE_1_NAME), Serdes.String(), Serdes.String());
+		}
+
+		@Bean
+		public Consumer<KStream<String, String>> app1() {
+			// NOTE: No reference to the state store via transformer
+			return s -> s
+					.foreach((k, v) -> log.info("Echo {} -> {} into {}", k, v, STORE_1_NAME));
+		}
+
+		@Bean
+		public StoreBuilder<KeyValueStore<String, String>> store2() {
+			return Stores.keyValueStoreBuilder(
+					Stores.persistentKeyValueStore(STORE_2_NAME), Serdes.String(), Serdes.String());
+		}
+
+		@Bean
+		public Consumer<KStream<String, String>> app2() {
+			// NOTE: No reference to the state store via transformer
+			return s -> s
+					.foreach((k, v) -> log.info("Echo {} -> {} into {}", k, v, STORE_2_NAME));
+		}
+
+		@Bean
+		public CleanupConfig cleanupConfig() {
+			return new CleanupConfig(false, true);
+		}
+
+	}
+
+	static class EchoTransformer implements ValueTransformerWithKey<String, String, String> {
+
+		@Override
+		public void init(ProcessorContext context) {
+		}
+
+		@Override
+		public String transform(String key, String value) {
+			return value;
+		}
+
+		@Override
+		public void close() {
+		}
+	}
+}


### PR DESCRIPTION
Fixes #2445

### Background
In KafkaStreams 3.0 the mechanism used to answer _“does this topology have this store?“_ was changed.

In 3.0 it asked the actual built topology which would not return a state store unless the KafkaStreams instance was actually using it:
```java
public <T> T store(StoreQueryParameters<T> storeQueryParameters) {
    this.validateIsRunningOrRebalancing();
    String storeName = storeQueryParameters.storeName();
    if (this.taskTopology != null && this.taskTopology.hasStore(storeName) || this.globalTaskTopology != null && this.globalTaskTopology.hasStore(storeName)) {
        return this.queryableStoreProvider.getStore(storeQueryParameters);
    } else {
        throw new UnknownStateStoreException("Cannot get state store " + storeName + " because no such store is registered in the topology.");
    }
}
```

However in 3.2 it asks the topology metadata which will answer yes if any of its state factories have the state store, regardless if it used or not. 

```java
public <T> T store(final StoreQueryParameters<T> storeQueryParameters) {
    validateIsRunningOrRebalancing();
    final String storeName = storeQueryParameters.storeName();
    if (!topologyMetadata.hasStore(storeName)) {
        throw new UnknownStateStoreException(
            "Cannot get state store " + storeName + " because no such store is registered in the topology."
        );
    }
    return queryableStoreProvider.getStore(storeQueryParameters);
}
```
Because SCSt adds all state stores beans to all KafkaStreams apps, we now get back unwanted/unused state stores.

### Not Chosen Solution
One solution would be to add an extra param to `InteractiveQueryService.store` for the application id to differentiate which KafkaStreams app the caller is interested in. However, this is an API change and rather intrusive. 

### Chosen Solution
Instead we have added an additional check against the streams state store metadata to see if it the state store is actually being used. This returns us back to the 3.0 behavior. 

### Caveat
⚠️  The streams state store metadata check will fail if the topology is a named topology. This should not be an issue w/ the streams created by SCSt. If it does become a problem later, we will then add the additional optional app id param to `InteractiveQueryService.store`. 