### PR TITLE
Update Spring Boot from `3.0.0-M4` -> `3.0.0-SNAPSHOT`

### DIFF
--- a/binders/kafka-binder/pom.xml
+++ b/binders/kafka-binder/pom.xml
@@ -35,6 +35,12 @@
 
 	<dependencyManagement>
 		<dependencies>
+			<!-- TODO Remove this dep. block when SB moves to SI 6.0.0-SNAPSHOT  -->
+			<dependency>
+				<groupId>org.springframework.integration</groupId>
+				<artifactId>spring-integration-kafka</artifactId>
+				<version>6.0.0-SNAPSHOT</version>
+			</dependency>
 			<dependency>
 				<groupId>org.apache.kafka</groupId>
 				<artifactId>kafka-streams</artifactId>

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/KafkaStreamsBinderHealthIndicatorTests.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/integration/KafkaStreamsBinderHealthIndicatorTests.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.stream.binder.kafka.streams.integration;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -30,6 +31,7 @@ import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 import org.apache.kafka.streams.kstream.KStream;
 import org.assertj.core.util.Lists;
 import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -52,13 +54,12 @@ import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.condition.EmbeddedKafkaCondition;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
-import org.springframework.util.concurrent.ListenableFuture;
-import org.springframework.util.concurrent.ListenableFutureCallback;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Arnaud Jardiné
+ * @author Chris Bono
  */
 @EmbeddedKafka(topics = {"out", "out2"})
 public class KafkaStreamsBinderHealthIndicatorTests {
@@ -152,22 +153,16 @@ public class KafkaStreamsBinderHealthIndicatorTests {
 			KafkaTemplate<Integer, String> template = new KafkaTemplate<>(pf, true);
 			CountDownLatch latch = new CountDownLatch(records.size());
 			for (ProducerRecord<Integer, String> record : records) {
-				ListenableFuture<SendResult<Integer, String>> future = template
-						.send(record);
-				future.addCallback(
-						new ListenableFutureCallback<SendResult<Integer, String>>() {
-							@Override
-							public void onFailure(Throwable ex) {
-								Assert.fail();
-							}
-
-							@Override
-							public void onSuccess(SendResult<Integer, String> result) {
-								latch.countDown();
-							}
-						});
+				CompletableFuture<SendResult<Integer, String>> future = template.send(record);
+				future.whenComplete((result, ex) -> {
+					if (ex != null) {
+						Assertions.fail();
+					}
+					else {
+						latch.countDown();
+					}
+				});
 			}
-
 			latch.await(5, TimeUnit.SECONDS);
 
 			embeddedKafka.consumeFromEmbeddedTopics(consumer, topics);
@@ -281,13 +276,8 @@ public class KafkaStreamsBinderHealthIndicatorTests {
 		@Bean
 		public StreamsBuilderFactoryBeanConfigurer customizer() {
 			return factoryBean -> {
-				factoryBean.setKafkaStreamsCustomizer(new KafkaStreamsCustomizer() {
-					@Override
-					public void customize(KafkaStreams kafkaStreams) {
-						kafkaStreams.setUncaughtExceptionHandler(exception ->
-								StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.SHUTDOWN_CLIENT);
-					}
-				});
+				factoryBean.setKafkaStreamsCustomizer(kafkaStreams -> kafkaStreams.setUncaughtExceptionHandler(exception ->
+						StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.SHUTDOWN_CLIENT));
 			};
 		}
 

--- a/bom/spring-cloud-starter-parent/pom.xml
+++ b/bom/spring-cloud-starter-parent/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.0-M4</version>
+		<version>3.0.0-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<groupId>org.springframework.cloud</groupId>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.0-M4</version>
+		<version>3.0.0-SNAPSHOT</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 


### PR DESCRIPTION
Adapts to the following changes in upstreams libs:

- Spring Kafka removed ListenableFuture
- Spring AOT changed generator API

Fixes #2473 #2465

⚠️ **NOTE**  SB `3.0.0-SNAPSHOT` is still pointing to SI [`6.0.0-M4`](https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot-dependencies/build.gradle#L1449) which still has the old `ListenableFuture` usage. This was causing the integration tests in SCSt Kafka binder to fail. I have worked around this by pinning the Kafka binder to SI `6.0.0-SNAPSHOT`. I am a bit hesitant recommending a merge of this as I do not like having SB pointing to SI M4 and us overriding it and pointing to SI SNAPSHOT as it feels like we could run into some errors. Thoughts? 

@artembilan do you know when SB will jump to SI `6.0.0-SNAPSHOT`? 

