### PR TITLE
Use empty context for AOT binder child context

### DIFF
--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderChildContextInitializer.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderChildContextInitializer.java
@@ -153,7 +153,7 @@ public class BinderChildContextInitializer implements ApplicationContextAware, B
 							this.logger.debug(() -> "Generating AOT child context initializer for " + name);
 							GenerationContext childGenerationContext = generationContext.withName(name + "Binder");
 							ClassName initializerClassName = aotGenerator.processAheadOfTime(context, childGenerationContext);
-							method.addStatement("$T<? extends $T>" + name + "Initializer = new $L()", ApplicationContextInitializer.class,
+							method.addStatement("$T<? extends $T> " + name + "Initializer = new $L()", ApplicationContextInitializer.class,
 									ConfigurableApplicationContext.class, initializerClassName);
 							method.addStatement("initializers.put($S," + name + "Initializer)", name);
 						});


### PR DESCRIPTION
Previously, when running in AOT mode the binder child context was created w/ the same beans as when in JVM mode. The whole point of the former is to static initialize an empty fresh contextusing the AOT generated initializer.

@artembilan this addresses your concern in the initial commit of this feature. 