### PR TITLE
GH-2453: RMQ: Full Support for Alternate Exchange

### DIFF
--- a/binders/rabbit-binder/pom.xml
+++ b/binders/rabbit-binder/pom.xml
@@ -53,7 +53,7 @@
 		        <groupId>org.apache.maven.plugins</groupId>
 		        <artifactId>maven-surefire-plugin</artifactId>
 		        <configuration>
-		          <skipTests>true</skipTests>
+		          <skipTests>false</skipTests>
 		        </configuration>
 	        </plugin>
 			<plugin>

--- a/binders/rabbit-binder/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitProducerProperties.java
+++ b/binders/rabbit-binder/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitProducerProperties.java
@@ -20,9 +20,11 @@ import java.util.Optional;
 
 import jakarta.validation.constraints.Min;
 
+import org.springframework.amqp.core.ExchangeTypes;
 import org.springframework.amqp.core.MessageDeliveryMode;
 import org.springframework.expression.Expression;
 import org.springframework.expression.common.LiteralExpression;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 
@@ -148,6 +150,12 @@ public class RabbitProducerProperties extends RabbitCommonProperties {
 	 * @since 3.2
 	 */
 	private String streamMessageConverterBeanName;
+
+	/**
+	 * Configure an alternate exchange for when no queues are bound.
+	 * @since 4.0
+	 */
+	private AlternateExchange alternateExchange;
 
 	/**
 	 * @param requestHeaderPatterns the patterns.
@@ -300,6 +308,102 @@ public class RabbitProducerProperties extends RabbitCommonProperties {
 
 	public void setStreamMessageConverterBeanName(String streamMessageConverterBeanName) {
 		this.streamMessageConverterBeanName = streamMessageConverterBeanName;
+	}
+
+	@Nullable
+	public AlternateExchange getAlternateExchange() {
+		return this.alternateExchange;
+	}
+
+	public void setAlternateExchange(AlternateExchange alternate) {
+		this.alternateExchange = alternate;
+	}
+
+	public static class AlternateExchange {
+
+		/**
+		 * The alternate exchange name.
+		 */
+		private String name;
+
+		/**
+		 * Whether the exchange exists or should be provisioned.
+		 */
+		private boolean exists = false;
+
+		/**
+		 * The alternate exchange type.
+		 */
+		private String type = ExchangeTypes.TOPIC;
+
+		/**
+		 * Bind a durable queue to the alternate exchange.
+		 */
+		private Binding binding;
+
+		public String getName() {
+			return this.name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public boolean isExists() {
+			return this.exists;
+		}
+
+		public void setExists(boolean exists) {
+			this.exists = exists;
+		}
+
+		public String getType() {
+			return this.type;
+		}
+
+		public void setType(String type) {
+			this.type = type;
+		}
+
+		public Binding getBinding() {
+			return this.binding;
+		}
+
+		public void setBinding(Binding binding) {
+			this.binding = binding;
+		}
+
+		public static class Binding {
+
+			/**
+			 * The routing key.
+			 */
+			private String routingKey = "#";
+
+			/**
+			 * The queue name.
+			 */
+			private String queue;
+
+			public String getRoutingKey() {
+				return this.routingKey;
+			}
+
+			public void setRoutingKey(String routingKey) {
+				this.routingKey = routingKey;
+			}
+
+			public String getQueue() {
+				return this.queue;
+			}
+
+			public void setQueue(String queue) {
+				this.queue = queue;
+			}
+
+
+		}
+
 	}
 
 }

--- a/docs/src/main/asciidoc/rabbit/rabbit_overview.adoc
+++ b/docs/src/main/asciidoc/rabbit/rabbit_overview.adoc
@@ -682,7 +682,27 @@ in the format of `spring.cloud.stream.rabbit.default.<property>=<value>`.
 
 Also, keep in mind that binding specific property will override its equivalent in the default.
 
-
+altermateExchange.binding.queue::
+If the exchange does not already exist, and a `name` is provided, bind this queue to the alternate exhange.
+A simple durable queue with no arguments is provisioned; if more sophisticated configuration is required, you must configure and bind the queue yourself.
++
+Default: `null`
+alternateExchange.binding.routingKey
+If the exchange does not already exist, and a `name` and `queue` is provided, bind the queue to the alternate exhange using this routing key.
++
+Default: `#` (for the default `topic` alternate exchange)
+alternateExchange.exists::
+Whether the alternate exchange exists, or needs to be provisioned.
++
+Default: `false`
+alternateExchange.type::
+If the alternate exchange does not already exist, the type of exchange to provision.
++
+Default: `topic`
+alternateExchange.name::
+Configure an alternate exchange on the destination exchange.
++
+Default: `null`
 autoBindDlq::
 Whether to automatically declare the DLQ and bind it to the binder DLX.
 +


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-stream/issues/2453

Previously, to configure the use of an alternative exchange (used to route
messages when no queue is bound), the user had to manually declare the
exchange and any bindings, and modify the destination exchange using a
`DeclarablesCustomizer` bean.

Add first class support to configure the destination exchange and, optionally,
provision the alternate exchange as well as optionally binding a specific
queue to it.