### PR TITLE
Fix KafkaBinderHealthIndicator return Down Error

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
@@ -410,7 +410,7 @@ public class KafkaBinderConfigurationProperties {
 
 	private void filterStreamManagedConfiguration(Map<String, Object> configuration) {
 		if (configuration.containsKey(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG)
-				&& configuration.get(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG).equalsIgnoreCase("true")) {
+				&& configuration.get(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG).equals("true")) {
 			logger.warn(constructIgnoredConfigMessage(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG) +
 					ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG + "=true is not supported by the Kafka binder");
 			configuration.remove(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG);

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
@@ -410,7 +410,7 @@ public class KafkaBinderConfigurationProperties {
 
 	private void filterStreamManagedConfiguration(Map<String, Object> configuration) {
 		if (configuration.containsKey(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG)
-				&& configuration.get(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG).equals(true)) {
+				&& configuration.get(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG).equalsIgnoreCase("true")) {
 			logger.warn(constructIgnoredConfigMessage(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG) +
 					ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG + "=true is not supported by the Kafka binder");
 			configuration.remove(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG);


### PR DESCRIPTION
We set enable.auto.commit=true, the actuator/health return  
```
{
    "status":"DOWN",
    "components":{
        "binders":{
            "status":"DOWN",
            "components":{
                "xxxx":{
                    "status":"DOWN",
                    "details":{
                        "error":"org.apache.kafka.common.KafkaException: Failed to construct kafka consumer",
                        "listenerContainers":[
                            {
                                "isPaused":false,
                                "listenerId":"KafkaConsumerDestination{consumerDestinationName='XXX', partitions=xxx, dlqName='null'}.container",
                                "isRunning":true,
                                "groupId":"XXX"
                            }
                        ]
                    }
                }
            }
        }
    }
}
```

PS: 
spring boot version is 2.3.12.RELEASE
spring cloud version is 2.2.9.RELEASE
spring cloud stream version is 3.0.13.RELEASE