### PR TITLE
Cleanup Kafka Client Deps

### DIFF
--- a/binders/kafka-binder/pom.xml
+++ b/binders/kafka-binder/pom.xml
@@ -20,7 +20,6 @@
 	</scm>
 	<properties>
 		<java.version>17</java.version>
-		<kafka.version>3.2.0</kafka.version>
 		<maven-checkstyle-plugin.failsOnError>true</maven-checkstyle-plugin.failsOnError>
 		<maven-checkstyle-plugin.failsOnViolation>true</maven-checkstyle-plugin.failsOnViolation>
 		<maven-checkstyle-plugin.includeTestSourceDirectory>true</maven-checkstyle-plugin.includeTestSourceDirectory>
@@ -32,62 +31,6 @@
 		<module>spring-cloud-stream-binder-kafka-streams</module>
         <module>spring-cloud-stream-binder-kafka-reactive</module>
 	</modules>
-
-	<dependencyManagement>
-		<dependencies>
-			<!-- TODO Remove this dep. block when SB moves to SI 6.0.0-SNAPSHOT  -->
-			<dependency>
-				<groupId>org.springframework.integration</groupId>
-				<artifactId>spring-integration-kafka</artifactId>
-				<version>6.0.0-SNAPSHOT</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.kafka</groupId>
-				<artifactId>kafka-streams</artifactId>
-				<version>${kafka.version}</version>
-				<exclusions>
-					<exclusion>
-						<groupId>org.slf4j</groupId>
-						<artifactId>slf4j-log4j12</artifactId>
-					</exclusion>
-				</exclusions>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.kafka</groupId>
-				<artifactId>kafka_2.13</artifactId>
-				<version>${kafka.version}</version>
-				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.kafka</groupId>
-				<artifactId>kafka_2.13</artifactId>
-				<classifier>test</classifier>
-				<scope>test</scope>
-				<version>${kafka.version}</version>
-				<exclusions>
-					<exclusion>
-						<groupId>jline</groupId>
-						<artifactId>jline</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>org.slf4j</groupId>
-						<artifactId>slf4j-log4j12</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>log4j</groupId>
-						<artifactId>log4j</artifactId>
-					</exclusion>
-				</exclusions>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.kafka</groupId>
-				<artifactId>kafka-clients</artifactId>
-				<version>${kafka.version}</version>
-				<classifier>test</classifier>
-				<scope>test</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
 
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
Let the Kafka client versions be managed from Spring Boot rather than the binder manages it's own versions.