### PR TITLE
[WIP - DO NOT MERGE] Add binder specific outer context initializer

### DIFF
--- a/binders/rabbit-binder/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitBinderOuterContextInitializer.java
+++ b/binders/rabbit-binder/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/config/RabbitBinderOuterContextInitializer.java
@@ -1,0 +1,15 @@
+package org.springframework.cloud.stream.binder.rabbit.config;
+
+import org.springframework.boot.autoconfigure.amqp.ConnectionFactoryCustomizer;
+import org.springframework.cloud.stream.binder.BinderOuterContextInitializer;
+import org.springframework.context.support.GenericApplicationContext;
+
+public class RabbitBinderOuterContextInitializer extends BinderOuterContextInitializer {
+
+	@Override
+	public void initialize(GenericApplicationContext applicationContext) {
+		super.initialize(applicationContext);
+		getOuterContext().getBeanProvider(ConnectionFactoryCustomizer.class).forEach((customizer) ->
+				applicationContext.registerBean(ConnectionFactoryCustomizer.class, () -> customizer));
+	}
+}

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderOuterContextInitializer.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderOuterContextInitializer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder;
+
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
+
+/**
+ * An {@link ApplicationContextInitializer} that isets the outer application context as a bean under the name
+ * 'outerContext' on a binder child context.
+ *
+ * @author Chris Bono
+ */
+public class BinderOuterContextInitializer implements ApplicationContextInitializer<GenericApplicationContext> {
+
+	private ConfigurableApplicationContext outerContext;
+
+	public ConfigurableApplicationContext getOuterContext() {
+		return outerContext;
+	}
+
+	public void setOuterContext(ConfigurableApplicationContext outerContext) {
+		this.outerContext = outerContext;
+	}
+
+	@Override
+	public void initialize(GenericApplicationContext applicationContext) {
+		// For backwards compatibility
+		applicationContext.getBeanFactory().registerSingleton("outerContext", this.outerContext);
+	}
+}


### PR DESCRIPTION
This replaces the current limited outer context initializer w/ an attempt to load a binder-specific one (based on naming convention currently). The rabbit impl simply propagates the CFCs.

1. It is not tested (at all)
2. It is not tested (at all)

cc: @sobychacko @garyrussell @artembilan @olegz 