### PR TITLE
GH-2523:  Smarter state store resolution in InteractiveQueryService

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsVersionAgnosticTopologyInfoFacade.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsVersionAgnosticTopologyInfoFacade.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2018-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.kafka.streams;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Collection;
+
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
+import org.apache.kafka.streams.processor.internals.TopologyMetadata;
+
+import org.springframework.core.log.LogAccessor;
+import org.springframework.lang.Nullable;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * A facade to access topology info for a Kafka Streams application in a version agnostic
+ * manner.
+ * <p>Before kafka-streams 3.1 the topology exists at 'KafkaStreams.internalTopologyBuilder'.
+ * Starting in kafka-streams 3.1 the topology exists at 'KafkaStreams.topologyMetadata'.
+ *
+ * @author Chris Bono
+ * @since 3.2.6
+ */
+class KafkaStreamsVersionAgnosticTopologyInfoFacade {
+
+	private final LogAccessor logger = new LogAccessor(KafkaStreamsVersionAgnosticTopologyInfoFacade.class);
+
+	@Nullable
+	private Field topologyInfoField;
+
+	@Nullable
+	private Method sourceTopicsForStoreMethod;
+
+	KafkaStreamsVersionAgnosticTopologyInfoFacade() {
+
+		// First look for KafkaStreams.internalTopologyBuilder (exists in kafka-streams <= 3.0)
+		Field internalTopologyBuilderField = ReflectionUtils.findField(KafkaStreams.class, "internalTopologyBuilder");
+		if (internalTopologyBuilderField != null) {
+			internalTopologyBuilderField.setAccessible(true);
+			this.topologyInfoField = internalTopologyBuilderField;
+			this.sourceTopicsForStoreMethod = ReflectionUtils.findMethod(InternalTopologyBuilder.class, "sourceTopicsForStore", String.class);
+			logger.info("Using KafkaStreams.internalTopologyBuilder.sourceTopicsForStore for kafka-streams <= 3.0");
+		}
+
+		// Otherwise look for KafkaStreams.topologyMetadata (exists in kafka-streams >= 3.1)
+		Field topologyMetadataField = ReflectionUtils.findField(KafkaStreams.class, "topologyMetadata");
+		if (topologyMetadataField != null) {
+			topologyMetadataField.setAccessible(true);
+			this.topologyInfoField = topologyMetadataField;
+			this.sourceTopicsForStoreMethod = ReflectionUtils.findMethod(TopologyMetadata.class, "sourceTopicsForStore", String.class);
+			logger.info("Using KafkaStreams.topologyMetadata.sourceTopicsForStore for kafka-streams >= 3.1");
+		}
+
+		if (this.sourceTopicsForStoreMethod == null) {
+			logger.warn("Could not find 'topologyMetadata.sourceTopicsForStore' or 'internalTopologyBuilder.sourceTopicsForStore' " +
+					"from KafkaStreams class - will be unable to reason about state stores.");
+		}
+
+	}
+
+	/**
+	 * Determines if a state store is actually available to a KafkaStreams instance by
+	 * querying the topology info source topics for the requested store.
+	 *
+	 * @param kafkaStreams the streams app
+	 * @param storeName the name of the state store
+	 * @return {@code true} if state store is available or {@code false} if the state store is
+	 * 	not available or there was a problem reflecting on the topology info
+	 */
+	boolean streamsAppActuallyHasStore(KafkaStreams kafkaStreams, String storeName) {
+		if (this.sourceTopicsForStoreMethod == null) {
+			logger.warn("Unable to reason about state store because sourceTopicsForStore method was not found - returning false");
+			return false;
+		}
+		try {
+			Object topologyInfo = ReflectionUtils.getField(this.topologyInfoField, kafkaStreams);
+			if (topologyInfo != null) {
+				logger.warn("Unable to reason about state store because topologyInfo field was null - returning false");
+				return false;
+			}
+			Collection<String> sourceTopicsForStore = (Collection<String>)
+					ReflectionUtils.invokeMethod(this.sourceTopicsForStoreMethod, topologyInfo, storeName);
+			return !CollectionUtils.isEmpty(sourceTopicsForStore);
+		}
+		catch (Exception ex) {
+			logger.error(ex, () -> "Unable to reason about state store due to error: " + ex.getMessage() + " - returning false");
+		}
+		return false;
+	}
+}


### PR DESCRIPTION
This proposal solves the "does this streams app actually have this state store available?" question in a KafkaStreams version agnostic manner. 

### Original Problem 
The original complication (#2445) summarized:
 

> In KafkaStreams 3.1 the mechanism used to answer “does this topology have this store?“ was changed.
> 
> In 3.0 it asked the actual built topology which would not return a state store unless the KafkaStreams instance was actually using it.
> 
> However in 3.1+ it asks the topology metadata which will answer yes if any of its state factories have the state store, regardless if it used or not. This is a problem because SCSt adds all state stores beans to all KafkaStreams apps which in turns leads to IQS getting back unwanted/unused state stores from `getQueryableStore`.

### Attempted Fix 1
The 1st [attempted fix](https://github.com/spring-cloud/spring-cloud-stream/commit/0cb59496fef59226afafbda464230231b38b0386) relied on `KafkaStreams.streamsMetadataForStore`. This seemed to work well. It was tested manually on sample apps and also coverage was added to the integration test suite for the relevant use cases. **However** it only works when the `spring.cloud.stream.kafka.streams.binder.configuration.application.server=<server>:<port>` property is set. The tests were always setting this property so this fact was hidden. This was reported under #2523 . 

### Fix 2 (this PR)
Rather than rely on `KafkaStreams.streamsMetadataForStore` we consult the topology directly to ask if it knows of the requested state store. The complication here is that the topology info differs between `-3.0` and `3.1+` which leads to reflective code. We hide this fact behind a facade. 

### Alternative Approach
Another approach would be to set the `spring.cloud.stream.kafka.streams.binder.configuration.application.server=<server>:<port>` property for the user w/ a default when it is not set by the user. The concern here is that there may be  other unknown edge cases that affect the reliability of `KafkaStreams.streamsMetadataForStore` giving us the answer we need at all times.


