### PR TITLE
Update spring-cloud-stream.adoc

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-stream.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-stream.adoc
@@ -2917,7 +2917,6 @@ Now you can test your microservice as a simple unit test
 [source,java]
 ----
 @SpringBootTest
-@RunWith(SpringRunner.class)
 public class SampleStreamTests {
 
 	@Autowired


### PR DESCRIPTION
Ran across this while converting the stream-applications to SB3/SF6/SCSt4....

Remove `@RunWith(SpringRunner.class)` from sample code in Spring Integration Test Binder section:
1. It is a JUnit4 annotation
2. `@SpringBootTest` composes the JUnit5 counterpart (`@ExtendWith({SpringExtension.class})`)