### PR TITLE
Fix producer Binding#companion bean not set

### DIFF
--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
@@ -303,7 +303,8 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 		};
 
 		Lifecycle companion = null;
-		String companionLifecycleName = destination + "_spca";
+		String outputChannelName = ((AbstractMessageChannel) outputChannel).getBeanName();
+		String companionLifecycleName = outputChannelName + "_spca";
 		if (this.getApplicationContext().containsBean(companionLifecycleName)) {
 			companion = this.getApplicationContext().getBean(companionLifecycleName, Lifecycle.class);
 		}


### PR DESCRIPTION
## version
* Spring Cloud Stream 3.2.5
* Spring Cloud Stream RabbitMQ Binder 3.2.5

## problem
[Reference: Actuator](https://docs.spring.io/spring-cloud-stream/docs/current/reference/html/spring-cloud-stream.html#_actuator)

The endpoint `POST:/actuator/bindings/{bindingName}` request can control the state of **supplier's binding**, but cannnot control the state of **supplier's source polling**.
`BindingsLifecycleController#changeState({bindingName})` (`stop`, `start`) also cannot control it.

## cause
[Javadoc: DefaultBinding#setCompanion](https://javadoc.io/static/org.springframework.cloud/spring-cloud-stream/3.2.5/org/springframework/cloud/stream/binder/DefaultBinding.html#setCompanion-org.springframework.context.Lifecycle-)

When I checked the Binding obtained by `BindingsLifecycleController#queryState({bindingName})`, I found that the `SourcePollingChannelAdapter` Bean generated by `FunctionConfiguration` is not set to `companion` property.

Because [AbstractMessageChannelBinder#doBindProducer](https://github.com/spring-cloud/spring-cloud-stream/blob/v3.2.5/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java#L305-L310) find SPCA bean named `{destination}_spca`, but [FunctionConfiguration](https://github.com/spring-cloud/spring-cloud-stream/blob/v3.2.5/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java#L333-L337) create SPCA bean named `{bindingName}_spca`.

## sample apps
[The similer evaluation app is here.](https://github.com/yoshikawaa/spring-cloud-stream-pr2544)

Regards.