### PR TITLE
Fix ClassCastException when using batch mode

### DIFF
--- a/binders/rabbit-binder/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/BatchCapableRejectAndDontRequeueRecoverer.java
+++ b/binders/rabbit-binder/spring-cloud-stream-binder-rabbit/src/main/java/org/springframework/cloud/stream/binder/rabbit/BatchCapableRejectAndDontRequeueRecoverer.java
@@ -1,0 +1,52 @@
+package org.springframework.cloud.stream.binder.rabbit;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.amqp.AmqpRejectAndDontRequeueException;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.rabbit.retry.MessageBatchRecoverer;
+import org.springframework.amqp.rabbit.support.ListenerExecutionFailedException;
+import org.springframework.util.Assert;
+
+public class BatchCapableRejectAndDontRequeueRecoverer implements MessageBatchRecoverer {
+
+	protected final Log logger = LogFactory.getLog(getClass()); // NOSONAR protected
+
+	private final Supplier<String> messageSupplier;
+
+	public BatchCapableRejectAndDontRequeueRecoverer() {
+		this(() -> "Retry Policy Exhausted");
+	}
+
+	/**
+	 * Construct an instance with the provided exception message supplier.
+	 *
+	 * @param messageSupplier the message supplier.
+	 */
+	public BatchCapableRejectAndDontRequeueRecoverer(Supplier<String> messageSupplier) {
+		Assert.notNull(messageSupplier, "'messageSupplier' cannot be null");
+		this.messageSupplier = messageSupplier;
+	}
+
+	@Override
+	public void recover(List<Message> messages, Throwable cause) {
+		if (this.logger.isWarnEnabled()) {
+			this.logger.warn("Retries exhausted for message " + messages, cause);
+		}
+		throw new ListenerExecutionFailedException(this.messageSupplier.get(),
+				new AmqpRejectAndDontRequeueException(cause), messages.toArray(Message[]::new));
+	}
+
+	@Override
+	public void recover(Message message, Throwable cause) {
+		if (this.logger.isWarnEnabled()) {
+			this.logger.warn("Retries exhausted for message " + message, cause);
+		}
+		throw new ListenerExecutionFailedException(this.messageSupplier.get(),
+				new AmqpRejectAndDontRequeueException(cause), message);
+	}
+}

--- a/binders/rabbit-binder/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/BatchCapableRejectAndDontRequeueRecovererTest.java
+++ b/binders/rabbit-binder/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/BatchCapableRejectAndDontRequeueRecovererTest.java
@@ -1,0 +1,56 @@
+package org.springframework.cloud.stream.binder.rabbit;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.amqp.AmqpRejectAndDontRequeueException;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.rabbit.retry.MessageBatchRecoverer;
+import org.springframework.amqp.rabbit.support.ListenerExecutionFailedException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BatchCapableRejectAndDontRequeueRecovererTest {
+
+	@Test
+	void testBatchRecoverThrowExceptionCorrectly() {
+		MessageBatchRecoverer messageBatchRecoverer = new BatchCapableRejectAndDontRequeueRecoverer();
+
+		Message expectedMessage1 = new Message(new byte[] {});
+		Message expectedMessage2 = new Message(new byte[] {});
+
+		List<Message> messages = List.of(expectedMessage1, expectedMessage2);
+
+		Throwable expectedThrowable = new RuntimeException("test");
+
+		ListenerExecutionFailedException exception = assertThrows(ListenerExecutionFailedException.class,
+				() -> messageBatchRecoverer.recover(messages, expectedThrowable));
+
+		assertTrue(exception.getFailedMessages().contains(expectedMessage1));
+		assertTrue(exception.getFailedMessages().contains(expectedMessage2));
+		assertTrue(exception.getCause() instanceof AmqpRejectAndDontRequeueException);
+		assertEquals(expectedThrowable, exception.getCause().getCause());
+
+	}
+
+	@Test
+	void testRecoverThrowExceptionCorrectly() {
+		MessageBatchRecoverer messageBatchRecoverer = new BatchCapableRejectAndDontRequeueRecoverer();
+
+		Message expectedMessage = new Message(new byte[] {});
+
+		Throwable expectedThrowable = new RuntimeException("test");
+
+		ListenerExecutionFailedException exception = assertThrows(ListenerExecutionFailedException.class,
+				() -> messageBatchRecoverer.recover(expectedMessage, expectedThrowable));
+
+		assertEquals(expectedMessage, exception.getFailedMessage());
+		assertTrue(exception.getCause() instanceof AmqpRejectAndDontRequeueException);
+		assertEquals(expectedThrowable, exception.getCause().getCause());
+
+	}
+
+}


### PR DESCRIPTION
Fix ClassCastException when handling error while using batch mode that prevents the republish of the message into the DLQ. The issue happened whenever the republish to dlq was enabled or if republish was disabled and max attempts were > 1 while the batch mode was enabled, because the handler was not expecting the the sourceData for the ErrorMessage could be a list of amqp message.

Fix #2332 