### PR TITLE
Binder instantiation changes

### DIFF
--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
@@ -163,7 +163,7 @@ public class DefaultBinderFactory implements BinderFactory, DisposableBean, Appl
 			return this.doGetBinderConventional(name, bindingTargetType);
 		}
 		else {
-			if (!StringUtils.hasText(name) && this.binderChildContextInitializers.size() == 1) {
+			if ((!StringUtils.hasText(name) || this.defaultBinder != null) && this.binderChildContextInitializers.size() == 1) {
 				String configurationName = this.binderChildContextInitializers.keySet().iterator().next();
 				return this.getBinderInstance(configurationName);
 			}


### PR DESCRIPTION
 - When default binder is provided, consider it while instantiating the binder. This is needed for AOT/Native applications that provide a default binder.

Resolves https://github.com/spring-cloud/spring-cloud-stream/issues/2569