### PR TITLE
Fixing AOT compilation with multi binders

### DIFF
--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
@@ -167,6 +167,15 @@ public class DefaultBinderFactory implements BinderFactory, DisposableBean, Appl
 				String configurationName = this.binderChildContextInitializers.keySet().iterator().next();
 				return this.getBinderInstance(configurationName);
 			}
+			else if (this.defaultBinder != null && this.binderChildContextInitializers.size() > 1) {
+				// Handling default binder when different binders are present on the classpath.
+				for (String binderName : this.binderChildContextInitializers.keySet()) {
+					if (binderName.equals(this.defaultBinder)) {
+						return this.getBinderInstance(binderName);
+					}
+				}
+				throw new IllegalStateException("Default binder provided, but can't determine which binder to initialize");
+			}
 			else {
 				throw new IllegalStateException("Can't determine which binder to use: " + name + "/" + this.binderChildContextInitializers.size());
 			}


### PR DESCRIPTION
When default binder is provided and multiple binder types are present on the classpath, then the binder requested as default is not instantiated when compiling in AOT mode.

Resolves https://github.com/spring-cloud/spring-cloud-stream/issues/2584