### PR TITLE
Fix a message array index in kafka binder test code

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
@@ -1766,7 +1766,7 @@ public class KafkaBinderTests extends
 
 		assertThat(messages[0]).isNotNull();
 		assertThat(messages[1]).isNotNull();
-		assertThat(messages[1]).isNotNull();
+		assertThat(messages[2]).isNotNull();
 		assertThat(messages).extracting("payload").containsExactlyInAnyOrder(
 				testPayload1.getBytes(), testPayload2.getBytes(), testPayload3.getBytes());
 		Arrays.asList(messages).forEach(message -> {


### PR DESCRIPTION
fix a message array index in kafka binder test code, so that the third message can be tested.

### message send/receive related code
https://github.com/spring-cloud/spring-cloud-stream/blob/f1d4f8a53ef4110ae70b9bd2ce99cc26ef3feee1/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java#L1761-L1768