### PR TITLE
Enable KafkaNull converter tests

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/integration/KafkaNullConverterTest.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/integration/KafkaNullConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -62,7 +61,6 @@ public class KafkaNullConverterTest {
 	private KafkaNullConverterTestConfig config;
 
 	@Test
-	@Disabled
 	void testKafkaNullConverterOutput() throws InterruptedException {
 		final StreamBridge streamBridge = context.getBean(StreamBridge.class);
 


### PR DESCRIPTION
Enable a test that uses StreamBridge and KafkaNull together.

Resolves https://github.com/spring-cloud/spring-cloud-stream/issues/2614

Need this PR from Spring Cloud Function merged first: https://github.com/spring-cloud/spring-cloud-function/pull/981