### PR TITLE
Replace hardcoded "UTF-8" with StandardCharsets.UTF_8

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/utils/KafkaTopicUtils.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/utils/KafkaTopicUtils.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.stream.binder.kafka.utils;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Utility methods releated to Kafka topics.
@@ -34,20 +34,15 @@ public final class KafkaTopicUtils {
 	 * @param topicName name of the topic
 	 */
 	public static void validateTopicName(String topicName) {
-		try {
-			byte[] utf8 = topicName.getBytes("UTF-8");
-			for (byte b : utf8) {
-				if (!((b >= 'a') && (b <= 'z') || (b >= 'A') && (b <= 'Z')
-						|| (b >= '0') && (b <= '9') || (b == '.') || (b == '-')
-						|| (b == '_'))) {
-					throw new IllegalArgumentException(
-							"Topic name can only have ASCII alphanumerics, '.', '_' and '-', but was: '"
-									+ topicName + "'");
-				}
+		byte[] utf8 = topicName.getBytes(StandardCharsets.UTF_8);
+		for (byte b : utf8) {
+			if (!((b >= 'a') && (b <= 'z') || (b >= 'A') && (b <= 'Z')
+					|| (b >= '0') && (b <= '9') || (b == '.') || (b == '-')
+					|| (b == '_'))) {
+				throw new IllegalArgumentException(
+						"Topic name can only have ASCII alphanumerics, '.', '_' and '-', but was: '"
+								+ topicName + "'");
 			}
-		}
-		catch (UnsupportedEncodingException ex) {
-			throw new AssertionError(ex); // Can't happen
 		}
 	}
 

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/EmbeddedHeaderUtils.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/EmbeddedHeaderUtils.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.stream.binder;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -67,7 +68,7 @@ public abstract class EmbeddedHeaderUtils {
 				Object value = original.get(header);
 				if (value != null) {
 					String json = objectMapper.toJson(value);
-					headerValues[n] = json.getBytes("UTF-8");
+					headerValues[n] = json.getBytes(StandardCharsets.UTF_8);
 					headerCount++;
 					headersLength += header.length() + headerValues[n++].length;
 				}
@@ -84,7 +85,7 @@ public abstract class EmbeddedHeaderUtils {
 			for (int i = 0; i < headers.length; i++) {
 				if (headerValues[i] != null) {
 					byteBuffer.put((byte) headers[i].length());
-					byteBuffer.put(headers[i].getBytes("UTF-8"));
+					byteBuffer.put(headers[i].getBytes(StandardCharsets.UTF_8));
 					byteBuffer.putInt(headerValues[i].length);
 					byteBuffer.put(headerValues[i]);
 				}
@@ -125,11 +126,11 @@ public abstract class EmbeddedHeaderUtils {
 			for (int i = 0; i < headerCount; i++) {
 				int len = byteBuffer.get() & 0xff;
 				String headerName = new String(payload, byteBuffer.position(), len,
-						"UTF-8");
+						StandardCharsets.UTF_8);
 				byteBuffer.position(byteBuffer.position() + len);
 				len = byteBuffer.getInt();
 				String headerValue = new String(payload, byteBuffer.position(), len,
-						"UTF-8");
+						StandardCharsets.UTF_8);
 				Object headerContent = objectMapper.fromJson(headerValue, Object.class);
 				headers.put(headerName, headerContent);
 				byteBuffer.position(byteBuffer.position() + len);

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/ObjectStringMessageConverter.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/ObjectStringMessageConverter.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.stream.converter;
 
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.stream.Collectors;
@@ -41,7 +40,7 @@ import org.springframework.util.MimeType;
 public class ObjectStringMessageConverter extends AbstractMessageConverter {
 
 	public ObjectStringMessageConverter() {
-		super(new MimeType("text", "*", Charset.forName("UTF-8")));
+		super(new MimeType("text", "*", StandardCharsets.UTF_8));
 		setStrictContentTypeMatch(true);
 	}
 

--- a/core/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/MessageConverterTests.java
+++ b/core/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/MessageConverterTests.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.stream.binder;
 
 import java.nio.BufferUnderflowException;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.Test;
 
@@ -101,7 +102,7 @@ public class MessageConverterTests {
 		byte[] embedded = EmbeddedHeaderUtils.embedHeaders(new MessageValues(message),
 				"foo", "baz");
 		assertThat(embedded[0] & 0xff).isEqualTo(0xff);
-		assertThat(new String(embedded, "UTF-8").substring(1)).isEqualTo(
+		assertThat(new String(embedded, StandardCharsets.UTF_8).substring(1)).isEqualTo(
 				"\u0002\u0003foo\u0000\u0000\u0000\u0005\"bar\"\u0003baz\u0000\u0000\u0000\u0012\"ØØØØØØØØ\"Hello");
 
 		MessageValues extracted = EmbeddedHeaderUtils


### PR DESCRIPTION
Use StandardCharsets.UTF_8 instead of hardcoded "UTF-8".

It could make the codebase be cosistent with regards to using Charsets.

### StandardCharsets.UTF_8 usages in the project
https://github.com/spring-cloud/spring-cloud-stream/blob/e1232ae7317d7a65bb92e0c6592a2858a3cc8ac9/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/ObjectStringMessageConverter.java#L94
https://github.com/spring-cloud/spring-cloud-stream/blob/e1232ae7317d7a65bb92e0c6592a2858a3cc8ac9/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/converter/ObjectStringMessageConverter.java#L106