### PR TITLE
fix the @return tag comment for `retryAndDlqInBinding` method

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/ListenerContainerWithDlqAndRetryCustomizer.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/ListenerContainerWithDlqAndRetryCustomizer.java
@@ -62,7 +62,7 @@ public interface ListenerContainerWithDlqAndRetryCustomizer
 	 * {@link #configure(AbstractMessageListenerContainer, String, String, BiFunction, BackOff)}.
 	 * @param destinationName the destination name.
 	 * @param group the group.
-	 * @return true to disable retrie in the binding
+	 * @return false to disable retries and DLQ in the binding
 	 */
 	default boolean retryAndDlqInBinding(String destinationName, String group) {
 		return true;

--- a/docs/src/main/asciidoc/kafka/kafka_overview.adoc
+++ b/docs/src/main/asciidoc/kafka/kafka_overview.adoc
@@ -894,7 +894,7 @@ void configure(AbstractMessageListenerContainer<?, ?> container, String destinat
  * {@link #configure(AbstractMessageListenerContainer, String, String, BiFunction, BackOff)}.
  * @param destinationName the destination name.
  * @param group the group.
- * @return true to disable retrie in the binding
+ * @return false to disable retries and DLQ in the binding
  */
 default boolean retryAndDlqInBinding(String destinationName, String group) {
     return true;


### PR DESCRIPTION
Fix the javadoc for `retryAndDlqInBinding` method.

It seems the `@return` tag comment for `retryAndDlqInBinding` method is accidentally missing some words.
By seeing how the method is used and the [PR](https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/pull/1162) where the method is introduced, I guess it was probably intended as below.

**"@return false to disable retries and DLQ in the binding"**

### the method call site
https://github.com/spring-cloud/spring-cloud-stream/blob/af2df8ba0eff2e81c3a8fce358a09a54abb3a974/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java#L724-L731

### a comment from the PR
> Provide a mechanism to provide retry/dlq configuration when adding a custom error handler,
effectively moving this functionality from the binder to the container.

