### PR TITLE
Remove the gitter chat badge in the README

### DIFF
--- a/docs/src/main/asciidoc/README.adoc
+++ b/docs/src/main/asciidoc/README.adoc
@@ -7,7 +7,6 @@
 
 image::https://circleci.com/gh/spring-cloud/spring-cloud-stream.svg?style=svg["CircleCI", link="https://circleci.com/gh/spring-cloud/spring-cloud-stream"]
 image::https://codecov.io/gh/spring-cloud/spring-cloud-stream/branch/{github-tag}/graph/badge.svg["codecov", link="https://codecov.io/gh/spring-cloud/spring-cloud-stream"]
-image::https://badges.gitter.im/spring-cloud/spring-cloud-stream.svg[Gitter, link="https://gitter.im/spring-cloud/spring-cloud-stream?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"]
 
 // ======================================================================================
 


### PR DESCRIPTION
Remove the gitter chat badge since the gitter channel is effectively closed.

### gitter channel close announcement 
https://gitter.im/spring-cloud/spring-cloud-stream?at=627a832ad4ef6e15af3c7c68