### PR TITLE
Health indicator fixes when topic is pattern

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderHealthIndicator.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderHealthIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -170,6 +170,19 @@ public class KafkaBinderHealthIndicator implements KafkaBinderHealth, Disposable
 							}
 						}
 						checkedTopics.add(topic);
+					}
+					else {
+						try {
+							// Since destination is a pattern, all we are doing is just to make sure that
+							// we can connect to the cluster and query the topics.
+							this.metadataConsumer.listTopics(Duration.ofSeconds(this.timeout));
+						}
+						catch (Exception ex) {
+							return Health.down()
+								.withDetail("Cluster not connected",
+									"Destination provided is a pattern, but cannot connect to the cluster for any verification")
+								.build();
+						}
 					}
 				}
 			}


### PR DESCRIPTION
When destination is pattern, even when the cluster is down, health indicator is erroneously reporting the status as UP. Addressing this issue by calling a simple listTopics on the consumer when the destination is pattern, and if it throws an exception, report the status as DOWN. If the call succeeds, we assume that the cluster is accessible.

Resolves https://github.com/spring-cloud/spring-cloud-stream/issues/2628