### PR TITLE
GH-2634: Reactor Kafka Binder Customization

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-reactive/src/main/java/org/springframework/cloud/stream/binder/reactorkafka/ReactorKafkaBinder.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-reactive/src/main/java/org/springframework/cloud/stream/binder/reactorkafka/ReactorKafkaBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 the original author or authors.
+ * Copyright 2021-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import reactor.kafka.sender.SenderOptions;
 import reactor.kafka.sender.SenderRecord;
 import reactor.kafka.sender.SenderResult;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.cloud.stream.binder.AbstractMessageChannelBinder;
 import org.springframework.cloud.stream.binder.BinderSpecificPropertiesProvider;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
@@ -86,6 +87,10 @@ public class ReactorKafkaBinder
 
 	private ProducerConfigCustomizer producerConfigCustomizer;
 
+	private ReceiverOptionsCustomizer receiverOptionsCustomizer = (name, opts) -> opts;
+
+	private SenderOptionsCustomizer senderOptionsCustomizer = (name, opts) -> opts;
+
 	public ReactorKafkaBinder(KafkaBinderConfigurationProperties configurationProperties,
 			KafkaTopicProvisioner provisioner) {
 
@@ -101,6 +106,44 @@ public class ReactorKafkaBinder
 		this.producerConfigCustomizer = producerConfigCustomizer;
 	}
 
+	public void receiverOptionsCustomizers(ObjectProvider<ReceiverOptionsCustomizer> customizers) {
+		if (customizers.getIfUnique() != null) {
+			this.receiverOptionsCustomizer = customizers.getIfUnique();
+		}
+		else {
+			List<ReceiverOptionsCustomizer> list = customizers.orderedStream().toList();
+			ReceiverOptionsCustomizer customizer = (name, opts) -> {
+				ReceiverOptions<Object, Object> last = null;
+				for (ReceiverOptionsCustomizer cust: list) {
+					last = cust.apply(name, opts);
+				}
+				return last;
+			};
+			if (!list.isEmpty()) {
+				this.receiverOptionsCustomizer = customizer;
+			}
+		}
+	}
+
+	public void senderOptionsCustomizers(ObjectProvider<SenderOptionsCustomizer> customizers) {
+		if (customizers.getIfUnique() != null) {
+			this.senderOptionsCustomizer = customizers.getIfUnique();
+		}
+		else {
+			List<SenderOptionsCustomizer> list = customizers.orderedStream().toList();
+			SenderOptionsCustomizer customizer = (name, opts) -> {
+				SenderOptions<Object, Object> last = null;
+				for (SenderOptionsCustomizer cust: list) {
+					last = cust.apply(name, opts);
+				}
+				return last;
+			};
+			if (!list.isEmpty()) {
+				this.senderOptionsCustomizer = customizer;
+			}
+		}
+	}
+
 	@Override
 	protected MessageHandler createProducerMessageHandler(ProducerDestination destination,
 			ExtendedProducerProperties<KafkaProducerProperties> producerProperties, MessageChannel errorChannel)
@@ -113,7 +156,8 @@ public class ReactorKafkaBinder
 					destination.getName());
 		}
 
-		SenderOptions<Object, Object> opts = SenderOptions.create(configs);
+		SenderOptions<Object, Object> opts = this.senderOptionsCustomizer.apply(producerProperties.getBindingName(),
+				SenderOptions.create(configs));
 		// TODO bean for converter; MCB doesn't use one on the producer side.
 		RecordMessageConverter converter = new MessagingMessageConverter();
 		return new ReactorMessageHandler(opts, converter, destination.getName());
@@ -139,6 +183,8 @@ public class ReactorKafkaBinder
 		ReceiverOptions<Object, Object> opts = ReceiverOptions.create(configs)
 			.addAssignListener(parts -> logger.info("Assigned: " + parts))
 			.subscription(Collections.singletonList(destination.getName()));
+		opts = this.receiverOptionsCustomizer.apply(properties.getBindingName(), opts);
+		ReceiverOptions<Object, Object> finalOpts = opts;
 
 		class ReactorMessageProducer extends MessageProducerSupport {
 
@@ -146,7 +192,7 @@ public class ReactorKafkaBinder
 
 			ReactorMessageProducer() {
 				for (int i = 0; i < properties.getConcurrency(); i++) {
-					this.receivers.add(KafkaReceiver.create(opts));
+					this.receivers.add(KafkaReceiver.create(finalOpts));
 				}
 			}
 

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-reactive/src/main/java/org/springframework/cloud/stream/binder/reactorkafka/ReactorKafkaBinderConfiguration.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-reactive/src/main/java/org/springframework/cloud/stream/binder/reactorkafka/ReactorKafkaBinderConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,12 +60,16 @@ public class ReactorKafkaBinderConfiguration {
 			KafkaTopicProvisioner provisioningProvider,
 			KafkaExtendedBindingProperties extendedBindingProperties,
 			ObjectProvider<ConsumerConfigCustomizer> consumerConfigCustomizer,
-			ObjectProvider<ProducerConfigCustomizer> producerConfigCustomizer) {
+			ObjectProvider<ProducerConfigCustomizer> producerConfigCustomizer,
+			ObjectProvider<ReceiverOptionsCustomizer> receiverOptionsCustomizers,
+			ObjectProvider<SenderOptionsCustomizer> senderOptionsptionsCustomizers) {
 
 		ReactorKafkaBinder reactorKafkaBinder = new ReactorKafkaBinder(configurationProperties, provisioningProvider);
 		reactorKafkaBinder.setExtendedBindingProperties(extendedBindingProperties);
 		reactorKafkaBinder.setConsumerConfigCustomizer(consumerConfigCustomizer.getIfUnique());
 		reactorKafkaBinder.setProducerConfigCustomizer(producerConfigCustomizer.getIfUnique());
+		reactorKafkaBinder.receiverOptionsCustomizers(receiverOptionsCustomizers);
+		reactorKafkaBinder.senderOptionsCustomizers(senderOptionsptionsCustomizers);
 		return reactorKafkaBinder;
 	}
 

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-reactive/src/main/java/org/springframework/cloud/stream/binder/reactorkafka/ReceiverOptionsCustomizer.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-reactive/src/main/java/org/springframework/cloud/stream/binder/reactorkafka/ReceiverOptionsCustomizer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.reactorkafka;
+
+import java.util.function.BiFunction;
+
+import reactor.kafka.receiver.ReceiverOptions;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+
+/**
+ * Customizer for {@link ReceiverOptions}; the first parameter contains the binder name;
+ * the second is the {@link ReceiverOptions} to customize. Return the customized
+ * {@link ReceiverOptions}. Applied in {@link Order} if multiple customizers are found.
+ *
+ * @author Gary Russell
+ * @since 4.0.2
+ *
+ */
+public interface ReceiverOptionsCustomizer
+		extends BiFunction<String, ReceiverOptions<Object, Object>, ReceiverOptions<Object, Object>>, Ordered {
+
+	@Override
+	default int getOrder() {
+		return 0;
+	}
+
+}

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-reactive/src/main/java/org/springframework/cloud/stream/binder/reactorkafka/SenderOptionsCustomizer.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-reactive/src/main/java/org/springframework/cloud/stream/binder/reactorkafka/SenderOptionsCustomizer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.reactorkafka;
+
+import java.util.function.BiFunction;
+
+import reactor.kafka.sender.SenderOptions;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+
+/**
+ * Customizer for {@link SenderOptions}; the first parameter contains the binder name; the
+ * second is the {@link SenderOptions} to customize. Return the customized
+ * {@link SenderOptions}. Applied in {@link Order} if multiple customizers are found.
+ *
+ * @author Gary Russell
+ * @since 4.0.2
+ *
+ */
+public interface SenderOptionsCustomizer
+		extends BiFunction<String, SenderOptions<Object, Object>, SenderOptions<Object, Object>>, Ordered {
+
+	@Override
+	default int getOrder() {
+		return 0;
+	}
+
+}

--- a/docs/src/main/asciidoc/kafka/kafka-reactive.adoc
+++ b/docs/src/main/asciidoc/kafka/kafka-reactive.adoc
@@ -40,7 +40,11 @@ This is because the underlying binder is built on top of https://projectreactor.
 On the consumer side, it makes use of the https://projectreactor.io/docs/kafka/release/reference/#api-guide-receiver[KafkaReceiver] which is a reactive implementation of a Kafka consumer.
 Similarly, on the producer side, it uses https://projectreactor.io/docs/kafka/release/reference/#api-guide-sender[KafkaSender] API which is the reactive implementation of a Kafka producer.
 Since the foundations of the reactive Kafka binder is built upon a proper reactive Kafka API, applications get the full benefits of using reactive technologies.
-Things like automatic backpressure among other reactive capabilities are built-in for the application when using this reactive Kafka binder.
+Things like automatic back pressure, among other reactive capabilities, are built-in for the application when using this reactive Kafka binder.
+
+Starting with version 4.0.2, you can customize the `ReceiverOptions` and `SenderOptions` by providing one or more `ReceiverOptionsCustomizer` or `SenderOptionsCustomizer` beans respectively.
+They are `BiFunction` s which receive the binding name and initial options, returning the customized options.
+The interfaces extend `Ordered` so the customizers will be applied in the order required, when more than one are present.
 
 === Consuming Records in the Raw Format
 


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-stream/issues/2634

Allow customization of `ReceiverOptions` and `ProducerOptions`.