### PR TITLE
BiConsumer creates an output binding

### DIFF
--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
@@ -839,7 +839,12 @@ public class FunctionConfiguration {
 						}
 						else {
 							this.inputCount = FunctionTypeUtils.getInputCount(function);
-							this.outputCount = this.getOutputCount(function, false);
+							if (function.isWrappedBiConsumer()) {
+								this.outputCount = 0;
+							}
+							else {
+								this.outputCount = this.getOutputCount(function, false);
+							}
 						}
 
 						AtomicReference<BindableFunctionProxyFactory> proxyFactory = new AtomicReference<>();


### PR DESCRIPTION
Currently, when the user provides a BiConsumer, the framework creates an output binding and subsequently a target destination on the middleware. This is unncessary and causes issues for the application. This commit addresses this issue.

This commit requires changes from the following PR in Spring Cloud Function: https://github.com/spring-cloud/spring-cloud-function/pull/1016