### PR TITLE
GH-2705: AOT support complex binding properties

### DIFF
--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
@@ -543,9 +543,11 @@ public class DefaultBinderFactory implements BinderFactory, DisposableBean, Appl
 	 */
 	GenericApplicationContext createUnitializedContextForAOT(String configurationName,
 			Map<String, Object> binderProperties, BinderConfiguration binderConfiguration) {
-
 		GenericApplicationContext binderContext = new GenericApplicationContext();
-
+		// Set the conversion service on the binder producing context to handle complex properties
+		if (this.context != null) {
+			binderContext.getBeanFactory().setConversionService(this.context.getBeanFactory().getConversionService());
+		}
 		MapPropertySource binderPropertySource = new MapPropertySource(configurationName, binderProperties);
 		binderContext.getEnvironment().getPropertySources().addFirst(binderPropertySource);
 		binderContext.setDisplayName(configurationName + "_context");


### PR DESCRIPTION
- Sets the conversion service on AOT child binder contexts to allow complex properties to be bound in extended binding props

**NOTE** Update of AOT smoke tests in progress in other PR.

Fixes #2705