### PR TITLE
GH-2709: Reactive Kafka Binder and Topic Patterns

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-reactive/src/main/java/org/springframework/cloud/stream/binder/reactorkafka/ReactorKafkaBinder.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-reactive/src/main/java/org/springframework/cloud/stream/binder/reactorkafka/ReactorKafkaBinder.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -197,8 +198,13 @@ public class ReactorKafkaBinder
 				.map(dest -> dest.trim())
 				.toList();
 		ReceiverOptions<Object, Object> opts = ReceiverOptions.create(configs)
-			.addAssignListener(parts -> logger.info("Assigned: " + parts))
-			.subscription(destList);
+			.addAssignListener(parts -> logger.info("Assigned: " + parts));
+		if (properties.getExtension().isDestinationIsPattern()) {
+			opts = opts.subscription(Pattern.compile(destinations));
+		}
+		else {
+			opts = opts.subscription(destList);
+		}
 		opts = this.receiverOptionsCustomizer.apply(properties.getBindingName(), opts);
 		ReceiverOptions<Object, Object> finalOpts = opts;
 


### PR DESCRIPTION
Resolves https://github.com/spring-cloud/spring-cloud-stream/issues/2709

Add support for `...destinationIsPattern` as is supported by the message channel binder.