### PR TITLE
reactor kafka sender result consumer draft

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-reactive/src/main/java/org/springframework/cloud/stream/binder/reactorkafka/SenderOptionsCustomizer.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-reactive/src/main/java/org/springframework/cloud/stream/binder/reactorkafka/SenderOptionsCustomizer.java
@@ -16,9 +16,12 @@
 
 package org.springframework.cloud.stream.binder.reactorkafka;
 
+import java.util.UUID;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 
 import reactor.kafka.sender.SenderOptions;
+import reactor.kafka.sender.SenderResult;
 
 import org.springframework.core.Ordered;
 
@@ -43,6 +46,11 @@ public interface SenderOptionsCustomizer<K, V>
 	@Override
 	default int getOrder() {
 		return 0;
+	}
+
+	default Consumer<SenderResult<UUID>> senderResultConsumer() {
+		return sr -> {
+		};
 	}
 
 }


### PR DESCRIPTION
Hi @garyrussell @artembilan ,
I just wanted to propose this for the sending the SenderResult.

It is just a draft to give an idea. I tested locally for my application and it seems to work fine.
I was thinking we could add a `Consumer<SenderResult<T>>` as part of **_SenderOptionsCustomizer_**.

```
default Consumer<SenderResult<UUID>> senderResultConsumer() {
	return sr -> {
               // default NO-OP
	};
}

```

Users like us can use it like this.

```
private final Sinks.Many<SenderResult<UUID>> sink = Sinks.many().unicast().onBackpressureBuffer();

@Bean
public SenderOptionsCustomizer<String, String> customizer(){
    return new SenderOptionsCustomizer<String, String>() {
        
        @Override
        public SenderOptions<String, String> apply(String s, SenderOptions<String, String> stringStringSenderOptions) {
            return stringStringSenderOptions;
        }

        @Override
        public Consumer<SenderResult<UUID>> senderResultConsumer() {
            return sink::tryEmitNext;
        }
    };
}
```
and somewhere else
```
public void printSentMessageIds(){
        sink.asFlux()
                .doOnNext(id -> print(id))
                .subscribe();
}
```




