### PR TITLE
Reactive Kafka Binder errors when concurrency > 1

### DIFF
--- a/core/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/function/ImplicitFunctionBindingTests.java
+++ b/core/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/function/ImplicitFunctionBindingTests.java
@@ -970,7 +970,7 @@ public class ImplicitFunctionBindingTests {
 				TestChannelBinderConfiguration.getCompleteConfiguration(ReactiveConsumerWithConcurrencyFailureConfiguration.class))
 				.web(WebApplicationType.NONE).run("--spring.jmx.enabled=false",
 					"--spring.cloud.stream.bindings.input-in-0.consumer.concurrency=2")) {
-			assertThat(output).contains("When using concurrency > 1 in reactive contexts, please make sure that you are using a proper reactive binder");
+			assertThat(output).contains("When using concurrency > 1 in reactive contexts, please make sure that you are using a reactive binder");
 		}
 	}
 

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
@@ -519,7 +519,7 @@ public class FunctionConfiguration {
 						function.setSkipInputConversion(consumerProperties.isUseNativeDecoding());
 						if (consumerProperties.getConcurrency() > 1) {
 							this.logger.warn("When using concurrency > 1 in reactive contexts, please make sure that you are using a proper " +
-								"reactive binder that supports concurrency settings. Otherwise, concurrency settings > 1 will be a no-op when " +
+								"reactive binder that supports concurrency settings. Otherwise, concurrency settings > 1 will be ignored when " +
 								"using reactive types.");
 						}
 					}

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
@@ -518,7 +518,7 @@ public class FunctionConfiguration {
 					if (consumerProperties != null) {
 						function.setSkipInputConversion(consumerProperties.isUseNativeDecoding());
 						if (consumerProperties.getConcurrency() > 1) {
-							this.logger.warn("When using concurrency > 1 in reactive contexts, please make sure that you are using a proper " +
+							this.logger.warn("When using concurrency > 1 in reactive contexts, please make sure that you are using a " +
 								"reactive binder that supports concurrency settings. Otherwise, concurrency settings > 1 will be ignored when " +
 								"using reactive types.");
 						}

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
@@ -517,9 +517,11 @@ public class FunctionConfiguration {
 					ConsumerProperties consumerProperties = bindingProperties == null ? null : bindingProperties.getConsumer();
 					if (consumerProperties != null) {
 						function.setSkipInputConversion(consumerProperties.isUseNativeDecoding());
-						Assert.isTrue(consumerProperties.getConcurrency() <= 1, "Concurrency > 1 is not supported by reactive "
-								+ "consumer, given that project reactor maintains its own concurrency mechanism. Was '..."
-								+ inputBindingName + ".consumer.concurrency=" + consumerProperties.getConcurrency() + "'");
+						if (consumerProperties.getConcurrency() > 1) {
+							this.logger.warn("When using concurrency > 1 in reactive contexts, please make sure that you are using a proper " +
+								"reactive binder that supports concurrency settings. Otherwise, concurrency settings > 1 will be a no-op when " +
+								"using reactive types.");
+						}
 					}
 					MessageChannel inputChannel = this.applicationContext.getBean(inputBindingName, MessageChannel.class);
 					return IntegrationReactiveUtils.messageChannelToFlux(inputChannel).map(m -> {


### PR DESCRIPTION
When using Reactive Kafka binder, it is allowed to have concurrency > 1. There is a check in FunctionConfiguration that throws an error if concurrency is > 1, when using reactive types. Since it is allowed to do so with Reative Kafka binder, switch this conversion into a warning log message.

Resolves https://github.com/spring-cloud/spring-cloud-stream/issues/2726