### PR TITLE
KafkaStreams Functions Detection Logic

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderUtils.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderUtils.java
@@ -82,7 +82,7 @@ public final class KafkaStreamsBinderUtils {
 	 * @param methods collection of methods to search from
 	 * @return found method as an {@link Optional}
 	 */
-	public static Optional<Method> findTargetMethod(String key, Method[] methods) {
+	public static Optional<Method> findMethodWithName(String key, Method[] methods) {
 		return Arrays.stream(methods).filter(m -> m.getName().equals(key)).findFirst();
 	}
 

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderUtils.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,12 @@
 
 package org.springframework.cloud.stream.binder.kafka.streams;
 
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.BiFunction;
 
 import org.apache.commons.logging.Log;
@@ -64,12 +67,23 @@ import org.springframework.util.StringUtils;
  * @author Soby Chacko
  * @author Gary Russell
  */
-final class KafkaStreamsBinderUtils {
+public final class KafkaStreamsBinderUtils {
 
 	private static final Log LOGGER = LogFactory.getLog(KafkaStreamsBinderUtils.class);
 
 	private KafkaStreamsBinderUtils() {
 
+	}
+
+	/**
+	 * Utility method to find the method targeted by the key.
+	 *
+	 * @param key name of the method
+	 * @param methods collection of methods to search from
+	 * @return found method as an {@link Optional}
+	 */
+	public static Optional<Method> findTargetMethod(String key, Method[] methods) {
+		return Arrays.stream(methods).filter(m -> m.getName().equals(key)).findFirst();
 	}
 
 	static void prepareConsumerBinding(String name, String group,

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/function/FunctionDetectorCondition.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/function/FunctionDetectorCondition.java
@@ -95,17 +95,17 @@ public class FunctionDetectorCondition extends SpringBootCondition {
 			try {
 
 				Method[] methods = classObj.getDeclaredMethods();
-				Optional<Method> kafkaStreamMethod = KafkaStreamsBinderUtils.findTargetMethod(key, methods);
+				Optional<Method> kafkaStreamMethod = KafkaStreamsBinderUtils.findMethodWithName(key, methods);
 				if (kafkaStreamMethod.isEmpty()) {
 					// check any inherited methods
 					methods = classObj.getMethods();
-					kafkaStreamMethod = KafkaStreamsBinderUtils.findTargetMethod(key, methods);
+					kafkaStreamMethod = KafkaStreamsBinderUtils.findMethodWithName(key, methods);
 				}
 				if (kafkaStreamMethod.isEmpty()) {
 					// check if the bean name is overridden.
 					final BeanDefinition beanDefinition = context.getBeanFactory().getBeanDefinition(key);
 					final String factoryMethodName = beanDefinition.getFactoryMethodName();
-					kafkaStreamMethod = KafkaStreamsBinderUtils.findTargetMethod(factoryMethodName, methods);
+					kafkaStreamMethod = KafkaStreamsBinderUtils.findMethodWithName(factoryMethodName, methods);
 				}
 
 				if (kafkaStreamMethod.isPresent()) {

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsFunctionBeanPostProcessor.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsFunctionBeanPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.cloud.stream.binder.kafka.streams.KafkaStreamsBinderUtils;
 import org.springframework.cloud.stream.function.StreamFunctionProperties;
 import org.springframework.core.ResolvableType;
 import org.springframework.util.ClassUtils;
@@ -176,11 +177,15 @@ public class KafkaStreamsFunctionBeanPostProcessor implements InitializingBean, 
 				ClassUtils.getDefaultClassLoader());
 		try {
 			Method[] methods = classObj.getDeclaredMethods();
-			Optional<Method> functionalBeanMethods = Arrays.stream(methods).filter(m -> m.getName().equals(key)).findFirst();
+			Optional<Method> functionalBeanMethods = KafkaStreamsBinderUtils.findTargetMethod(key, methods);
+			if (functionalBeanMethods.isEmpty()) {
+				methods = classObj.getMethods(); // check the inherited methods
+				functionalBeanMethods = KafkaStreamsBinderUtils.findTargetMethod(key, methods);
+			}
 			if (functionalBeanMethods.isEmpty()) {
 				final BeanDefinition beanDefinition = this.beanFactory.getBeanDefinition(key);
 				final String factoryMethodName = beanDefinition.getFactoryMethodName();
-				functionalBeanMethods = Arrays.stream(methods).filter(m -> m.getName().equals(factoryMethodName)).findFirst();
+				functionalBeanMethods = KafkaStreamsBinderUtils.findTargetMethod(factoryMethodName, methods);
 			}
 
 			if (functionalBeanMethods.isPresent()) {

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsFunctionBeanPostProcessor.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsFunctionBeanPostProcessor.java
@@ -177,15 +177,15 @@ public class KafkaStreamsFunctionBeanPostProcessor implements InitializingBean, 
 				ClassUtils.getDefaultClassLoader());
 		try {
 			Method[] methods = classObj.getDeclaredMethods();
-			Optional<Method> functionalBeanMethods = KafkaStreamsBinderUtils.findTargetMethod(key, methods);
+			Optional<Method> functionalBeanMethods = KafkaStreamsBinderUtils.findMethodWithName(key, methods);
 			if (functionalBeanMethods.isEmpty()) {
 				methods = classObj.getMethods(); // check the inherited methods
-				functionalBeanMethods = KafkaStreamsBinderUtils.findTargetMethod(key, methods);
+				functionalBeanMethods = KafkaStreamsBinderUtils.findMethodWithName(key, methods);
 			}
 			if (functionalBeanMethods.isEmpty()) {
 				final BeanDefinition beanDefinition = this.beanFactory.getBeanDefinition(key);
 				final String factoryMethodName = beanDefinition.getFactoryMethodName();
-				functionalBeanMethods = KafkaStreamsBinderUtils.findTargetMethod(factoryMethodName, methods);
+				functionalBeanMethods = KafkaStreamsBinderUtils.findMethodWithName(factoryMethodName, methods);
 			}
 
 			if (functionalBeanMethods.isPresent()) {

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/bootstrap/KafkaStreamsBinderBootstrapTest.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/bootstrap/KafkaStreamsBinderBootstrapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -176,7 +176,7 @@ class KafkaStreamsBinderBootstrapTest {
 	}
 
 	@SpringBootApplication
-	static class SimpleKafkaStreamsApplication {
+	static class SimpleKafkaStreamsApplication extends BaseConfig {
 
 		@Bean
 		public Consumer<KStream<Object, String>> input1() {
@@ -192,6 +192,11 @@ class KafkaStreamsBinderBootstrapTest {
 			};
 		}
 
+	}
+
+	// Testing the scenario reported by https://github.com/spring-cloud/spring-cloud-stream/issues/2737
+	static class BaseConfig {
+
 		@Bean
 		public Consumer<GlobalKTable<Object, String>> input3() {
 			return s -> {
@@ -199,4 +204,6 @@ class KafkaStreamsBinderBootstrapTest {
 			};
 		}
 	}
+
+
 }


### PR DESCRIPTION
Kafka Streams functions declared in super classes are no longer detected by the binder discovery algorithms. Fixing this issue by properly scanning the methods from the super classes.

Resolves https://github.com/spring-cloud/spring-cloud-stream/issues/2737