### PR TITLE
Fix FunctionUnit derivation

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderUtils.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderUtils.java
@@ -66,6 +66,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Soby Chacko
  * @author Gary Russell
+ * @author James Forward
  */
 public final class KafkaStreamsBinderUtils {
 
@@ -84,6 +85,14 @@ public final class KafkaStreamsBinderUtils {
 	 */
 	public static Optional<Method> findMethodWithName(String key, Method[] methods) {
 		return Arrays.stream(methods).filter(m -> m.getName().equals(key)).findFirst();
+	}
+
+	public static String[] deriveFunctionUnits(String definition) {
+		if(!StringUtils.hasText(definition)) {
+			return new String[]{};
+		}
+		final String[] rawSplitDefinition = definition.split(";");
+		return Arrays.stream(rawSplitDefinition).map(String::trim).toArray(String[]::new);
 	}
 
 	static void prepareConsumerBinding(String name, String group,

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsFunctionBeanPostProcessor.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsFunctionBeanPostProcessor.java
@@ -52,10 +52,11 @@ import org.springframework.cloud.stream.binder.kafka.streams.KafkaStreamsBinderU
 import org.springframework.cloud.stream.function.StreamFunctionProperties;
 import org.springframework.core.ResolvableType;
 import org.springframework.util.ClassUtils;
-import org.springframework.util.StringUtils;
 
 /**
  * @author Soby Chacko
+ * @author James Forward
+ *
  * @since 2.2.0
  */
 public class KafkaStreamsFunctionBeanPostProcessor implements InitializingBean, BeanFactoryAware {
@@ -110,7 +111,7 @@ public class KafkaStreamsFunctionBeanPostProcessor implements InitializingBean, 
 		BeanDefinitionRegistry registry = (BeanDefinitionRegistry) beanFactory;
 
 		final String definition = streamFunctionProperties.getDefinition();
-		final String[] functionUnits = StringUtils.hasText(definition) ? definition.split(";") : new String[]{};
+		final String[] functionUnits = KafkaStreamsBinderUtils.deriveFunctionUnits(definition);
 
 		final Set<String> kafkaStreamsMethodNames = new HashSet<>(kafkaStreamsOnlyResolvableTypes.keySet());
 		kafkaStreamsMethodNames.addAll(this.resolvableTypeMap.keySet());

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsFunctionProcessorInvoker.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/function/KafkaStreamsFunctionProcessorInvoker.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 
 import jakarta.annotation.PostConstruct;
 
+import org.springframework.cloud.stream.binder.kafka.streams.KafkaStreamsBinderUtils;
 import org.springframework.cloud.stream.binder.kafka.streams.KafkaStreamsFunctionProcessor;
 import org.springframework.cloud.stream.function.StreamFunctionProperties;
 import org.springframework.core.ResolvableType;
@@ -30,6 +31,8 @@ import org.springframework.util.StringUtils;
 
 /**
  * @author Soby Chacko
+ * @author James Forward
+ *
  * @since 2.1.0
  */
 public class KafkaStreamsFunctionProcessorInvoker {
@@ -54,7 +57,7 @@ public class KafkaStreamsFunctionProcessorInvoker {
 	@PostConstruct
 	void invoke() {
 		final String definition = streamFunctionProperties.getDefinition();
-		final String[] functionUnits = StringUtils.hasText(definition) ? definition.split(";") : new String[]{};
+		final String[] functionUnits = KafkaStreamsBinderUtils.deriveFunctionUnits(definition);
 
 		if (functionUnits.length == 0) {
 						resolvableTypeMap.forEach((key, value) -> {

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderUtilsTest.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderUtilsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.kafka.streams;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+/**
+ * Tests for {@link KafkaStreamsBinderUtils} functions
+ *
+ * @author James Forward
+ */
+class KafkaStreamsBinderUtilsTest {
+
+	@Test
+	void testDeriveFunctionUnitsWithVariedSpacings() {
+		final String definition = "firstFunction; secondFunction;   thirdFunction;fourthFunction";
+
+		final String[] functionUnits = KafkaStreamsBinderUtils.deriveFunctionUnits(definition);
+
+		assertAll(
+			() -> assertThat(functionUnits.length).isEqualTo(4),
+			() -> assertThat(functionUnits[0]).isEqualTo("firstFunction"),
+			() -> assertThat(functionUnits[1]).isEqualTo("secondFunction"),
+			() -> assertThat(functionUnits[2]).isEqualTo("thirdFunction"),
+			() -> assertThat(functionUnits[3]).isEqualTo("fourthFunction")
+		);
+	}
+}


### PR DESCRIPTION
Given the following definition:

```
spring:
  cloud:
    function:
      definition: >
        function1;
        function2;
        function3
```

the Kafka Stream binder does *not* work, as after a split, each function will contain a leading whitespace, so when it later on goes to do a comparison to declared function method names via `kafkaStreamsMethodNames.contains`, it doesn't actually create the bindings when it should:

```
if (kafkaStreamsMethodNames.contains(functionUnit)) {
						ResolvableType[] resolvableTypes = new ResolvableType[]{getResolvableTypes().get(functionUnit)};
						RootBeanDefinition rootBeanDefinition = new RootBeanDefinition(
								KafkaStreamsBindableProxyFactory.class);
						registerKakaStreamsProxyFactory(registry, functionUnit, resolvableTypes, rootBeanDefinition);
					}
```

The current workaround is to place everything on one line, which is ugly if you have lots of functions.