### PR TITLE
Fix for function auto-detection when input/output-bindings are defined

### DIFF
--- a/core/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/binding/ExplicitBindingTests.java
+++ b/core/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/binding/ExplicitBindingTests.java
@@ -57,6 +57,28 @@ public class ExplicitBindingTests {
 	}
 
 	@Test
+	void testExplicitBindingsWithExistingFunctionalBean() {
+		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
+			TestChannelBinderConfiguration.getCompleteConfiguration(ConsumerConfiguration.class))
+			.web(WebApplicationType.NONE)
+			.run("--spring.jmx.enabled=false",
+				"--spring.cloud.stream.input-bindings=test")) {
+
+			assertThat(context.getBean("test", MessageChannel.class)).isNotNull();
+		}
+
+		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
+			TestChannelBinderConfiguration.getCompleteConfiguration(ConsumerConfiguration.class))
+			.web(WebApplicationType.NONE)
+			.run("--spring.jmx.enabled=false",
+				"--spring.cloud.stream.input-bindings=test;test1")) {
+
+			assertThat(context.getBean("test", MessageChannel.class)).isNotNull();
+			assertThat(context.getBean("test1", MessageChannel.class)).isNotNull();
+		}
+	}
+
+	@Test
 	void testExplicitBindingsWithExistingConsumer() {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
 			TestChannelBinderConfiguration.getCompleteConfiguration(ConsumerConfiguration.class))

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
@@ -120,6 +120,7 @@ import org.springframework.util.StringUtils;
  * @author Soby Chacko
  * @author Chris Bono
  * @author Byungjun You
+ * @author Ivan Shapoval
  * @since 2.1
  */
 @AutoConfiguration
@@ -887,7 +888,7 @@ public class FunctionConfiguration {
 					);
 			for (String inputBindingName : inputBindings) {
 				FunctionInvocationWrapper sourceFunc = functionCatalog.lookup(inputBindingName);
-				if (sourceFunc != null && !sourceFunc.getFunctionDefinition().equals(inputBindingName) && inputBindings.length == 1) {
+				if (sourceFunc != null && !sourceFunc.getFunctionDefinition().equals(inputBindingName)) {
 					sourceFunc = null;
 				}
 
@@ -903,7 +904,7 @@ public class FunctionConfiguration {
 
 			for (String outputBindingName : outputBindings) {
 				FunctionInvocationWrapper sourceFunc = functionCatalog.lookup(outputBindingName);
-				if (sourceFunc != null && !sourceFunc.getFunctionDefinition().equals(outputBindingName) && outputBindings.length == 1) {
+				if (sourceFunc != null && !sourceFunc.getFunctionDefinition().equals(outputBindingName)) {
 					sourceFunc = null;
 				}
 


### PR DESCRIPTION
This issue was discovered in the case of explicit binding creation but in ApplicationContext already exist some functional beans that should not be treated as binding function.
Already present [fix](https://github.com/spring-cloud/spring-cloud-stream/commit/2ab71f2f320bad3ce7af6e059d205f8230ba1d08) for case when I have single input/output-bindings but it will not work when I have several explicit binding.