### PR TITLE
GH-2770: sendto header and key extraction

### DIFF
--- a/core/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/function/ImplicitFunctionBindingTests.java
+++ b/core/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/function/ImplicitFunctionBindingTests.java
@@ -974,7 +974,8 @@ public class ImplicitFunctionBindingTests {
 			.web(WebApplicationType.NONE).run("--spring.jmx.enabled=false",
 				// partition-key-extractor also works below, but for easy testing we picked partition-key-expression since
 				// partition-key-extractor requires defining a bean.
-				"--spring.cloud.stream.bindings.aa.producer.partition-key-expression=payload")) {
+				"--spring.cloud.stream.bindings.aa.producer.partition-key-expression=payload",
+				"--spring.cloud.stream.bindings.bb.producer.partition-key-expression=payload")) {
 
 			InputDestination inputDestination = context.getBean(InputDestination.class);
 			OutputDestination outputDestination = context.getBean(OutputDestination.class);
@@ -997,7 +998,7 @@ public class ImplicitFunctionBindingTests {
 			receivedMessage = outputDestination.receive(1000, "bb");
 
 			MessageChannel bb = streamBridge.resolveDestination("bb", null, null);
-			List<ChannelInterceptor> interceptors2 = ((AbstractMessageChannel) aa).getInterceptors();
+			List<ChannelInterceptor> interceptors2 = ((AbstractMessageChannel) bb).getInterceptors();
 
 			assertThat(interceptors2.size()).isEqualTo(1);
 			assertThat(interceptors2.get(0)).isInstanceOf(DefaultPartitioningInterceptor.class);

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
@@ -71,6 +71,7 @@ import org.springframework.cloud.stream.binder.PartitionHandler;
 import org.springframework.cloud.stream.binder.ProducerProperties;
 import org.springframework.cloud.stream.binder.ProducerProperties.PollerProperties;
 import org.springframework.cloud.stream.binding.BindableProxyFactory;
+import org.springframework.cloud.stream.binding.DefaultPartitioningInterceptor;
 import org.springframework.cloud.stream.binding.NewDestinationBindingCallback;
 import org.springframework.cloud.stream.binding.SupportedBindableFeatures;
 import org.springframework.cloud.stream.config.BinderFactoryAutoConfiguration;
@@ -681,6 +682,12 @@ public class FunctionConfiguration {
 					if (result instanceof Message messageResult && messageResult.getHeaders().get("spring.cloud.stream.sendto.destination") != null) {
 						String destinationName = (String) messageResult.getHeaders().get("spring.cloud.stream.sendto.destination");
 						MessageChannel outputChannel = streamBridge.resolveDestination(destinationName, producerProperties, null);
+						BindingProperties bindingProperties = serviceProperties.getBindingProperties(destinationName);
+						ProducerProperties sendToBindingProducerProperties = bindingProperties.getProducer();
+						if (sendToBindingProducerProperties != null && sendToBindingProducerProperties.isPartitioned()) {
+							((AbstractMessageChannel) outputChannel)
+								.addInterceptor(new DefaultPartitioningInterceptor(bindingProperties, applicationContext.getBeanFactory()));
+						}
 						if (logger.isInfoEnabled()) {
 							logger.info("Output message is sent to '" + destinationName + "' destination");
 						}


### PR DESCRIPTION
When sendto header is used for dynamic destinations and a partition key extractor is given for binder based partitioning, then the partition key extractor is not invoked when publishing the message. Addressing this issue.

Resolves https://github.com/spring-cloud/spring-cloud-stream/issues/2770