### PR TITLE
If kafka truststore and keystore locations

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
@@ -62,6 +62,7 @@ import org.springframework.util.StringUtils;
  * @author Lukasz Kaminski
  * @author Chukwubuikem Ume-Ugwa
  * @author Nico Heller
+ * @author Norbert Gyurian
  */
 public class KafkaBinderConfigurationProperties {
 
@@ -213,7 +214,8 @@ public class KafkaBinderConfigurationProperties {
 	private boolean checkIfFileExists(String path) {
 		try {
 			return Files.isRegularFile(Paths.get(path));
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			return false;
 		}
 	}

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/test/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationPropertiesTest.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/test/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationPropertiesTest.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.stream.binder.kafka.properties;
 
-import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
@@ -24,6 +23,7 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Map;
 
+import com.sun.net.httpserver.HttpServer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.assertj.core.util.Files;
 import org.junit.jupiter.api.Test;

--- a/docs/src/main/asciidoc/kafka/kafka_overview.adoc
+++ b/docs/src/main/asciidoc/kafka/kafka_overview.adoc
@@ -151,12 +151,12 @@ Flag to set the binder health as `down`, when any partitions on the topic, regar
 Default: `false`.
 
 spring.cloud.stream.kafka.binder.certificateStoreDirectory::
-When the truststore or keystore certificate location is given as a classpath URL (`classpath:...`), the binder copies the resource from the classpath location inside the JAR file to a location on the filesystem.
+When the truststore or keystore certificate location is given as a non-local file system resources, the binder copies the resource from the path (which is convertible to org.springframework.core.io.Resource) to a location on the filesystem.
 This is true for both broker level certificates (`ssl.truststore.location` and `ssl.keystore.location`) and certificates intended for schema registry (`schema.registry.ssl.truststore.location` and `schema.registry.ssl.keystore.location`).
-Keep in mind that the truststore and keystore classpath locations must be provided under `spring.cloud.stream.kafka.binder.configuration...`.
+Keep in mind that the truststore and keystore location paths must be provided under `spring.cloud.stream.kafka.binder.configuration...`.
 For example, `spring.cloud.stream.kafka.binder.configuration.ssl.truststore.location`, `spring.cloud.stream.kafka.binder.configuration.schema.registry.ssl.truststore.location`, etc.
-The file will be moved to the location specified as the value for this property which must be an existing directory on the filesystem that is writable by the process running the application.
-If this value is not set and the certificate file is a classpath resource, then it will be moved to System's temp directory as returned by `System.getProperty("java.io.tmpdir")`.
+The file will be copied to the location specified as the value for this property which must be an existing directory on the filesystem that is writable by the process running the application.
+If this value is not set and the certificate file is a non-local file system resource, then it will be copied to System's temp directory as returned by `System.getProperty("java.io.tmpdir")`.
 This is also true, if this value is present, but the directory cannot be found on the filesystem or is not writable.
 +
 Default: none.

--- a/docs/src/main/asciidoc/kafka/kafka_overview.adoc
+++ b/docs/src/main/asciidoc/kafka/kafka_overview.adoc
@@ -151,7 +151,8 @@ Flag to set the binder health as `down`, when any partitions on the topic, regar
 Default: `false`.
 
 spring.cloud.stream.kafka.binder.certificateStoreDirectory::
-When the truststore or keystore certificate location is given as a non-local file system resources, the binder copies the resource from the path (which is convertible to org.springframework.core.io.Resource) to a location on the filesystem.
+When the truststore or keystore certificate location is given as a non-local file system resource (resources supported by org.springframework.core.io.Resource e.g. CLASSPATH, HTTP, etc.),
+the binder copies the resource from the path (which is convertible to org.springframework.core.io.Resource) to a location on the filesystem.
 This is true for both broker level certificates (`ssl.truststore.location` and `ssl.keystore.location`) and certificates intended for schema registry (`schema.registry.ssl.truststore.location` and `schema.registry.ssl.keystore.location`).
 Keep in mind that the truststore and keystore location paths must be provided under `spring.cloud.stream.kafka.binder.configuration...`.
 For example, `spring.cloud.stream.kafka.binder.configuration.ssl.truststore.location`, `spring.cloud.stream.kafka.binder.configuration.schema.registry.ssl.truststore.location`, etc.


### PR DESCRIPTION
If kafka truststore and keystore locations are not local files, then they are converted to org.springframework.core.io.Resource resources, then copied to local file system. This means that, paths can be defined as http resources too. It is useful if you have a config server where your certificates reside.