### PR TITLE
Nested Configuration Problem For ProducerProperties And ConsumerProperties under BindingProperties(Spring Native Docker Image)

### DIFF
--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingProperties.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingProperties.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.stream.config;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.cloud.stream.binder.ConsumerProperties;
 import org.springframework.cloud.stream.binder.ProducerProperties;
 import org.springframework.util.MimeType;
@@ -33,6 +34,7 @@ import org.springframework.validation.annotation.Validated;
  * @author Gary Russell
  * @author Soby Chacko
  * @author Oleg Zhurakousky
+ * @author Omer Celik
  */
 @JsonInclude(Include.NON_DEFAULT)
 @Validated
@@ -82,11 +84,13 @@ public class BindingProperties {
 	/**
 	 * Additional consumer specific properties (see {@link ConsumerProperties}).
 	 */
+	@NestedConfigurationProperty
 	private ConsumerProperties consumer;
 
 	/**
 	 * Additional producer specific properties (see {@link ProducerProperties}).
 	 */
+	@NestedConfigurationProperty
 	private ProducerProperties producer;
 
 	public String getDestination() {


### PR DESCRIPTION
Resolves #2787 

Hello, I had opened [nested-configuration-issue](https://github.com/spring-cloud/spring-cloud-stream/issues/2787) before. I have created a request to resolve this error. I would appreciate it if you take the time to look into it.

The ConsumerProperties and ProducerProperties configs under BindingProperties were being initialized to null. For this reason, none of the consumer or producer configurations under Bindings work. This is the reason why the autoStartup configuration in the issue I opened does not work.

This problem only occurs when I build with spring native. (Spring Native Docker Image)

For example, the yellow marked configurations in the picture will not work.




![nested-property-issue](https://github.com/spring-cloud/spring-cloud-stream/assets/34758411/4059cb03-a7b1-449f-9191-06a4f8928242)

