### PR TITLE
Register InputBindingLifecycle and OutputBindingLifecycle Classes For Spring Native

### DIFF
--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aot/StreamRuntimeHints.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/aot/StreamRuntimeHints.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.aot;
+
+import java.util.stream.Stream;
+
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.ReflectionHints;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.cloud.stream.binding.InputBindingLifecycle;
+import org.springframework.cloud.stream.binding.OutputBindingLifecycle;
+import org.springframework.lang.Nullable;
+
+/**
+ * {@link RuntimeHintsRegistrar} for the Core in Spring Cloud Stream.
+ *
+ * @author Omer Celik
+ *
+ */
+public class StreamRuntimeHints implements RuntimeHintsRegistrar {
+	@Override
+	public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
+		ReflectionHints reflectionHints = hints.reflection();
+		Stream.of(
+				InputBindingLifecycle.class,
+				OutputBindingLifecycle.class)
+			.forEach(type -> reflectionHints.registerType(type,
+				builder -> builder.withMembers(MemberCategory.DECLARED_FIELDS)));
+	}
+}

--- a/core/spring-cloud-stream/src/main/resources/META-INF/spring/aot.factories
+++ b/core/spring-cloud-stream/src/main/resources/META-INF/spring/aot.factories
@@ -1,0 +1,1 @@
+org.springframework.aot.hint.RuntimeHintsRegistrar=org.springframework.cloud.stream.aot.StreamRuntimeHints


### PR DESCRIPTION
I am using spring cloud stream function in my project. I am also creating a docker image with spring native. If I try to start bindings with the BindingsLifecycleController bean, I get the following error. I reviewed the code. Attempting to access inputBindings field with Reflection. So we need to register them for spring native. I developed the code and tried it, it works. But I don't know if the solution I found is correct. Or I don't know if it is right for you to solve this problem in this way.

I would also love to be able to contribute to the community. I would be very happy if you could guide me. (_For Example : Maybe it would be better to add the ConditionalOnBean annotation.(ConditionalOnBean(value = BindingsLifecycleController.class_))


My Project Github Link: [graalvm-spring-cloud-stream](https://github.com/omercelikceng/graalvm-spring-cloud-auto-startup)

**Spring Boot Starter Parent Version :** 3.1.2
**Spring Cloud Version :** 2022.0.4
**GraalVM Version:** 17

Code:
```
@Service("personInitializer")
public class PersonInitializer implements SmartLifecycle {

    @Autowired
    private BindingsLifecycleController lifecycleController;

    @Override
    public void start() {
        lifecycleController.changeState("listenPersonData-in-0", STARTED);
    }
}
```


Error:

```
org.springframework.beans.NotReadablePropertyException: Invalid property 'inputBindings' of bean class [org.springframework.cloud.stream.binding.InputBindingLifecycle]: Bean property 'inputBindings' is not readable or has an invalid getter method: Does the return type of the getter match the parameter type of the setter?
        at org.springframework.beans.AbstractNestablePropertyAccessor.getPropertyValue(AbstractNestablePropertyAccessor.java:626) ~[org.example.graalvm.spring.cloud.GraalVMInitializationApplication:6.0.11]
        at org.springframework.beans.AbstractNestablePropertyAccessor.getPropertyValue(AbstractNestablePropertyAccessor.java:616) ~[org.example.graalvm.spring.cloud.GraalVMInitializationApplication:6.0.11]
        at org.springframework.cloud.stream.binding.BindingsLifecycleController.gatherInputBindings(BindingsLifecycleController.java:158) ~[org.example.graalvm.spring.cloud.GraalVMInitializationApplication:4.1.0-DOOB-SNAPSHOT]
        at org.springframework.cloud.stream.binding.BindingsLifecycleController.locateBinding(BindingsLifecycleController.java:180) ~[org.example.graalvm.spring.cloud.GraalVMInitializationApplication:4.1.0-DOOB-SNAPSHOT]
        at org.springframework.cloud.stream.binding.BindingsLifecycleController.changeState(BindingsLifecycleController.java:112) ~[org.example.graalvm.spring.cloud.GraalVMInitializationApplication:4.1.0-DOOB-SNAPSHOT]
        at org.example.graalvm.spring.cloud.PersonScheduled.deneme(PersonScheduled.java:24) ~[org.example.graalvm.spring.cloud.GraalVMInitializationApplication:na]
        at java.base@17.0.7/java.lang.reflect.Method.invoke(Method.java:568) ~[org.example.graalvm.spring.cloud.GraalVMInitializationApplication:na]
        at org.springframework.scheduling.support.ScheduledMethodRunnable.run(ScheduledMethodRunnable.java:84) ~[na:na]
        at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54) ~[org.example.graalvm.spring.cloud.GraalVMInitializationApplication:6.0.11]
        at java.base@17.0.7/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) ~[na:na]
        at java.base@17.0.7/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) ~[org.example.graalvm.spring.cloud.GraalVMInitializationApplication:na]
        at java.base@17.0.7/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[na:na]
        at java.base@17.0.7/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[org.example.graalvm.spring.cloud.GraalVMInitializationApplication:na]
        at java.base@17.0.7/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[na:na]
        at java.base@17.0.7/java.lang.Thread.run(Thread.java:833) ~[org.example.graalvm.spring.cloud.GraalVMInitializationApplication:na]
        at com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:838) ~[org.example.graalvm.spring.cloud.GraalVMInitializationApplication:na]
        at com.oracle.svm.core.posix.thread.PosixPlatformThreads.pthreadStartRoutine(PosixPlatformThreads.java:211) ~[na:na]
```

In this code in the photo, the inputbindings field is accessed by reflection.
![image](https://github.com/spring-cloud/spring-cloud-stream/assets/34758411/9d465b61-1911-487b-b025-61e97bc155c2)
