### PR TITLE
GH-2662: Kafka binder DLQ root cause message

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
@@ -1300,7 +1300,7 @@ public class KafkaBinderTests extends
 			else {
 				assertThat(new String((byte[]) receivedMessage.getHeaders()
 						.get(KafkaMessageChannelBinder.X_EXCEPTION_MESSAGE))).startsWith(
-								"Dispatcher failed to deliver Message");
+								"Dispatcher failed to deliver Message; fail");
 			}
 
 			assertThat(receivedMessage.getHeaders()


### PR DESCRIPTION
 - Becasue NestedRuntimeException from Spring Framework core 6.x removed the getMessage method that included the detailMessage with cause in it, the Kafka binder DLQ records no longer include the cause message. Fix this issue by including the cause in the exception message.

See this comment for more details:
 - https://github.com/spring-cloud/spring-cloud-stream/issues/2662#issuecomment-1722849892 This fix is based on the following Spring Kafka commit.
 - https://github.com/spring-projects/spring-kafka/commit/6f585058a60090f2940c563bca0a4b9208b7e44e

Resolves https://github.com/spring-cloud/spring-cloud-stream/issues/2662