### PR TITLE
GH-2675: DefaultBinding isRunning enhancements

### DIFF
--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
@@ -228,7 +228,7 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 	}
 
 	private String resolveBinderName(String bindingName, BindingServiceProperties bindingServiceProperties) {
-		String binder = bindingServiceProperties == null ? null : bindingServiceProperties.getBindings().get(bindingName).getBinder();
+		String binder = getBinderName(bindingName, bindingServiceProperties);
 		if (!StringUtils.hasText(binder)) {
 			return resolveFromDefaultBinder();
 		}
@@ -247,7 +247,7 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 	}
 
 	private String resolveBinderType(String bindingName, BindingServiceProperties bindingServiceProperties) {
-		String binder = bindingServiceProperties == null ? null : bindingServiceProperties.getBindings().get(bindingName).getBinder();
+		String binder = getBinderName(bindingName, bindingServiceProperties);
 		if (!StringUtils.hasText(binder)) {
 			return resolveFromDefaultBinder();
 		}
@@ -257,6 +257,18 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 			}
 			return bindingServiceProperties.getBinders().get(binder).getType();
 		}
+	}
+
+	private static String getBinderName(String bindingName, BindingServiceProperties bindingServiceProperties) {
+		String binder;
+		if (bindingServiceProperties == null) {
+			binder = null;
+		}
+		else {
+			BindingProperties bindingProperties = bindingServiceProperties.getBindings().get(bindingName);
+			binder = bindingProperties == null ? null : bindingProperties.getBinder();
+		}
+		return binder;
 	}
 
 	/**
@@ -655,7 +667,9 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 			}
 
 		};
-
+		if (properties.isAutoStartup()) {
+			binding.start();
+		}
 		doPublishEvent(new BindingCreatedEvent(binding));
 		return binding;
 	}

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinding.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinding.java
@@ -41,7 +41,6 @@ import org.springframework.util.StringUtils;
  * @author Myeonghyeon Lee
  * @author Soby Chacko
  * @author Byungjun You
- * @see org.springframework.cloud.stream.annotation.EnableBinding
  */
 
 @JsonPropertyOrder({ "bindingName", "name", "group", "pausable", "state" })
@@ -59,6 +58,8 @@ public class DefaultBinding<T> implements Binding<T> {
 	private final Log logger = LogFactory.getLog(this.getClass().getName());
 
 	private boolean paused;
+
+	private boolean running;
 
 	private boolean restartable;
 
@@ -118,7 +119,16 @@ public class DefaultBinding<T> implements Binding<T> {
 
 	@Override
 	public boolean isRunning() {
-		return this.lifecycle != null && this.lifecycle.isRunning();
+		if (this.running) {
+			return true;
+		}
+		else {
+			if (this.lifecycle != null && this.lifecycle.isRunning()) {
+				this.running = true;
+				return true;
+			}
+			return false;
+		}
 	}
 
 	public boolean isPausable() {
@@ -138,6 +148,7 @@ public class DefaultBinding<T> implements Binding<T> {
 		if (!this.isRunning()) {
 			if (this.lifecycle != null && this.restartable) {
 				this.lifecycle.start();
+				this.running = true;
 			}
 			else {
 				this.logger.warn("Can not re-bind an anonymous binding");
@@ -152,6 +163,7 @@ public class DefaultBinding<T> implements Binding<T> {
 		}
 		if (this.isRunning()) {
 			this.lifecycle.stop();
+			this.running = false;
 		}
 	}
 


### PR DESCRIPTION
 - Instead of relying on the lifecycle object's isRunning method which could possibly be synchronized and cause a contention for the lock,  maintain the running state separately inside DefaultBinding via a field (similar to how it tracks the pausable state).

   Without this change, in the pollable Kafka consumer based applications, there is a possiblity for a longer wait when queyring the binding status in DefaultBinding (for example via the binding actuator endpoint) due to this aforementioned lock contention.

Resolves https://github.com/spring-cloud/spring-cloud-stream/issues/2675