### PR TITLE
Fix failure in PulsarExtendedBindingPropertiesTests

### DIFF
--- a/binders/pulsar-binder/spring-cloud-stream-binder-pulsar/src/test/java/org/springframework/cloud/stream/binder/pulsar/PulsarExtendedBindingPropertiesTests.java
+++ b/binders/pulsar-binder/spring-cloud-stream-binder-pulsar/src/test/java/org/springframework/cloud/stream/binder/pulsar/PulsarExtendedBindingPropertiesTests.java
@@ -97,7 +97,7 @@ class PulsarExtendedBindingPropertiesTests {
 		PulsarContainerProperties pulsarContainerProperties = new PulsarContainerProperties();
 		pulsarContainerProperties.getPulsarConsumerProperties().putAll(consumerProps);
 		assertThat(pulsarContainerProperties.getSubscriptionName()).isNull();
-		assertThat(pulsarContainerProperties.getSubscriptionType()).isEqualTo(SubscriptionType.Exclusive);
+		assertThat(pulsarContainerProperties.getSubscriptionType()).isNull();
 		pulsarContainerProperties.updateContainerProperties();
 		assertThat(pulsarContainerProperties.getSubscriptionName()).isEqualTo("my-foo-sbscription");
 		assertThat(pulsarContainerProperties.getSubscriptionType()).isEqualTo(SubscriptionType.Shared);


### PR DESCRIPTION
The default value for PulsarContainerProperties.subscriptionType was switched to `null` in https://github.com/spring-projects/spring-pulsar/commit/ed3899fcb9aee8e6767cdbe8275055a47fd22c47#diff-1371e1026362d375ef0f90846291add7cdcae0c340b934e3972d0bd72b312fa5L61.

This commit adjusts the PulsarExtendedBindingPropertiesTests 'extendedBindingsArePropagatedToContainerProperties' test for this fact.