### PR TITLE
The bug for multiplex configuration in ReactorKafkaBinder

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -43,7 +43,6 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.PartitionInfo;
@@ -420,14 +419,8 @@ public class KafkaMessageChannelBinder extends
 				? transMan.getProducerFactory()
 				: getProducerFactory(null, producerProperties, destination.getName() + ".producer",
 				destination.getName());
-		Collection<PartitionInfo> partitions = provisioningProvider.getPartitionsForTopic(
-				producerProperties.getPartitionCount(), false, () -> {
-					Producer<byte[], byte[]> producer = producerFB.createProducer();
-					List<PartitionInfo> partitionsFor = producer
-							.partitionsFor(destination.getName());
-					producer.close();
-					return partitionsFor;
-				}, destination.getName());
+		Collection<PartitionInfo> partitions = provisioningProvider.getPartitionInfoForProducer(
+				destination.getName(), producerFB, producerProperties);
 		this.topicsInUse.put(destination.getName(),
 				new TopicInformation(null, partitions, false));
 		if (producerProperties.isPartitioned()
@@ -1013,14 +1006,14 @@ public class KafkaMessageChannelBinder extends
 			// all partitions
 			// not just the ones this binding is listening to; doesn't seem right for a
 			// health check.
-			Collection<PartitionInfo> partitionInfos = provisioningProvider.getPartitionInfo(
+			Collection<PartitionInfo> partitionInfos = provisioningProvider.getPartitionInfoForConsumer(
 					destination.getName(), extendedConsumerProperties, consumerFactory, -1);
 			this.topicsInUse.put(destination.getName(),
 					new TopicInformation(consumerGroup, partitionInfos, false));
 		}
 		else {
 			for (int i = 0; i < topics.length; i++) {
-				Collection<PartitionInfo> partitionInfos = provisioningProvider.getPartitionInfo(topics[i],
+				Collection<PartitionInfo> partitionInfos = provisioningProvider.getPartitionInfoForConsumer(topics[i],
 						extendedConsumerProperties, consumerFactory, -1);
 				this.topicsInUse.put(topics[i],
 						new TopicInformation(consumerGroup, partitionInfos, false));

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderUnitTests.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderUnitTests.java
@@ -84,7 +84,7 @@ class KafkaBinderUnitTests {
 		KafkaMessageChannelBinder binder = new KafkaMessageChannelBinder(
 				binderConfigurationProperties, provisioningProvider);
 		KafkaConsumerProperties consumerProps = new KafkaConsumerProperties();
-		ExtendedConsumerProperties<KafkaConsumerProperties> ecp = new ExtendedConsumerProperties<KafkaConsumerProperties>(
+		ExtendedConsumerProperties<KafkaConsumerProperties> ecp = new ExtendedConsumerProperties<>(
 				consumerProps);
 		Method method = KafkaMessageChannelBinder.class.getDeclaredMethod(
 				"createKafkaConsumerFactory", boolean.class, String.class,
@@ -195,7 +195,8 @@ class KafkaBinderUnitTests {
 			return partitions.stream().map(p -> new PartitionInfo(topic,
 					part.getAndIncrement(), null, null, null))
 					.collect(Collectors.toList());
-		}).given(provisioningProvider).getListenedPartitions(anyString(), any(), any(), anyInt(), anyBoolean(), anyBoolean(), anyString(), any());
+		}).given(provisioningProvider).getListenedPartitions(anyString(), any(), any(),
+			anyInt(), anyBoolean(), anyBoolean(), anyString(), any());
 		@SuppressWarnings("unchecked")
 		final Consumer<byte[], byte[]> consumer = mock(Consumer.class);
 		final CountDownLatch latch = new CountDownLatch(1);

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderUnitTests.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderUnitTests.java
@@ -67,6 +67,7 @@ import static org.mockito.Mockito.verify;
 
 /**
  * @author Gary Russell
+ * @author Omer Celik
  * @since 1.2.2
  *
  */
@@ -194,8 +195,7 @@ class KafkaBinderUnitTests {
 			return partitions.stream().map(p -> new PartitionInfo(topic,
 					part.getAndIncrement(), null, null, null))
 					.collect(Collectors.toList());
-		}).given(provisioningProvider).getPartitionsForTopic(anyInt(), anyBoolean(),
-				any(), any());
+		}).given(provisioningProvider).getListenedPartitions(anyString(), any(), any(), anyInt(), anyBoolean(), anyBoolean(), anyString(), any());
 		@SuppressWarnings("unchecked")
 		final Consumer<byte[], byte[]> consumer = mock(Consumer.class);
 		final CountDownLatch latch = new CountDownLatch(1);


### PR DESCRIPTION
I found some issues when given multiplex configuration in consumer for ReactorKafkaBinder. The reason is that destinationName is not parsed while partition information is fetched. That is, when the destinationName "testA, testB, testC" is given, the topic name is accepted as "testA, testB, testC". However, this is not just one topic ("testA, testB, testC"). They are 3 different topics (topic1="testA", topic2="testB", topic3="testC"). It is necessary to parse it and process it as 3 different topics.