### PR TITLE
GH-2847: Multiple outputs routing-key-expression

### DIFF
--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/MessageConverterConfigurer.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/MessageConverterConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2015-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.cloud.stream.binder.ProducerProperties;
 import org.springframework.cloud.stream.config.BindingProperties;
 import org.springframework.cloud.stream.config.BindingServiceProperties;
 import org.springframework.cloud.stream.converter.MessageConverterUtils;
+import org.springframework.cloud.stream.function.BindableFunctionProxyFactory;
 import org.springframework.cloud.stream.function.StreamFunctionProperties;
 import org.springframework.core.env.Environment;
 import org.springframework.integration.channel.AbstractMessageChannel;
@@ -164,7 +165,9 @@ public class MessageConverterConfigurer
 			}
 			else {
 				if (environment != null && environment.containsProperty("spring.cloud.stream.rabbit.bindings." + channelName + ".producer.routing-key-expression")) {
-					this.setSkipOutputConversionIfNecessary();
+					Map<String, String> channelNameToFunctions = BindableFunctionProxyFactory.getChannelNameToFunctions();
+					String functionName = channelNameToFunctions.get(channelName);
+					this.setSkipOutputConversionIfNecessary(functionName);
 					functional = false;
 				}
 				if (!functional) {
@@ -174,10 +177,10 @@ public class MessageConverterConfigurer
 		}
 	}
 
-	private void setSkipOutputConversionIfNecessary() {
+	private void setSkipOutputConversionIfNecessary(String functionName) {
 		FunctionCatalog catalog = this.beanFactory.getBean(FunctionCatalog.class);
 		if (catalog != null) {
-			FunctionInvocationWrapper function = catalog.lookup(this.streamFunctionProperties.getDefinition());
+			FunctionInvocationWrapper function = catalog.lookup(functionName);
 			if (function != null) {
 				function.setSkipOutputConversion(true);
 			}


### PR DESCRIPTION
 - When there are multiple output bindings present and one of them defines a routing-key-expression, there is a bug that bypasses the code that skips the output conversion. This results in the framework attempts a pre-mature type conversion causing in later downstream errors. This happens because MessageConverterConfigurer tries to find a corresponding function for the entire function definition rather than using the individual function under consideraion. Fixing this issue by properly keeping track of the function name keyed off of the channel name, since channel name is what MessageConverterConfigurer uses to retrieve info about the function name.

Resolves https://github.com/spring-cloud/spring-cloud-stream/issues/2847