### PR TITLE
Schema registry SSL config propagation to producer and consumer confgurations

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
@@ -91,11 +91,11 @@ public class KafkaBinderConfigurationProperties {
 	 */
 	private Map<String, String> producerProperties = new HashMap<>();
 
-	private String[] brokers = new String[]{"localhost"};
+	private String[] brokers = new String[] { "localhost" };
 
 	private String defaultBrokerPort = "9092";
 
-	private String[] headers = new String[]{};
+	private String[] headers = new String[] {};
 
 	private boolean autoCreateTopics = true;
 
@@ -147,9 +147,9 @@ public class KafkaBinderConfigurationProperties {
 
 
 	/**
-	 * Schema registry ssl configuration properties.
+	 * Schema registry ssl configuration properties
 	 */
-	private final String[] schemaRegistryProperties = new String[]{"schema.registry.url", "schema.registry.ssl.keystore.location", "schema.registry.ssl.keystore.password", "schema.registry.ssl.truststore.location", "schema.registry.ssl.truststore.password", "schema.registry.ssl.key.password"};
+	private final String[] schemaRegistryProperties = new String[]{"schema.registry.url", "schema.registry.ssl.keystore.location", "schema.registry.ssl.keystore.password", "schema.registry.ssl.truststore.location", "schema.registry.ssl.truststore.password", "schema.registry.ssl.key.password"} ;
 
 	/**
 	 * Earlier, @Autowired on this constructor was necessary for all the properties to be discovered
@@ -198,7 +198,8 @@ public class KafkaBinderConfigurationProperties {
 			// schema registry certificates
 			moveCertsIfApplicable("schema.registry.ssl.truststore.location");
 			moveCertsIfApplicable("schema.registry.ssl.keystore.location");
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			throw new IllegalStateException(e);
 		}
 	}
@@ -218,7 +219,8 @@ public class KafkaBinderConfigurationProperties {
 	private boolean checkIfFileExists(String path) {
 		try {
 			return Files.isRegularFile(Paths.get(path));
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			return false;
 		}
 	}
@@ -231,13 +233,15 @@ public class KafkaBinderConfigurationProperties {
 			final Path path = Paths.get(fileSystemLocation);
 			if (!Files.exists(path) || !Files.isDirectory(path) || !Files.isWritable(path)) {
 				logger.warn("The filesystem location to move the cert files (" + fileSystemLocation + ") " +
-					"is not found or a directory that is writable. The system temp folder (java.io.tmpdir) will be used instead.");
+						"is not found or a directory that is writable. The system temp folder (java.io.tmpdir) will be used instead.");
 				targetFile = new File(Paths.get(tempDir, resource.getFilename()).toString());
-			} else {
+			}
+			else {
 				// the given location is verified to be a writable directory.
 				targetFile = new File(Paths.get(fileSystemLocation, resource.getFilename()).toString());
 			}
-		} else {
+		}
+		else {
 			targetFile = new File(Paths.get(tempDir, resource.getFilename()).toString());
 		}
 
@@ -274,8 +278,7 @@ public class KafkaBinderConfigurationProperties {
 	/**
 	 * Converts an array of host values to a comma-separated String. It will append the
 	 * default port value, if not already specified.
-	 *
-	 * @param hosts       host string
+	 * @param hosts host string
 	 * @param defaultPort port
 	 * @return formatted connection string
 	 */
@@ -284,7 +287,8 @@ public class KafkaBinderConfigurationProperties {
 		for (int i = 0; i < hosts.length; i++) {
 			if (hosts[i].contains(":") || !StringUtils.hasText(defaultPort)) {
 				fullyFormattedHosts[i] = hosts[i];
-			} else {
+			}
+			else {
 				fullyFormattedHosts[i] = hosts[i] + ":" + defaultPort;
 			}
 		}
@@ -377,7 +381,6 @@ public class KafkaBinderConfigurationProperties {
 	 * Merge boot consumer properties, general properties from
 	 * {@link #setConfiguration(Map)} that apply to consumers, properties from
 	 * {@link #setConsumerProperties(Map)}, in that order.
-	 *
 	 * @return the merged properties.
 	 */
 	public Map<String, Object> mergedConsumerConfiguration() {
@@ -385,11 +388,11 @@ public class KafkaBinderConfigurationProperties {
 		// Copy configured binder properties that apply to consumers
 		// allow schema registry properties to be propagated to consumer configuration
 		for (Map.Entry<String, String> configurationEntry : this.configuration
-			.entrySet()) {
+				.entrySet()) {
 			if (ConsumerConfig.configNames().contains(configurationEntry.getKey())
 				|| ObjectUtils.containsElement(schemaRegistryProperties, configurationEntry.getKey())) {
 				consumerConfiguration.put(configurationEntry.getKey(),
-					configurationEntry.getValue());
+						configurationEntry.getValue());
 			}
 		}
 		consumerConfiguration.putAll(this.consumerProperties);
@@ -397,14 +400,13 @@ public class KafkaBinderConfigurationProperties {
 		// Override Spring Boot bootstrap server setting if left to default with the value
 		// configured in the binder
 		return getConfigurationWithBootstrapServer(consumerConfiguration,
-			ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG);
+				ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG);
 	}
 
 	/**
 	 * Merge boot producer properties, general properties from
 	 * {@link #setConfiguration(Map)} that apply to producers, properties from
 	 * {@link #setProducerProperties(Map)}, in that order.
-	 *
 	 * @return the merged properties.
 	 */
 	public Map<String, Object> mergedProducerConfiguration() {
@@ -412,31 +414,31 @@ public class KafkaBinderConfigurationProperties {
 		// Copy configured binder properties that apply to producers
 		// allow schema registry properties to be propagated to consumer configuration
 		for (Map.Entry<String, String> configurationEntry : this.configuration
-			.entrySet()) {
+				.entrySet()) {
 			if (ProducerConfig.configNames().contains(configurationEntry.getKey())
-				|| ObjectUtils.containsElement(schemaRegistryProperties, configurationEntry.getKey())) {
+			|| ObjectUtils.containsElement(schemaRegistryProperties, configurationEntry.getKey())) {
 				producerConfiguration.put(configurationEntry.getKey(),
-					configurationEntry.getValue());
+						configurationEntry.getValue());
 			}
 		}
 		producerConfiguration.putAll(this.producerProperties);
 		// Override Spring Boot bootstrap server setting if left to default with the value
 		// configured in the binder
 		return getConfigurationWithBootstrapServer(producerConfiguration,
-			ProducerConfig.BOOTSTRAP_SERVERS_CONFIG);
+				ProducerConfig.BOOTSTRAP_SERVERS_CONFIG);
 	}
 
 	private void filterStreamManagedConfiguration(Map<String, Object> configuration) {
 		if (configuration.containsKey(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG)
-			&& configuration.get(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG).toString().equalsIgnoreCase("true")) {
+				&& configuration.get(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG).toString().equalsIgnoreCase("true")) {
 			logger.warn(constructIgnoredConfigMessage(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG) +
-				ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG + "=true is not supported by the Kafka binder");
+					ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG + "=true is not supported by the Kafka binder");
 			configuration.remove(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG);
 		}
 		if (configuration.containsKey(ConsumerConfig.GROUP_ID_CONFIG)) {
 			logger.warn(constructIgnoredConfigMessage(ConsumerConfig.GROUP_ID_CONFIG) +
-				"Use spring.cloud.stream.default.group or spring.cloud.stream.binding.<name>.group to specify " +
-				"the group instead of " + ConsumerConfig.GROUP_ID_CONFIG);
+					"Use spring.cloud.stream.default.group or spring.cloud.stream.binding.<name>.group to specify " +
+					"the group instead of " + ConsumerConfig.GROUP_ID_CONFIG);
 			configuration.remove(ConsumerConfig.GROUP_ID_CONFIG);
 		}
 	}
@@ -446,10 +448,10 @@ public class KafkaBinderConfigurationProperties {
 	}
 
 	private Map<String, Object> getConfigurationWithBootstrapServer(
-		Map<String, Object> configuration, String bootstrapServersConfig) {
+			Map<String, Object> configuration, String bootstrapServersConfig) {
 		final String kafkaConnectionString = getKafkaConnectionString();
 		if (ObjectUtils.isEmpty(configuration.get(bootstrapServersConfig)) ||
-			!kafkaConnectionString.equals("localhost:9092")) {
+				!kafkaConnectionString.equals("localhost:9092")) {
 			configuration.put(bootstrapServersConfig, kafkaConnectionString);
 		}
 		return Collections.unmodifiableMap(configuration);
@@ -556,9 +558,9 @@ public class KafkaBinderConfigurationProperties {
 		}
 
 		public void setPartitionSelectorExpression(
-			Expression partitionSelectorExpression) {
+				Expression partitionSelectorExpression) {
 			this.producerProperties
-				.setPartitionSelectorExpression(partitionSelectorExpression);
+					.setPartitionSelectorExpression(partitionSelectorExpression);
 		}
 
 		public @Min(value = 1, message = "Partition count should be greater than zero.") int getPartitionCount() {
@@ -578,12 +580,12 @@ public class KafkaBinderConfigurationProperties {
 		}
 
 		public @AssertTrue(message = "Partition key expression and partition key extractor class properties "
-			+ "are mutually exclusive.") boolean isValidPartitionKeyProperty() {
+				+ "are mutually exclusive.") boolean isValidPartitionKeyProperty() {
 			return this.producerProperties.isValidPartitionKeyProperty();
 		}
 
 		public @AssertTrue(message = "Partition selector class and partition selector expression "
-			+ "properties are mutually exclusive.") boolean isValidPartitionSelectorProperty() {
+				+ "properties are mutually exclusive.") boolean isValidPartitionSelectorProperty() {
 			return this.producerProperties.isValidPartitionSelectorProperty();
 		}
 
@@ -617,7 +619,7 @@ public class KafkaBinderConfigurationProperties {
 
 		public void setPartitionKeyExtractorName(String partitionKeyExtractorName) {
 			this.producerProperties
-				.setPartitionKeyExtractorName(partitionKeyExtractorName);
+					.setPartitionKeyExtractorName(partitionKeyExtractorName);
 		}
 
 		public String getPartitionSelectorName() {

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
@@ -91,11 +91,11 @@ public class KafkaBinderConfigurationProperties {
 	 */
 	private Map<String, String> producerProperties = new HashMap<>();
 
-	private String[] brokers = new String[] { "localhost" };
+	private String[] brokers = new String[]{"localhost"};
 
 	private String defaultBrokerPort = "9092";
 
-	private String[] headers = new String[] {};
+	private String[] headers = new String[]{};
 
 	private boolean autoCreateTopics = true;
 
@@ -147,9 +147,9 @@ public class KafkaBinderConfigurationProperties {
 
 
 	/**
-	 * Schema registry ssl configuration properties
+	 * Schema registry ssl configuration properties.
 	 */
-	private final String[] schemaRegistryProperties = new String[]{"schema.registry.url", "schema.registry.ssl.keystore.location", "schema.registry.ssl.keystore.password", "schema.registry.ssl.truststore.location", "schema.registry.ssl.truststore.password", "schema.registry.ssl.key.password"} ;
+	private final String[] schemaRegistryProperties = new String[]{"schema.registry.url", "schema.registry.ssl.keystore.location", "schema.registry.ssl.keystore.password", "schema.registry.ssl.truststore.location", "schema.registry.ssl.truststore.password", "schema.registry.ssl.key.password"};
 
 	/**
 	 * Earlier, @Autowired on this constructor was necessary for all the properties to be discovered
@@ -198,8 +198,7 @@ public class KafkaBinderConfigurationProperties {
 			// schema registry certificates
 			moveCertsIfApplicable("schema.registry.ssl.truststore.location");
 			moveCertsIfApplicable("schema.registry.ssl.keystore.location");
-		}
-		catch (Exception e) {
+		} catch (Exception e) {
 			throw new IllegalStateException(e);
 		}
 	}
@@ -219,8 +218,7 @@ public class KafkaBinderConfigurationProperties {
 	private boolean checkIfFileExists(String path) {
 		try {
 			return Files.isRegularFile(Paths.get(path));
-		}
-		catch (Exception e) {
+		} catch (Exception e) {
 			return false;
 		}
 	}
@@ -233,15 +231,13 @@ public class KafkaBinderConfigurationProperties {
 			final Path path = Paths.get(fileSystemLocation);
 			if (!Files.exists(path) || !Files.isDirectory(path) || !Files.isWritable(path)) {
 				logger.warn("The filesystem location to move the cert files (" + fileSystemLocation + ") " +
-						"is not found or a directory that is writable. The system temp folder (java.io.tmpdir) will be used instead.");
+					"is not found or a directory that is writable. The system temp folder (java.io.tmpdir) will be used instead.");
 				targetFile = new File(Paths.get(tempDir, resource.getFilename()).toString());
-			}
-			else {
+			} else {
 				// the given location is verified to be a writable directory.
 				targetFile = new File(Paths.get(fileSystemLocation, resource.getFilename()).toString());
 			}
-		}
-		else {
+		} else {
 			targetFile = new File(Paths.get(tempDir, resource.getFilename()).toString());
 		}
 
@@ -278,7 +274,8 @@ public class KafkaBinderConfigurationProperties {
 	/**
 	 * Converts an array of host values to a comma-separated String. It will append the
 	 * default port value, if not already specified.
-	 * @param hosts host string
+	 *
+	 * @param hosts       host string
 	 * @param defaultPort port
 	 * @return formatted connection string
 	 */
@@ -287,8 +284,7 @@ public class KafkaBinderConfigurationProperties {
 		for (int i = 0; i < hosts.length; i++) {
 			if (hosts[i].contains(":") || !StringUtils.hasText(defaultPort)) {
 				fullyFormattedHosts[i] = hosts[i];
-			}
-			else {
+			} else {
 				fullyFormattedHosts[i] = hosts[i] + ":" + defaultPort;
 			}
 		}
@@ -381,6 +377,7 @@ public class KafkaBinderConfigurationProperties {
 	 * Merge boot consumer properties, general properties from
 	 * {@link #setConfiguration(Map)} that apply to consumers, properties from
 	 * {@link #setConsumerProperties(Map)}, in that order.
+	 *
 	 * @return the merged properties.
 	 */
 	public Map<String, Object> mergedConsumerConfiguration() {
@@ -388,11 +385,11 @@ public class KafkaBinderConfigurationProperties {
 		// Copy configured binder properties that apply to consumers
 		// allow schema registry properties to be propagated to consumer configuration
 		for (Map.Entry<String, String> configurationEntry : this.configuration
-				.entrySet()) {
+			.entrySet()) {
 			if (ConsumerConfig.configNames().contains(configurationEntry.getKey())
 				|| ObjectUtils.containsElement(schemaRegistryProperties, configurationEntry.getKey())) {
 				consumerConfiguration.put(configurationEntry.getKey(),
-						configurationEntry.getValue());
+					configurationEntry.getValue());
 			}
 		}
 		consumerConfiguration.putAll(this.consumerProperties);
@@ -400,13 +397,14 @@ public class KafkaBinderConfigurationProperties {
 		// Override Spring Boot bootstrap server setting if left to default with the value
 		// configured in the binder
 		return getConfigurationWithBootstrapServer(consumerConfiguration,
-				ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG);
+			ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG);
 	}
 
 	/**
 	 * Merge boot producer properties, general properties from
 	 * {@link #setConfiguration(Map)} that apply to producers, properties from
 	 * {@link #setProducerProperties(Map)}, in that order.
+	 *
 	 * @return the merged properties.
 	 */
 	public Map<String, Object> mergedProducerConfiguration() {
@@ -414,31 +412,31 @@ public class KafkaBinderConfigurationProperties {
 		// Copy configured binder properties that apply to producers
 		// allow schema registry properties to be propagated to consumer configuration
 		for (Map.Entry<String, String> configurationEntry : this.configuration
-				.entrySet()) {
+			.entrySet()) {
 			if (ProducerConfig.configNames().contains(configurationEntry.getKey())
-			|| ObjectUtils.containsElement(schemaRegistryProperties, configurationEntry.getKey())) {
+				|| ObjectUtils.containsElement(schemaRegistryProperties, configurationEntry.getKey())) {
 				producerConfiguration.put(configurationEntry.getKey(),
-						configurationEntry.getValue());
+					configurationEntry.getValue());
 			}
 		}
 		producerConfiguration.putAll(this.producerProperties);
 		// Override Spring Boot bootstrap server setting if left to default with the value
 		// configured in the binder
 		return getConfigurationWithBootstrapServer(producerConfiguration,
-				ProducerConfig.BOOTSTRAP_SERVERS_CONFIG);
+			ProducerConfig.BOOTSTRAP_SERVERS_CONFIG);
 	}
 
 	private void filterStreamManagedConfiguration(Map<String, Object> configuration) {
 		if (configuration.containsKey(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG)
-				&& configuration.get(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG).toString().equalsIgnoreCase("true")) {
+			&& configuration.get(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG).toString().equalsIgnoreCase("true")) {
 			logger.warn(constructIgnoredConfigMessage(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG) +
-					ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG + "=true is not supported by the Kafka binder");
+				ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG + "=true is not supported by the Kafka binder");
 			configuration.remove(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG);
 		}
 		if (configuration.containsKey(ConsumerConfig.GROUP_ID_CONFIG)) {
 			logger.warn(constructIgnoredConfigMessage(ConsumerConfig.GROUP_ID_CONFIG) +
-					"Use spring.cloud.stream.default.group or spring.cloud.stream.binding.<name>.group to specify " +
-					"the group instead of " + ConsumerConfig.GROUP_ID_CONFIG);
+				"Use spring.cloud.stream.default.group or spring.cloud.stream.binding.<name>.group to specify " +
+				"the group instead of " + ConsumerConfig.GROUP_ID_CONFIG);
 			configuration.remove(ConsumerConfig.GROUP_ID_CONFIG);
 		}
 	}
@@ -448,10 +446,10 @@ public class KafkaBinderConfigurationProperties {
 	}
 
 	private Map<String, Object> getConfigurationWithBootstrapServer(
-			Map<String, Object> configuration, String bootstrapServersConfig) {
+		Map<String, Object> configuration, String bootstrapServersConfig) {
 		final String kafkaConnectionString = getKafkaConnectionString();
 		if (ObjectUtils.isEmpty(configuration.get(bootstrapServersConfig)) ||
-				!kafkaConnectionString.equals("localhost:9092")) {
+			!kafkaConnectionString.equals("localhost:9092")) {
 			configuration.put(bootstrapServersConfig, kafkaConnectionString);
 		}
 		return Collections.unmodifiableMap(configuration);
@@ -558,9 +556,9 @@ public class KafkaBinderConfigurationProperties {
 		}
 
 		public void setPartitionSelectorExpression(
-				Expression partitionSelectorExpression) {
+			Expression partitionSelectorExpression) {
 			this.producerProperties
-					.setPartitionSelectorExpression(partitionSelectorExpression);
+				.setPartitionSelectorExpression(partitionSelectorExpression);
 		}
 
 		public @Min(value = 1, message = "Partition count should be greater than zero.") int getPartitionCount() {
@@ -580,12 +578,12 @@ public class KafkaBinderConfigurationProperties {
 		}
 
 		public @AssertTrue(message = "Partition key expression and partition key extractor class properties "
-				+ "are mutually exclusive.") boolean isValidPartitionKeyProperty() {
+			+ "are mutually exclusive.") boolean isValidPartitionKeyProperty() {
 			return this.producerProperties.isValidPartitionKeyProperty();
 		}
 
 		public @AssertTrue(message = "Partition selector class and partition selector expression "
-				+ "properties are mutually exclusive.") boolean isValidPartitionSelectorProperty() {
+			+ "properties are mutually exclusive.") boolean isValidPartitionSelectorProperty() {
 			return this.producerProperties.isValidPartitionSelectorProperty();
 		}
 
@@ -619,7 +617,7 @@ public class KafkaBinderConfigurationProperties {
 
 		public void setPartitionKeyExtractorName(String partitionKeyExtractorName) {
 			this.producerProperties
-					.setPartitionKeyExtractorName(partitionKeyExtractorName);
+				.setPartitionKeyExtractorName(partitionKeyExtractorName);
 		}
 
 		public String getPartitionSelectorName() {

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
@@ -62,6 +62,7 @@ import org.springframework.util.StringUtils;
  * @author Chukwubuikem Ume-Ugwa
  * @author Nico Heller
  * @author Norbert Gyurian
+ * @author Boini Srinivas
  */
 public class KafkaBinderConfigurationProperties {
 
@@ -144,6 +145,12 @@ public class KafkaBinderConfigurationProperties {
 	 */
 	private boolean enableObservation;
 
+
+	/**
+	 * Schema registry ssl configuration properties
+	 */
+	private final String[] schemaRegistryProperties = new String[]{"schema.registry.url", "schema.registry.ssl.keystore.location", "schema.registry.ssl.keystore.password", "schema.registry.ssl.truststore.location", "schema.registry.ssl.truststore.password", "schema.registry.ssl.key.password"} ;
+
 	/**
 	 * Earlier, @Autowired on this constructor was necessary for all the properties to be discovered
 	 * and bound when running as a native application. However, now that Spring Boot fixed the underlying
@@ -205,12 +212,7 @@ public class KafkaBinderConfigurationProperties {
 			final String fileSystemLocation = moveCertToFileSystem(storeLocation, this.certificateStoreDirectory);
 			// Overriding the value with absolute filesystem path.
 			this.configuration.put(storeProperty, fileSystemLocation);
-			// Provide schema-registry properties as producer and consumer properties
-			// for potential usage by specific serializers/deserializers downstream
-			if (storeProperty.startsWith("schema.registry")) {
-				this.producerProperties.put(storeProperty, fileSystemLocation);
-				this.consumerProperties.put(storeProperty, fileSystemLocation);
-			}
+
 		}
 	}
 
@@ -384,9 +386,11 @@ public class KafkaBinderConfigurationProperties {
 	public Map<String, Object> mergedConsumerConfiguration() {
 		Map<String, Object> consumerConfiguration = new HashMap<>(this.kafkaProperties.buildConsumerProperties(null));
 		// Copy configured binder properties that apply to consumers
+		// allow schema registry properties to be propagated to consumer configuration
 		for (Map.Entry<String, String> configurationEntry : this.configuration
 				.entrySet()) {
-			if (ConsumerConfig.configNames().contains(configurationEntry.getKey())) {
+			if (ConsumerConfig.configNames().contains(configurationEntry.getKey())
+				|| ObjectUtils.containsElement(schemaRegistryProperties, configurationEntry.getKey())) {
 				consumerConfiguration.put(configurationEntry.getKey(),
 						configurationEntry.getValue());
 			}
@@ -408,9 +412,11 @@ public class KafkaBinderConfigurationProperties {
 	public Map<String, Object> mergedProducerConfiguration() {
 		Map<String, Object> producerConfiguration = new HashMap<>(this.kafkaProperties.buildProducerProperties(null));
 		// Copy configured binder properties that apply to producers
+		// allow schema registry properties to be propagated to consumer configuration
 		for (Map.Entry<String, String> configurationEntry : this.configuration
 				.entrySet()) {
-			if (ProducerConfig.configNames().contains(configurationEntry.getKey())) {
+			if (ProducerConfig.configNames().contains(configurationEntry.getKey())
+			|| ObjectUtils.containsElement(schemaRegistryProperties, configurationEntry.getKey())) {
 				producerConfiguration.put(configurationEntry.getKey(),
 						configurationEntry.getValue());
 			}

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
@@ -62,7 +62,6 @@ import org.springframework.util.StringUtils;
  * @author Chukwubuikem Ume-Ugwa
  * @author Nico Heller
  * @author Norbert Gyurian
- * @author Boini Srinivas
  */
 public class KafkaBinderConfigurationProperties {
 
@@ -145,12 +144,6 @@ public class KafkaBinderConfigurationProperties {
 	 */
 	private boolean enableObservation;
 
-
-	/**
-	 * Schema registry ssl configuration properties
-	 */
-	private final String[] schemaRegistryProperties = new String[]{"schema.registry.url", "schema.registry.ssl.keystore.location", "schema.registry.ssl.keystore.password", "schema.registry.ssl.truststore.location", "schema.registry.ssl.truststore.password", "schema.registry.ssl.key.password"} ;
-
 	/**
 	 * Earlier, @Autowired on this constructor was necessary for all the properties to be discovered
 	 * and bound when running as a native application. However, now that Spring Boot fixed the underlying
@@ -212,7 +205,12 @@ public class KafkaBinderConfigurationProperties {
 			final String fileSystemLocation = moveCertToFileSystem(storeLocation, this.certificateStoreDirectory);
 			// Overriding the value with absolute filesystem path.
 			this.configuration.put(storeProperty, fileSystemLocation);
-
+			// Provide schema-registry properties as producer and consumer properties
+			// for potential usage by specific serializers/deserializers downstream
+			if (storeProperty.startsWith("schema.registry")) {
+				this.producerProperties.put(storeProperty, fileSystemLocation);
+				this.consumerProperties.put(storeProperty, fileSystemLocation);
+			}
 		}
 	}
 
@@ -386,11 +384,9 @@ public class KafkaBinderConfigurationProperties {
 	public Map<String, Object> mergedConsumerConfiguration() {
 		Map<String, Object> consumerConfiguration = new HashMap<>(this.kafkaProperties.buildConsumerProperties(null));
 		// Copy configured binder properties that apply to consumers
-		// allow schema registry properties to be propagated to consumer configuration
 		for (Map.Entry<String, String> configurationEntry : this.configuration
 				.entrySet()) {
-			if (ConsumerConfig.configNames().contains(configurationEntry.getKey())
-				|| ObjectUtils.containsElement(schemaRegistryProperties, configurationEntry.getKey())) {
+			if (ConsumerConfig.configNames().contains(configurationEntry.getKey())) {
 				consumerConfiguration.put(configurationEntry.getKey(),
 						configurationEntry.getValue());
 			}
@@ -412,11 +408,9 @@ public class KafkaBinderConfigurationProperties {
 	public Map<String, Object> mergedProducerConfiguration() {
 		Map<String, Object> producerConfiguration = new HashMap<>(this.kafkaProperties.buildProducerProperties(null));
 		// Copy configured binder properties that apply to producers
-		// allow schema registry properties to be propagated to consumer configuration
 		for (Map.Entry<String, String> configurationEntry : this.configuration
 				.entrySet()) {
-			if (ProducerConfig.configNames().contains(configurationEntry.getKey())
-			|| ObjectUtils.containsElement(schemaRegistryProperties, configurationEntry.getKey())) {
+			if (ProducerConfig.configNames().contains(configurationEntry.getKey())) {
 				producerConfiguration.put(configurationEntry.getKey(),
 						configurationEntry.getValue());
 			}

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/test/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationPropertiesTest.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/test/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationPropertiesTest.java
@@ -40,10 +40,10 @@ class KafkaBinderConfigurationPropertiesTest {
 		KafkaProperties kafkaProperties = new KafkaProperties();
 		kafkaProperties.getConsumer().setGroupId("group1");
 		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
-				new KafkaBinderConfigurationProperties(kafkaProperties);
+			new KafkaBinderConfigurationProperties(kafkaProperties);
 
 		Map<String, Object> mergedConsumerConfiguration =
-				kafkaBinderConfigurationProperties.mergedConsumerConfiguration();
+			kafkaBinderConfigurationProperties.mergedConsumerConfiguration();
 
 		assertThat(mergedConsumerConfiguration).doesNotContainKeys(ConsumerConfig.GROUP_ID_CONFIG);
 	}
@@ -53,10 +53,10 @@ class KafkaBinderConfigurationPropertiesTest {
 		KafkaProperties kafkaProperties = new KafkaProperties();
 		kafkaProperties.getConsumer().setEnableAutoCommit(true);
 		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
-				new KafkaBinderConfigurationProperties(kafkaProperties);
+			new KafkaBinderConfigurationProperties(kafkaProperties);
 
 		Map<String, Object> mergedConsumerConfiguration =
-				kafkaBinderConfigurationProperties.mergedConsumerConfiguration();
+			kafkaBinderConfigurationProperties.mergedConsumerConfiguration();
 
 		assertThat(mergedConsumerConfiguration).doesNotContainKeys(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG);
 	}
@@ -65,9 +65,9 @@ class KafkaBinderConfigurationPropertiesTest {
 	void mergedConsumerConfigurationFiltersGroupIdFromKafkaBinderConfigurationPropertiesConfiguration() {
 		KafkaProperties kafkaProperties = new KafkaProperties();
 		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
-				new KafkaBinderConfigurationProperties(kafkaProperties);
+			new KafkaBinderConfigurationProperties(kafkaProperties);
 		kafkaBinderConfigurationProperties
-				.setConfiguration(Collections.singletonMap(ConsumerConfig.GROUP_ID_CONFIG, "group1"));
+			.setConfiguration(Collections.singletonMap(ConsumerConfig.GROUP_ID_CONFIG, "group1"));
 
 		Map<String, Object> mergedConsumerConfiguration = kafkaBinderConfigurationProperties.mergedConsumerConfiguration();
 
@@ -78,9 +78,9 @@ class KafkaBinderConfigurationPropertiesTest {
 	void mergedConsumerConfigurationFiltersEnableAutoCommitFromKafkaBinderConfigurationPropertiesConfiguration() {
 		KafkaProperties kafkaProperties = new KafkaProperties();
 		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
-				new KafkaBinderConfigurationProperties(kafkaProperties);
+			new KafkaBinderConfigurationProperties(kafkaProperties);
 		kafkaBinderConfigurationProperties
-				.setConfiguration(Collections.singletonMap(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true"));
+			.setConfiguration(Collections.singletonMap(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true"));
 
 		Map<String, Object> mergedConsumerConfiguration = kafkaBinderConfigurationProperties.mergedConsumerConfiguration();
 
@@ -91,9 +91,9 @@ class KafkaBinderConfigurationPropertiesTest {
 	void mergedConsumerConfigurationFiltersGroupIdFromKafkaBinderConfigurationPropertiesConsumerProperties() {
 		KafkaProperties kafkaProperties = new KafkaProperties();
 		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
-				new KafkaBinderConfigurationProperties(kafkaProperties);
+			new KafkaBinderConfigurationProperties(kafkaProperties);
 		kafkaBinderConfigurationProperties
-				.setConsumerProperties(Collections.singletonMap(ConsumerConfig.GROUP_ID_CONFIG, "group1"));
+			.setConsumerProperties(Collections.singletonMap(ConsumerConfig.GROUP_ID_CONFIG, "group1"));
 
 		Map<String, Object> mergedConsumerConfiguration = kafkaBinderConfigurationProperties.mergedConsumerConfiguration();
 
@@ -104,9 +104,9 @@ class KafkaBinderConfigurationPropertiesTest {
 	void mergedConsumerConfigurationFiltersEnableAutoCommitFromKafkaBinderConfigurationPropertiesConsumerProps() {
 		KafkaProperties kafkaProperties = new KafkaProperties();
 		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
-				new KafkaBinderConfigurationProperties(kafkaProperties);
+			new KafkaBinderConfigurationProperties(kafkaProperties);
 		kafkaBinderConfigurationProperties
-				.setConsumerProperties(Collections.singletonMap(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true"));
+			.setConsumerProperties(Collections.singletonMap(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true"));
 
 		Map<String, Object> mergedConsumerConfiguration = kafkaBinderConfigurationProperties.mergedConsumerConfiguration();
 
@@ -117,7 +117,7 @@ class KafkaBinderConfigurationPropertiesTest {
 	void certificateFilesAreConvertedToAbsolutePathsFromClassPathResources() {
 		KafkaProperties kafkaProperties = new KafkaProperties();
 		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
-				new KafkaBinderConfigurationProperties(kafkaProperties);
+			new KafkaBinderConfigurationProperties(kafkaProperties);
 		final Map<String, String> configuration = kafkaBinderConfigurationProperties.getConfiguration();
 		configuration.put("ssl.truststore.location", "classpath:testclient.truststore");
 		configuration.put("ssl.keystore.location", "classpath:testclient.keystore");
@@ -125,9 +125,9 @@ class KafkaBinderConfigurationPropertiesTest {
 		kafkaBinderConfigurationProperties.getKafkaConnectionString();
 
 		assertThat(configuration.get("ssl.truststore.location"))
-				.isEqualTo(Paths.get(System.getProperty("java.io.tmpdir"), "testclient.truststore").toString());
+			.isEqualTo(Paths.get(System.getProperty("java.io.tmpdir"), "testclient.truststore").toString());
 		assertThat(configuration.get("ssl.keystore.location"))
-				.isEqualTo(Paths.get(System.getProperty("java.io.tmpdir"), "testclient.keystore").toString());
+			.isEqualTo(Paths.get(System.getProperty("java.io.tmpdir"), "testclient.keystore").toString());
 		deleteTempCertFiles();
 	}
 
@@ -167,7 +167,7 @@ class KafkaBinderConfigurationPropertiesTest {
 	void certificateFilesAreConvertedToGivenAbsolutePathsFromClassPathResources() {
 		KafkaProperties kafkaProperties = new KafkaProperties();
 		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
-				new KafkaBinderConfigurationProperties(kafkaProperties);
+			new KafkaBinderConfigurationProperties(kafkaProperties);
 		final Map<String, String> configuration = kafkaBinderConfigurationProperties.getConfiguration();
 		configuration.put("ssl.truststore.location", "classpath:testclient.truststore");
 		configuration.put("ssl.keystore.location", "classpath:testclient.keystore");
@@ -176,16 +176,16 @@ class KafkaBinderConfigurationPropertiesTest {
 		kafkaBinderConfigurationProperties.getKafkaConnectionString();
 
 		assertThat(configuration.get("ssl.truststore.location")).isEqualTo(
-				Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString());
+			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString());
 		assertThat(configuration.get("ssl.keystore.location")).isEqualTo(
-				Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString());
+			Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString());
 	}
 
 	@Test
 	void certificateFilesAreMovedForSchemaRegistryConfiguration() {
 		KafkaProperties kafkaProperties = new KafkaProperties();
 		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
-				new KafkaBinderConfigurationProperties(kafkaProperties);
+			new KafkaBinderConfigurationProperties(kafkaProperties);
 		final Map<String, String> configuration = kafkaBinderConfigurationProperties.getConfiguration();
 
 		configuration.put("schema.registry.ssl.truststore.location", "classpath:testclient.truststore");
@@ -195,9 +195,9 @@ class KafkaBinderConfigurationPropertiesTest {
 		kafkaBinderConfigurationProperties.getKafkaConnectionString();
 
 		assertThat(configuration.get("schema.registry.ssl.truststore.location")).isEqualTo(
-				Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString());
+			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString());
 		assertThat(configuration.get("schema.registry.ssl.keystore.location")).isEqualTo(
-				Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString());
+			Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString());
 
 		final Map<String, Object> mergedProducerConfiguration = kafkaBinderConfigurationProperties.mergedProducerConfiguration();
 		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.truststore.location")).isEqualTo(
@@ -213,7 +213,7 @@ class KafkaBinderConfigurationPropertiesTest {
 	}
 
 	@Test
-	void schemaRegistryPropertiesPropagatedToMergedProducerProperties(){
+	void schemaRegistryPropertiesPropagatedToMergedProducerProperties() {
 		KafkaProperties kafkaProperties = new KafkaProperties();
 		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
 			new KafkaBinderConfigurationProperties(kafkaProperties);
@@ -230,25 +230,25 @@ class KafkaBinderConfigurationPropertiesTest {
 		kafkaBinderConfigurationProperties.getKafkaConnectionString();
 
 		final Map<String, Object> mergedProducerConfiguration = kafkaBinderConfigurationProperties.mergedProducerConfiguration();
-		assertThat(mergedProducerConfiguration.get("schema.registry.url")).isEqualTo("https://localhost:8081,https://localhost:8082") ;
+		assertThat(mergedProducerConfiguration.get("schema.registry.url")).isEqualTo("https://localhost:8081,https://localhost:8082");
 		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.keystore.location")).isEqualTo(
-			Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString()) ;
+			Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString());
 		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.truststore.location")).isEqualTo(
-			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString()) ;
-		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.keystore.password")).isEqualTo("generated") ;
-		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.truststore.password")).isEqualTo("generated") ;
-		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.key.password")).isEqualTo("generated") ;
+			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString());
+		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.keystore.password")).isEqualTo("generated");
+		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.truststore.password")).isEqualTo("generated");
+		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.key.password")).isEqualTo("generated");
 
 
 		final Map<String, Object> mergedConsumerConfiguration = kafkaBinderConfigurationProperties.mergedConsumerConfiguration();
-		assertThat(mergedConsumerConfiguration.get("schema.registry.url")).isEqualTo("https://localhost:8081,https://localhost:8082") ;
+		assertThat(mergedConsumerConfiguration.get("schema.registry.url")).isEqualTo("https://localhost:8081,https://localhost:8082");
 		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.keystore.location")).isEqualTo(
-			Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString()) ;
+			Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString());
 		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.truststore.location")).isEqualTo(
-			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString()) ;
-		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.keystore.password")).isEqualTo("generated") ;
-		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.truststore.password")).isEqualTo("generated") ;
-		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.key.password")).isEqualTo("generated") ;
+			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString());
+		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.keystore.password")).isEqualTo("generated");
+		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.truststore.password")).isEqualTo("generated");
+		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.key.password")).isEqualTo("generated");
 
 
 	}

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/test/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationPropertiesTest.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/test/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationPropertiesTest.java
@@ -187,7 +187,6 @@ class KafkaBinderConfigurationPropertiesTest {
 		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
 				new KafkaBinderConfigurationProperties(kafkaProperties);
 		final Map<String, String> configuration = kafkaBinderConfigurationProperties.getConfiguration();
-
 		configuration.put("schema.registry.ssl.truststore.location", "classpath:testclient.truststore");
 		configuration.put("schema.registry.ssl.keystore.location", "classpath:testclient.keystore");
 		kafkaBinderConfigurationProperties.setCertificateStoreDirectory("target");
@@ -199,6 +198,18 @@ class KafkaBinderConfigurationPropertiesTest {
 		assertThat(configuration.get("schema.registry.ssl.keystore.location")).isEqualTo(
 				Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString());
 
+		final Map<String, String> producerProperties = kafkaBinderConfigurationProperties.getProducerProperties();
+		assertThat(producerProperties.get("schema.registry.ssl.truststore.location")).isEqualTo(
+			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString());
+		assertThat(producerProperties.get("schema.registry.ssl.keystore.location")).isEqualTo(
+			Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString());
+
+		final Map<String, String> consumerProperties = kafkaBinderConfigurationProperties.getConsumerProperties();
+		assertThat(consumerProperties.get("schema.registry.ssl.truststore.location")).isEqualTo(
+			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString());
+		assertThat(consumerProperties.get("schema.registry.ssl.keystore.location")).isEqualTo(
+			Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString());
+
 		final Map<String, Object> mergedProducerConfiguration = kafkaBinderConfigurationProperties.mergedProducerConfiguration();
 		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.truststore.location")).isEqualTo(
 			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString());
@@ -210,47 +221,6 @@ class KafkaBinderConfigurationPropertiesTest {
 			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString());
 		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.keystore.location")).isEqualTo(
 			Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString());
-	}
-
-	@Test
-	void schemaRegistryPropertiesPropagatedToMergedProducerProperties(){
-		KafkaProperties kafkaProperties = new KafkaProperties();
-		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
-			new KafkaBinderConfigurationProperties(kafkaProperties);
-		final Map<String, String> configuration = kafkaBinderConfigurationProperties.getConfiguration();
-
-		configuration.put("schema.registry.url", "https://localhost:8081,https://localhost:8082");
-		configuration.put("schema.registry.ssl.truststore.location", "classpath:testclient.truststore");
-		configuration.put("schema.registry.ssl.keystore.location", "classpath:testclient.keystore");
-		configuration.put("schema.registry.ssl.keystore.password", "generated");
-		configuration.put("schema.registry.ssl.truststore.password", "generated");
-		configuration.put("schema.registry.ssl.key.password", "generated");
-
-		kafkaBinderConfigurationProperties.setCertificateStoreDirectory("target");
-		kafkaBinderConfigurationProperties.getKafkaConnectionString();
-
-		final Map<String, Object> mergedProducerConfiguration = kafkaBinderConfigurationProperties.mergedProducerConfiguration();
-		assertThat(mergedProducerConfiguration.get("schema.registry.url")).isEqualTo("https://localhost:8081,https://localhost:8082") ;
-		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.keystore.location")).isEqualTo(
-			Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString()) ;
-		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.truststore.location")).isEqualTo(
-			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString()) ;
-		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.keystore.password")).isEqualTo("generated") ;
-		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.truststore.password")).isEqualTo("generated") ;
-		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.key.password")).isEqualTo("generated") ;
-
-
-		final Map<String, Object> mergedConsumerConfiguration = kafkaBinderConfigurationProperties.mergedConsumerConfiguration();
-		assertThat(mergedConsumerConfiguration.get("schema.registry.url")).isEqualTo("https://localhost:8081,https://localhost:8082") ;
-		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.keystore.location")).isEqualTo(
-			Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString()) ;
-		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.truststore.location")).isEqualTo(
-			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString()) ;
-		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.keystore.password")).isEqualTo("generated") ;
-		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.truststore.password")).isEqualTo("generated") ;
-		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.key.password")).isEqualTo("generated") ;
-
-
 	}
 
 	private void createContextWithCertFileHandler(HttpServer server, String path) {

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/test/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationPropertiesTest.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/test/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationPropertiesTest.java
@@ -40,10 +40,10 @@ class KafkaBinderConfigurationPropertiesTest {
 		KafkaProperties kafkaProperties = new KafkaProperties();
 		kafkaProperties.getConsumer().setGroupId("group1");
 		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
-			new KafkaBinderConfigurationProperties(kafkaProperties);
+				new KafkaBinderConfigurationProperties(kafkaProperties);
 
 		Map<String, Object> mergedConsumerConfiguration =
-			kafkaBinderConfigurationProperties.mergedConsumerConfiguration();
+				kafkaBinderConfigurationProperties.mergedConsumerConfiguration();
 
 		assertThat(mergedConsumerConfiguration).doesNotContainKeys(ConsumerConfig.GROUP_ID_CONFIG);
 	}
@@ -53,10 +53,10 @@ class KafkaBinderConfigurationPropertiesTest {
 		KafkaProperties kafkaProperties = new KafkaProperties();
 		kafkaProperties.getConsumer().setEnableAutoCommit(true);
 		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
-			new KafkaBinderConfigurationProperties(kafkaProperties);
+				new KafkaBinderConfigurationProperties(kafkaProperties);
 
 		Map<String, Object> mergedConsumerConfiguration =
-			kafkaBinderConfigurationProperties.mergedConsumerConfiguration();
+				kafkaBinderConfigurationProperties.mergedConsumerConfiguration();
 
 		assertThat(mergedConsumerConfiguration).doesNotContainKeys(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG);
 	}
@@ -65,9 +65,9 @@ class KafkaBinderConfigurationPropertiesTest {
 	void mergedConsumerConfigurationFiltersGroupIdFromKafkaBinderConfigurationPropertiesConfiguration() {
 		KafkaProperties kafkaProperties = new KafkaProperties();
 		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
-			new KafkaBinderConfigurationProperties(kafkaProperties);
+				new KafkaBinderConfigurationProperties(kafkaProperties);
 		kafkaBinderConfigurationProperties
-			.setConfiguration(Collections.singletonMap(ConsumerConfig.GROUP_ID_CONFIG, "group1"));
+				.setConfiguration(Collections.singletonMap(ConsumerConfig.GROUP_ID_CONFIG, "group1"));
 
 		Map<String, Object> mergedConsumerConfiguration = kafkaBinderConfigurationProperties.mergedConsumerConfiguration();
 
@@ -78,9 +78,9 @@ class KafkaBinderConfigurationPropertiesTest {
 	void mergedConsumerConfigurationFiltersEnableAutoCommitFromKafkaBinderConfigurationPropertiesConfiguration() {
 		KafkaProperties kafkaProperties = new KafkaProperties();
 		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
-			new KafkaBinderConfigurationProperties(kafkaProperties);
+				new KafkaBinderConfigurationProperties(kafkaProperties);
 		kafkaBinderConfigurationProperties
-			.setConfiguration(Collections.singletonMap(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true"));
+				.setConfiguration(Collections.singletonMap(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true"));
 
 		Map<String, Object> mergedConsumerConfiguration = kafkaBinderConfigurationProperties.mergedConsumerConfiguration();
 
@@ -91,9 +91,9 @@ class KafkaBinderConfigurationPropertiesTest {
 	void mergedConsumerConfigurationFiltersGroupIdFromKafkaBinderConfigurationPropertiesConsumerProperties() {
 		KafkaProperties kafkaProperties = new KafkaProperties();
 		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
-			new KafkaBinderConfigurationProperties(kafkaProperties);
+				new KafkaBinderConfigurationProperties(kafkaProperties);
 		kafkaBinderConfigurationProperties
-			.setConsumerProperties(Collections.singletonMap(ConsumerConfig.GROUP_ID_CONFIG, "group1"));
+				.setConsumerProperties(Collections.singletonMap(ConsumerConfig.GROUP_ID_CONFIG, "group1"));
 
 		Map<String, Object> mergedConsumerConfiguration = kafkaBinderConfigurationProperties.mergedConsumerConfiguration();
 
@@ -104,9 +104,9 @@ class KafkaBinderConfigurationPropertiesTest {
 	void mergedConsumerConfigurationFiltersEnableAutoCommitFromKafkaBinderConfigurationPropertiesConsumerProps() {
 		KafkaProperties kafkaProperties = new KafkaProperties();
 		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
-			new KafkaBinderConfigurationProperties(kafkaProperties);
+				new KafkaBinderConfigurationProperties(kafkaProperties);
 		kafkaBinderConfigurationProperties
-			.setConsumerProperties(Collections.singletonMap(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true"));
+				.setConsumerProperties(Collections.singletonMap(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true"));
 
 		Map<String, Object> mergedConsumerConfiguration = kafkaBinderConfigurationProperties.mergedConsumerConfiguration();
 
@@ -117,7 +117,7 @@ class KafkaBinderConfigurationPropertiesTest {
 	void certificateFilesAreConvertedToAbsolutePathsFromClassPathResources() {
 		KafkaProperties kafkaProperties = new KafkaProperties();
 		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
-			new KafkaBinderConfigurationProperties(kafkaProperties);
+				new KafkaBinderConfigurationProperties(kafkaProperties);
 		final Map<String, String> configuration = kafkaBinderConfigurationProperties.getConfiguration();
 		configuration.put("ssl.truststore.location", "classpath:testclient.truststore");
 		configuration.put("ssl.keystore.location", "classpath:testclient.keystore");
@@ -125,9 +125,9 @@ class KafkaBinderConfigurationPropertiesTest {
 		kafkaBinderConfigurationProperties.getKafkaConnectionString();
 
 		assertThat(configuration.get("ssl.truststore.location"))
-			.isEqualTo(Paths.get(System.getProperty("java.io.tmpdir"), "testclient.truststore").toString());
+				.isEqualTo(Paths.get(System.getProperty("java.io.tmpdir"), "testclient.truststore").toString());
 		assertThat(configuration.get("ssl.keystore.location"))
-			.isEqualTo(Paths.get(System.getProperty("java.io.tmpdir"), "testclient.keystore").toString());
+				.isEqualTo(Paths.get(System.getProperty("java.io.tmpdir"), "testclient.keystore").toString());
 		deleteTempCertFiles();
 	}
 
@@ -167,7 +167,7 @@ class KafkaBinderConfigurationPropertiesTest {
 	void certificateFilesAreConvertedToGivenAbsolutePathsFromClassPathResources() {
 		KafkaProperties kafkaProperties = new KafkaProperties();
 		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
-			new KafkaBinderConfigurationProperties(kafkaProperties);
+				new KafkaBinderConfigurationProperties(kafkaProperties);
 		final Map<String, String> configuration = kafkaBinderConfigurationProperties.getConfiguration();
 		configuration.put("ssl.truststore.location", "classpath:testclient.truststore");
 		configuration.put("ssl.keystore.location", "classpath:testclient.keystore");
@@ -176,16 +176,16 @@ class KafkaBinderConfigurationPropertiesTest {
 		kafkaBinderConfigurationProperties.getKafkaConnectionString();
 
 		assertThat(configuration.get("ssl.truststore.location")).isEqualTo(
-			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString());
+				Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString());
 		assertThat(configuration.get("ssl.keystore.location")).isEqualTo(
-			Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString());
+				Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString());
 	}
 
 	@Test
 	void certificateFilesAreMovedForSchemaRegistryConfiguration() {
 		KafkaProperties kafkaProperties = new KafkaProperties();
 		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
-			new KafkaBinderConfigurationProperties(kafkaProperties);
+				new KafkaBinderConfigurationProperties(kafkaProperties);
 		final Map<String, String> configuration = kafkaBinderConfigurationProperties.getConfiguration();
 
 		configuration.put("schema.registry.ssl.truststore.location", "classpath:testclient.truststore");
@@ -195,9 +195,9 @@ class KafkaBinderConfigurationPropertiesTest {
 		kafkaBinderConfigurationProperties.getKafkaConnectionString();
 
 		assertThat(configuration.get("schema.registry.ssl.truststore.location")).isEqualTo(
-			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString());
+				Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString());
 		assertThat(configuration.get("schema.registry.ssl.keystore.location")).isEqualTo(
-			Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString());
+				Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString());
 
 		final Map<String, Object> mergedProducerConfiguration = kafkaBinderConfigurationProperties.mergedProducerConfiguration();
 		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.truststore.location")).isEqualTo(
@@ -213,7 +213,7 @@ class KafkaBinderConfigurationPropertiesTest {
 	}
 
 	@Test
-	void schemaRegistryPropertiesPropagatedToMergedProducerProperties() {
+	void schemaRegistryPropertiesPropagatedToMergedProducerProperties(){
 		KafkaProperties kafkaProperties = new KafkaProperties();
 		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
 			new KafkaBinderConfigurationProperties(kafkaProperties);
@@ -230,25 +230,25 @@ class KafkaBinderConfigurationPropertiesTest {
 		kafkaBinderConfigurationProperties.getKafkaConnectionString();
 
 		final Map<String, Object> mergedProducerConfiguration = kafkaBinderConfigurationProperties.mergedProducerConfiguration();
-		assertThat(mergedProducerConfiguration.get("schema.registry.url")).isEqualTo("https://localhost:8081,https://localhost:8082");
+		assertThat(mergedProducerConfiguration.get("schema.registry.url")).isEqualTo("https://localhost:8081,https://localhost:8082") ;
 		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.keystore.location")).isEqualTo(
-			Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString());
+			Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString()) ;
 		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.truststore.location")).isEqualTo(
-			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString());
-		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.keystore.password")).isEqualTo("generated");
-		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.truststore.password")).isEqualTo("generated");
-		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.key.password")).isEqualTo("generated");
+			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString()) ;
+		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.keystore.password")).isEqualTo("generated") ;
+		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.truststore.password")).isEqualTo("generated") ;
+		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.key.password")).isEqualTo("generated") ;
 
 
 		final Map<String, Object> mergedConsumerConfiguration = kafkaBinderConfigurationProperties.mergedConsumerConfiguration();
-		assertThat(mergedConsumerConfiguration.get("schema.registry.url")).isEqualTo("https://localhost:8081,https://localhost:8082");
+		assertThat(mergedConsumerConfiguration.get("schema.registry.url")).isEqualTo("https://localhost:8081,https://localhost:8082") ;
 		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.keystore.location")).isEqualTo(
-			Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString());
+			Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString()) ;
 		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.truststore.location")).isEqualTo(
-			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString());
-		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.keystore.password")).isEqualTo("generated");
-		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.truststore.password")).isEqualTo("generated");
-		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.key.password")).isEqualTo("generated");
+			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString()) ;
+		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.keystore.password")).isEqualTo("generated") ;
+		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.truststore.password")).isEqualTo("generated") ;
+		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.key.password")).isEqualTo("generated") ;
 
 
 	}

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/test/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationPropertiesTest.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/test/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationPropertiesTest.java
@@ -185,8 +185,9 @@ class KafkaBinderConfigurationPropertiesTest {
 	void certificateFilesAreMovedForSchemaRegistryConfiguration() {
 		KafkaProperties kafkaProperties = new KafkaProperties();
 		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
-				new KafkaBinderConfigurationProperties(kafkaProperties);
+			new KafkaBinderConfigurationProperties(kafkaProperties);
 		final Map<String, String> configuration = kafkaBinderConfigurationProperties.getConfiguration();
+
 		configuration.put("schema.registry.ssl.truststore.location", "classpath:testclient.truststore");
 		configuration.put("schema.registry.ssl.keystore.location", "classpath:testclient.keystore");
 		kafkaBinderConfigurationProperties.setCertificateStoreDirectory("target");
@@ -194,20 +195,8 @@ class KafkaBinderConfigurationPropertiesTest {
 		kafkaBinderConfigurationProperties.getKafkaConnectionString();
 
 		assertThat(configuration.get("schema.registry.ssl.truststore.location")).isEqualTo(
-				Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString());
+			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString());
 		assertThat(configuration.get("schema.registry.ssl.keystore.location")).isEqualTo(
-				Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString());
-
-		final Map<String, String> producerProperties = kafkaBinderConfigurationProperties.getProducerProperties();
-		assertThat(producerProperties.get("schema.registry.ssl.truststore.location")).isEqualTo(
-			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString());
-		assertThat(producerProperties.get("schema.registry.ssl.keystore.location")).isEqualTo(
-			Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString());
-
-		final Map<String, String> consumerProperties = kafkaBinderConfigurationProperties.getConsumerProperties();
-		assertThat(consumerProperties.get("schema.registry.ssl.truststore.location")).isEqualTo(
-			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString());
-		assertThat(consumerProperties.get("schema.registry.ssl.keystore.location")).isEqualTo(
 			Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString());
 
 		final Map<String, Object> mergedProducerConfiguration = kafkaBinderConfigurationProperties.mergedProducerConfiguration();
@@ -221,6 +210,47 @@ class KafkaBinderConfigurationPropertiesTest {
 			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString());
 		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.keystore.location")).isEqualTo(
 			Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString());
+	}
+
+	@Test
+	void schemaRegistryPropertiesPropagatedToMergedProducerProperties() {
+		KafkaProperties kafkaProperties = new KafkaProperties();
+		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
+			new KafkaBinderConfigurationProperties(kafkaProperties);
+		final Map<String, String> configuration = kafkaBinderConfigurationProperties.getConfiguration();
+
+		configuration.put("schema.registry.url", "https://localhost:8081,https://localhost:8082");
+		configuration.put("schema.registry.ssl.truststore.location", "classpath:testclient.truststore");
+		configuration.put("schema.registry.ssl.keystore.location", "classpath:testclient.keystore");
+		configuration.put("schema.registry.ssl.keystore.password", "generated");
+		configuration.put("schema.registry.ssl.truststore.password", "generated");
+		configuration.put("schema.registry.ssl.key.password", "generated");
+
+		kafkaBinderConfigurationProperties.setCertificateStoreDirectory("target");
+		kafkaBinderConfigurationProperties.getKafkaConnectionString();
+
+		final Map<String, Object> mergedProducerConfiguration = kafkaBinderConfigurationProperties.mergedProducerConfiguration();
+		assertThat(mergedProducerConfiguration.get("schema.registry.url")).isEqualTo("https://localhost:8081,https://localhost:8082");
+		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.keystore.location")).isEqualTo(
+			Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString());
+		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.truststore.location")).isEqualTo(
+			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString());
+		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.keystore.password")).isEqualTo("generated");
+		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.truststore.password")).isEqualTo("generated");
+		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.key.password")).isEqualTo("generated");
+
+
+		final Map<String, Object> mergedConsumerConfiguration = kafkaBinderConfigurationProperties.mergedConsumerConfiguration();
+		assertThat(mergedConsumerConfiguration.get("schema.registry.url")).isEqualTo("https://localhost:8081,https://localhost:8082");
+		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.keystore.location")).isEqualTo(
+			Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString());
+		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.truststore.location")).isEqualTo(
+			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString());
+		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.keystore.password")).isEqualTo("generated");
+		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.truststore.password")).isEqualTo("generated");
+		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.key.password")).isEqualTo("generated");
+
+
 	}
 
 	private void createContextWithCertFileHandler(HttpServer server, String path) {

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/test/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationPropertiesTest.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/test/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationPropertiesTest.java
@@ -187,6 +187,7 @@ class KafkaBinderConfigurationPropertiesTest {
 		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
 				new KafkaBinderConfigurationProperties(kafkaProperties);
 		final Map<String, String> configuration = kafkaBinderConfigurationProperties.getConfiguration();
+
 		configuration.put("schema.registry.ssl.truststore.location", "classpath:testclient.truststore");
 		configuration.put("schema.registry.ssl.keystore.location", "classpath:testclient.keystore");
 		kafkaBinderConfigurationProperties.setCertificateStoreDirectory("target");
@@ -197,18 +198,6 @@ class KafkaBinderConfigurationPropertiesTest {
 				Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString());
 		assertThat(configuration.get("schema.registry.ssl.keystore.location")).isEqualTo(
 				Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString());
-
-		final Map<String, String> producerProperties = kafkaBinderConfigurationProperties.getProducerProperties();
-		assertThat(producerProperties.get("schema.registry.ssl.truststore.location")).isEqualTo(
-			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString());
-		assertThat(producerProperties.get("schema.registry.ssl.keystore.location")).isEqualTo(
-			Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString());
-
-		final Map<String, String> consumerProperties = kafkaBinderConfigurationProperties.getConsumerProperties();
-		assertThat(consumerProperties.get("schema.registry.ssl.truststore.location")).isEqualTo(
-			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString());
-		assertThat(consumerProperties.get("schema.registry.ssl.keystore.location")).isEqualTo(
-			Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString());
 
 		final Map<String, Object> mergedProducerConfiguration = kafkaBinderConfigurationProperties.mergedProducerConfiguration();
 		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.truststore.location")).isEqualTo(
@@ -221,6 +210,47 @@ class KafkaBinderConfigurationPropertiesTest {
 			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString());
 		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.keystore.location")).isEqualTo(
 			Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString());
+	}
+
+	@Test
+	void schemaRegistryPropertiesPropagatedToMergedProducerProperties(){
+		KafkaProperties kafkaProperties = new KafkaProperties();
+		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
+			new KafkaBinderConfigurationProperties(kafkaProperties);
+		final Map<String, String> configuration = kafkaBinderConfigurationProperties.getConfiguration();
+
+		configuration.put("schema.registry.url", "https://localhost:8081,https://localhost:8082");
+		configuration.put("schema.registry.ssl.truststore.location", "classpath:testclient.truststore");
+		configuration.put("schema.registry.ssl.keystore.location", "classpath:testclient.keystore");
+		configuration.put("schema.registry.ssl.keystore.password", "generated");
+		configuration.put("schema.registry.ssl.truststore.password", "generated");
+		configuration.put("schema.registry.ssl.key.password", "generated");
+
+		kafkaBinderConfigurationProperties.setCertificateStoreDirectory("target");
+		kafkaBinderConfigurationProperties.getKafkaConnectionString();
+
+		final Map<String, Object> mergedProducerConfiguration = kafkaBinderConfigurationProperties.mergedProducerConfiguration();
+		assertThat(mergedProducerConfiguration.get("schema.registry.url")).isEqualTo("https://localhost:8081,https://localhost:8082") ;
+		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.keystore.location")).isEqualTo(
+			Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString()) ;
+		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.truststore.location")).isEqualTo(
+			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString()) ;
+		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.keystore.password")).isEqualTo("generated") ;
+		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.truststore.password")).isEqualTo("generated") ;
+		assertThat(mergedProducerConfiguration.get("schema.registry.ssl.key.password")).isEqualTo("generated") ;
+
+
+		final Map<String, Object> mergedConsumerConfiguration = kafkaBinderConfigurationProperties.mergedConsumerConfiguration();
+		assertThat(mergedConsumerConfiguration.get("schema.registry.url")).isEqualTo("https://localhost:8081,https://localhost:8082") ;
+		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.keystore.location")).isEqualTo(
+			Paths.get(Files.currentFolder().toString(), "target", "testclient.keystore").toString()) ;
+		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.truststore.location")).isEqualTo(
+			Paths.get(Files.currentFolder().toString(), "target", "testclient.truststore").toString()) ;
+		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.keystore.password")).isEqualTo("generated") ;
+		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.truststore.password")).isEqualTo("generated") ;
+		assertThat(mergedConsumerConfiguration.get("schema.registry.ssl.key.password")).isEqualTo("generated") ;
+
+
 	}
 
 	private void createContextWithCertFileHandler(HttpServer server, String path) {


### PR DESCRIPTION
When providing schema registry SSL properties under Kafka binder configuration, those properties are not being propagated to producer configurations and consumer configurations
This is necessary for certain serializer/deserializer to work. 

This change will fix https://github.com/spring-cloud/spring-cloud-stream/issues/2882 .

