### PR TITLE
GH-2893: Enable AutoConfiguration of TestChannelBinderConfiguration

### DIFF
--- a/core/spring-cloud-stream-test-binder/src/main/java/org/springframework/cloud/stream/binder/test/TestChannelBinderConfiguration.java
+++ b/core/spring-cloud-stream-test-binder/src/main/java/org/springframework/cloud/stream/binder/test/TestChannelBinderConfiguration.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cloud.stream.binder.Binder;
 import org.springframework.cloud.stream.binder.ConsumerProperties;
@@ -28,7 +28,6 @@ import org.springframework.cloud.stream.binder.ProducerProperties;
 import org.springframework.cloud.stream.config.BinderFactoryAutoConfiguration;
 import org.springframework.cloud.stream.config.BindingServiceConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.integration.config.EnableIntegration;
 
@@ -42,8 +41,7 @@ import org.springframework.integration.config.EnableIntegration;
  * @author David Turanski
  * @see TestChannelBinder
  */
-@Configuration
-@ConditionalOnMissingBean(Binder.class)
+@AutoConfiguration
 @Import(BinderFactoryAutoConfiguration.class)
 @EnableIntegration
 public class TestChannelBinderConfiguration<T> {

--- a/core/spring-cloud-stream-test-binder/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/core/spring-cloud-stream-test-binder/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration


### PR DESCRIPTION
- Resolved the issue where the auto-configuration of TestChannelBinderConfiguration is delayed and injection fails if a message handler is not registered.
- Always enable the AutoConfiguration of TestChannelBinderConfiguration.

Resolves #2893