### PR TITLE
Thread Safety Issue in serializeOnOutbound Method of KafkaStreamsMessageConversionDelegate

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsMessageConversionDelegate.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsMessageConversionDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Soby Chacko
  * @author Byungjun You
+ * @author Lazare Giorgobiani
  */
 public class KafkaStreamsMessageConversionDelegate {
 

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsMessageConversionDelegate.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsMessageConversionDelegate.java
@@ -92,7 +92,7 @@ public class KafkaStreamsMessageConversionDelegate {
 		String contentType = this.kstreamBindingInformationCatalogue
 				.getContentType(outboundBindTarget);
 		MessageConverter messageConverter = this.compositeMessageConverter;
-		final PerRecordContentTypeHolder perRecordContentTypeHolder = new PerRecordContentTypeHolder();
+		final ThreadLocal<PerRecordContentTypeHolder> perRecordContentTypeHolderThreadLocal = ThreadLocal.withInitial(PerRecordContentTypeHolder::new);
 
 		final KStream<?, ?> kStreamWithEnrichedHeaders = outboundBindTarget
 			.filter((k, v) -> v != null)
@@ -105,7 +105,7 @@ public class KafkaStreamsMessageConversionDelegate {
 				}
 				MessageHeaders messageHeaders = new MessageHeaders(headers);
 				final Message<?> convertedMessage = messageConverter.toMessage(message.getPayload(), messageHeaders);
-				perRecordContentTypeHolder.setContentType((String) messageHeaders.get(MessageHeaders.CONTENT_TYPE));
+				perRecordContentTypeHolderThreadLocal.get().setContentType((String) messageHeaders.get(MessageHeaders.CONTENT_TYPE));
 				return Objects.requireNonNull(convertedMessage).getPayload();
 			});
 
@@ -120,12 +120,12 @@ public class KafkaStreamsMessageConversionDelegate {
 
 			@Override
 			public void process(Record record) {
-				if (perRecordContentTypeHolder.contentType != null) {
+				if (perRecordContentTypeHolderThreadLocal.get().contentType != null) {
 					record.headers().remove(MessageHeaders.CONTENT_TYPE);
 					final Header header;
 					try {
 						header = new RecordHeader(MessageHeaders.CONTENT_TYPE,
-							new ObjectMapper().writeValueAsBytes(perRecordContentTypeHolder.contentType));
+							new ObjectMapper().writeValueAsBytes(perRecordContentTypeHolderThreadLocal.get().contentType));
 						record.headers().add(header);
 					}
 					catch (Exception e) {
@@ -133,7 +133,7 @@ public class KafkaStreamsMessageConversionDelegate {
 							LOG.debug("Could not add content type header");
 						}
 					}
-					perRecordContentTypeHolder.unsetContentType();
+					perRecordContentTypeHolderThreadLocal.get().unsetContentType();
 				}
 			}
 


### PR DESCRIPTION
## Description

I've identified a thread safety issue in the `serializeOnOutbound` method of the `KafkaStreamsMessageConversionDelegate` class. Specifically, the usage of `PerRecordContentTypeHolder` is not thread-safe, which could lead to incorrect behavior in multi-threaded environments (For example when inbound topic has multiple partitions and and streams is processed conncurrently).

## Steps to Reproduce

The issue arises in scenarios where the `serializeOnOutbound` method is invoked concurrently by multiple threads, leading to potential race conditions and incorrect handling of the `contentType` for each record.

I've implemented POC application for reproducing this scenario: https://github.com/LazroLeader/CloudStreamRaceConditionPOC
 
## Expected Behavior

Each thread should have its own instance of `PerRecordContentTypeHolder` to ensure that the `contentType` is handled correctly without interference from other threads, avoiding outbound topic having `contentType` of `null`. 

## Actual Behavior

Due to the shared use of `PerRecordContentTypeHolder`, there's a risk that concurrent modifications by multiple threads could lead to unpredictable behavior and incorrect `contentType` processing. This leads to some messages produced to outbound topic having header with key `contentType` equal to `null`.  

## Proposed Solution

I have addressed this issue by introducing a `ThreadLocal<PerRecordContentTypeHolder>` to ensure that each thread has its own isolated instance of `PerRecordContentTypeHolder`, thus making the `serializeOnOutbound` method thread-safe. Here's a snippet of the proposed change:

```java
final ThreadLocal<PerRecordContentTypeHolder> perRecordContentTypeHolderThreadLocal = ThreadLocal.withInitial(PerRecordContentTypeHolder::new);
```

Also changing every occurance of:
```java
perRecordContentTypeholder
```
to
```java
perRecordContentTypeHolderThreadLocal.get()
