### PR TITLE
Fixing empty truststore-config in Kafka Streams binder

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
@@ -63,6 +63,7 @@ import org.springframework.util.StringUtils;
  * @author Nico Heller
  * @author Norbert Gyurian
  * @author Boini Srinivas
+ * @author Felix Schultze
  */
 public class KafkaBinderConfigurationProperties {
 
@@ -208,7 +209,7 @@ public class KafkaBinderConfigurationProperties {
 		final String storeLocation = this.configuration.get(storeProperty);
 
 		// If the path is not defined, or it is a local file path do not move the file
-		if (storeLocation != null && !checkIfFileExists(storeLocation)) {
+		if (StringUtils.hasText(storeLocation) && !checkIfFileExists(storeLocation)) {
 			final String fileSystemLocation = moveCertToFileSystem(storeLocation, this.certificateStoreDirectory);
 			// Overriding the value with absolute filesystem path.
 			this.configuration.put(storeProperty, fileSystemLocation);

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/test/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationPropertiesTest.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/test/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationPropertiesTest.java
@@ -253,6 +253,22 @@ class KafkaBinderConfigurationPropertiesTest {
 
 	}
 
+	@Test
+	public void testEmptyLocationsAreIgnored() {
+		KafkaProperties kafkaProperties = new KafkaProperties();
+		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
+				new KafkaBinderConfigurationProperties(kafkaProperties);
+		final Map<String, String> configuration = kafkaBinderConfigurationProperties.getConfiguration();
+		configuration.put("schema.registry.ssl.truststore.location", "");
+		configuration.put("schema.registry.ssl.keystore.location", "");
+		kafkaBinderConfigurationProperties.setCertificateStoreDirectory("target");
+
+		kafkaBinderConfigurationProperties.getKafkaConnectionString();
+
+		assertThat(configuration.get("schema.registry.ssl.truststore.location")).isEmpty();
+		assertThat(configuration.get("schema.registry.ssl.keystore.location")).isEmpty();
+	}
+
 	private void createContextWithCertFileHandler(HttpServer server, String path) {
 		server.createContext("/" + path, exchange -> {
 			ClassPathResource ts = new ClassPathResource(path);


### PR DESCRIPTION
* do not copy truststore, if "ssl.truststore.location" is set to empty string (e.g. ssl.truststore.location:{ENV_VARIABLE})

The Config worked until version 4.0.4 :-)

Error was:
`Caused by: java.lang.IllegalStateException: java.io.FileNotFoundException: class path resource [${TRUSTSTORE_PATH}] cannot be opened because it does not exist
at org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties.moveCertsToFileSystemIfNecessary(KafkaBinderConfigurationProperties.java:199)
at org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties.getKafkaConnectionString(KafkaBinderConfigurationProperties.java:183)
at org.springframework.cloud.stream.binder.kafka.provisioning.KafkaTopicProvisioner.normalalizeBootPropsWithBinder(KafkaTopicProvisioner.java:300)
at org.springframework.cloud.stream.binder.kafka.provisioning.KafkaTopicProvisioner.(KafkaTopicProvisioner.java:140)
at org.springframework.cloud.stream.binder.kafka.config.KafkaBinderConfiguration.provisioningProvider(KafkaBinderConfiguration.java:118)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.base/java.lang.reflect.Method.invoke(Method.java:568)
at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:139)
... 161 more
Caused by: java.io.FileNotFoundException: class path resource [${TRUSTSTORE_PATH}] cannot be opened because it does not exist
at org.springframework.core.io.ClassPathResource.getInputStream(ClassPathResource.java:211)
at org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties.moveCertToFileSystem(KafkaBinderConfigurationProperties.java:243)
at org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties.moveCertsIfApplicable(KafkaBinderConfigurationProperties.java:208)
at org.springframework.cloud.stream.binder.kafka.properties.KafkaBinderConfigurationProperties.moveCertsToFileSystemIfNecessary(KafkaBinderConfigurationProperties.java:191)`