### PR TITLE
Fix Pulsar binder for Java 21

### DIFF
--- a/binders/pulsar-binder/spring-cloud-stream-binder-pulsar/src/main/java/org/springframework/cloud/stream/binder/pulsar/PulsarMessageChannelBinder.java
+++ b/binders/pulsar-binder/spring-cloud-stream-binder-pulsar/src/main/java/org/springframework/cloud/stream/binder/pulsar/PulsarMessageChannelBinder.java
@@ -46,7 +46,6 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.pulsar.core.ProducerBuilderConfigurationUtil;
 import org.springframework.pulsar.core.ProducerBuilderCustomizer;
 import org.springframework.pulsar.core.PulsarConsumerFactory;
 import org.springframework.pulsar.core.PulsarTemplate;
@@ -111,7 +110,7 @@ public class PulsarMessageChannelBinder extends
 		var layeredProducerProps = PulsarBinderUtils.mergeModifiedProducerProperties(
 				this.binderConfigProps.getProducer(), producerProperties.getExtension());
 		var handler = new PulsarProducerConfigurationMessageHandler(this.pulsarTemplate, schema, destination.getName(),
-				(builder) -> ProducerBuilderConfigurationUtil.loadConf(builder, layeredProducerProps),
+				(builder) -> PulsarBinderUtils.loadConf(builder, layeredProducerProps),
 				determineOutboundHeaderMapper(producerProperties));
 		handler.setApplicationContext(getApplicationContext());
 		handler.setBeanFactory(getBeanFactory());

--- a/binders/pulsar-binder/spring-cloud-stream-binder-pulsar/src/main/java/org/springframework/cloud/stream/binder/pulsar/properties/ProducerConfigProperties.java
+++ b/binders/pulsar-binder/spring-cloud-stream-binder-pulsar/src/main/java/org/springframework/cloud/stream/binder/pulsar/properties/ProducerConfigProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2023 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -230,16 +230,20 @@ public class ProducerConfigProperties extends PulsarProperties.Producer {
 				.to(producerProps.in("maxPendingMessagesAcrossPartitions"));
 		map.from(this::getMultiSchema).to(producerProps.in("multiSchema"));
 		map.from(this::getProperties).to(producerProps.in("properties"));
+		this.mapBatchProperties(this.getBatch(), producerProps, map);
+		return producerProps;
+	}
+
+	private void mapBatchProperties(Batching batch, Properties producerProps, PropertyMapper map) {
 		if (this.isBatchingEnabled()) {
-			map.from(this::getBatch).as(Batching::getMaxPublishDelay).as(it -> it.toNanos() / 1000)
+			map.from(batch::getMaxPublishDelay).as(it -> it.toNanos() / 1000)
 					.to(producerProps.in("batchingMaxPublishDelayMicros"));
-			map.from(this::getBatch).as(Batching::getPartitionSwitchFrequencyByPublishDelay)
+			map.from(batch::getPartitionSwitchFrequencyByPublishDelay)
 					.to(producerProps.in("batchingPartitionSwitchFrequencyByPublishDelay"));
-			map.from(this::getBatch).as(Batching::getMaxMessages).to(producerProps.in("batchingMaxMessages"));
-			map.from(this::getBatch).as(Batching::getMaxBytes).asInt(DataSize::toBytes)
+			map.from(batch::getMaxMessages).to(producerProps.in("batchingMaxMessages"));
+			map.from(batch::getMaxBytes).asInt(DataSize::toBytes)
 					.to(producerProps.in("batchingMaxBytes"));
 		}
-		return producerProps;
 	}
 
 	/**

--- a/binders/pulsar-binder/spring-cloud-stream-binder-pulsar/src/test/java/org/springframework/cloud/stream/binder/pulsar/ConsumerConfigPropertiesTests.java
+++ b/binders/pulsar-binder/spring-cloud-stream-binder-pulsar/src/test/java/org/springframework/cloud/stream/binder/pulsar/ConsumerConfigPropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2023 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import org.springframework.cloud.stream.binder.pulsar.properties.ConsumerConfigP
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.entry;
 
 /**
  * Unit tests for {@link ConsumerConfigProperties}.
@@ -47,7 +48,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 class ConsumerConfigPropertiesTests {
 
 	@Test
-	void basePropsCanBeExtractedToMap() {
+	void allBasePropsCanBeExtractedToMap() {
 		var inputProps = basePropsInputMap();
 		var consumerConfigProps = bindInputPropsToConsumerConfigProps(inputProps);
 		var outputProps = consumerConfigProps.toBaseConsumerPropertiesMap();
@@ -55,35 +56,60 @@ class ConsumerConfigPropertiesTests {
 		verifyBasePropsInOutputMap(outputProps);
 	}
 
+	@Test
+	void nullBasePropsSkippedWhenExtractedToMap() {
+		var inputProps = Map.of("spring.pulsar.consumer.name", "my-consumer");
+		var consumerConfigProps = bindInputPropsToConsumerConfigProps(inputProps);
+		var outputProps = consumerConfigProps.toBaseConsumerPropertiesMap();
+		assertThat(outputProps).contains(entry("consumerName", "my-consumer"));
+		assertThat(outputProps).doesNotContainKey("deadLetterPolicy");
+	}
+
 	private Map<String, String> basePropsInputMap() {
 		Map<String, String> inputProps = new HashMap<>();
-		inputProps.put("spring.pulsar.consumer.dead-letter-policy.max-redeliver-count", "4");
-		inputProps.put("spring.pulsar.consumer.dead-letter-policy.retry-letter-topic", "my-retry-topic");
-		inputProps.put("spring.pulsar.consumer.dead-letter-policy.dead-letter-topic", "my-dlt-topic");
-		inputProps.put("spring.pulsar.consumer.dead-letter-policy.initial-subscription-name",
-				"my-initial-subscription");
 		inputProps.put("spring.pulsar.consumer.name", "my-consumer");
 		inputProps.put("spring.pulsar.consumer.priority-level", "8");
 		inputProps.put("spring.pulsar.consumer.read-compacted", "true");
 		inputProps.put("spring.pulsar.consumer.retry-enable", "true");
 		inputProps.put("spring.pulsar.consumer.topics[0]", "my-topic");
 		inputProps.put("spring.pulsar.consumer.topics-pattern", "my-pattern");
+		// DeadLetterPolicy
+		inputProps.put("spring.pulsar.consumer.dead-letter-policy.max-redeliver-count", "4");
+		inputProps.put("spring.pulsar.consumer.dead-letter-policy.retry-letter-topic", "my-retry-topic");
+		inputProps.put("spring.pulsar.consumer.dead-letter-policy.dead-letter-topic", "my-dlt-topic");
+		inputProps.put("spring.pulsar.consumer.dead-letter-policy.initial-subscription-name",
+				"my-initial-subscription");
+		// Subscription
+		inputProps.put("spring.pulsar.consumer.subscription.name", "my-subscription");
+		inputProps.put("spring.pulsar.consumer.subscription.type", "exclusive");
+		inputProps.put("spring.pulsar.consumer.subscription.mode", "non-durable");
+		inputProps.put("spring.pulsar.consumer.subscription.initial-position", "earliest");
+		inputProps.put("spring.pulsar.consumer.subscription.topics-mode", "all-topics");
 		return inputProps;
 	}
 
 	private void verifyBasePropsInOutputMap(Map<String, Object> outputProps) {
-		assertThat(outputProps).hasEntrySatisfying("deadLetterPolicy", dlp -> {
-			DeadLetterPolicy deadLetterPolicy = (DeadLetterPolicy) dlp;
-			assertThat(deadLetterPolicy.getMaxRedeliverCount()).isEqualTo(4);
-			assertThat(deadLetterPolicy.getRetryLetterTopic()).isEqualTo("my-retry-topic");
-			assertThat(deadLetterPolicy.getDeadLetterTopic()).isEqualTo("my-dlt-topic");
-			assertThat(deadLetterPolicy.getInitialSubscriptionName()).isEqualTo("my-initial-subscription");
-		}).containsEntry("consumerName", "my-consumer").containsEntry("priorityLevel", 8)
-				.containsEntry("readCompacted", true).containsEntry("retryEnable", true)
-				.hasEntrySatisfying("topicNames",
-						topics -> assertThat(topics).asInstanceOf(InstanceOfAssertFactories.collection(String.class))
+		assertThat(outputProps)
+				.containsEntry("consumerName", "my-consumer")
+				.containsEntry("priorityLevel", 8)
+				.containsEntry("readCompacted", true)
+				.containsEntry("retryEnable", true)
+				.hasEntrySatisfying("topicNames", topics ->
+						assertThat(topics).asInstanceOf(InstanceOfAssertFactories.collection(String.class))
 								.containsExactly("my-topic"))
-				.hasEntrySatisfying("topicsPattern", p -> assertThat(p.toString()).isEqualTo("my-pattern"));
+				.hasEntrySatisfying("topicsPattern", p -> assertThat(p.toString()).isEqualTo("my-pattern"))
+				.containsEntry("subscriptionName", "my-subscription")
+				.containsEntry("subscriptionType", SubscriptionType.Exclusive)
+				.containsEntry("subscriptionMode", SubscriptionMode.NonDurable)
+				.containsEntry("subscriptionInitialPosition", SubscriptionInitialPosition.Earliest)
+				.containsEntry("regexSubscriptionMode", RegexSubscriptionMode.AllTopics)
+				.hasEntrySatisfying("deadLetterPolicy", dlp -> {
+					DeadLetterPolicy deadLetterPolicy = (DeadLetterPolicy) dlp;
+					assertThat(deadLetterPolicy.getMaxRedeliverCount()).isEqualTo(4);
+					assertThat(deadLetterPolicy.getRetryLetterTopic()).isEqualTo("my-retry-topic");
+					assertThat(deadLetterPolicy.getDeadLetterTopic()).isEqualTo("my-dlt-topic");
+					assertThat(deadLetterPolicy.getInitialSubscriptionName()).isEqualTo("my-initial-subscription");
+				});
 	}
 
 	@Test
@@ -119,21 +145,19 @@ class ConsumerConfigPropertiesTests {
 		inputProps.put("spring.pulsar.consumer.receiver-queue-size", "1");
 		inputProps.put("spring.pulsar.consumer.reset-include-head", "true");
 		inputProps.put("spring.pulsar.consumer.start-paused", "true");
+		// Acknowledgment
 		inputProps.put("spring.pulsar.consumer.ack.group-time", "2s");
 		inputProps.put("spring.pulsar.consumer.ack.redelivery-delay", "3s");
 		inputProps.put("spring.pulsar.consumer.ack.timeout", "6s");
 		inputProps.put("spring.pulsar.consumer.ack.timeout-tick-duration", "7s");
 		inputProps.put("spring.pulsar.consumer.ack.batch-index-enabled", "true");
 		inputProps.put("spring.pulsar.consumer.ack.receipt-enabled", "true");
+		// Chunk
 		inputProps.put("spring.pulsar.consumer.chunk.expire-time-incomplete", "12s");
 		inputProps.put("spring.pulsar.consumer.chunk.auto-ack-oldest-on-queue-full", "false");
 		inputProps.put("spring.pulsar.consumer.chunk.max-pending-messages", "11");
-		inputProps.put("spring.pulsar.consumer.subscription.name", "my-subscription");
-		inputProps.put("spring.pulsar.consumer.subscription.type", "shared");
+		// Subscription
 		inputProps.put("spring.pulsar.consumer.subscription.properties[my-sub-prop]", "my-sub-prop-value");
-		inputProps.put("spring.pulsar.consumer.subscription.mode", "nondurable");
-		inputProps.put("spring.pulsar.consumer.subscription.initial-position", "earliest");
-		inputProps.put("spring.pulsar.consumer.subscription.topics-mode", "all-topics");
 		inputProps.put("spring.pulsar.consumer.subscription.replicate-state", "true");
 		return inputProps;
 	}
@@ -143,27 +167,28 @@ class ConsumerConfigPropertiesTests {
 				.containsEntry("autoUpdatePartitionsIntervalSeconds", 10L)
 				.containsEntry("cryptoFailureAction", ConsumerCryptoFailureAction.DISCARD)
 				.containsEntry("maxTotalReceiverQueueSizeAcrossPartitions", 5)
-				.containsEntry("patternAutoDiscoveryPeriod", 9).containsEntry("poolMessages", true)
+				.containsEntry("patternAutoDiscoveryPeriod", 9)
+				.containsEntry("poolMessages", true)
 				.hasEntrySatisfying("properties",
 						properties -> assertThat(properties)
 								.asInstanceOf(InstanceOfAssertFactories.map(String.class, String.class))
 								.containsEntry("my-prop", "my-prop-value"))
-				.containsEntry("receiverQueueSize", 1).containsEntry("resetIncludeHead", true)
-				.containsEntry("startPaused", true).containsEntry("acknowledgementsGroupTimeMicros", 2_000_000L)
-				.containsEntry("negativeAckRedeliveryDelayMicros", 3_000_000L).containsEntry("ackTimeoutMillis", 6_000L)
-				.containsEntry("tickDurationMillis", 7_000L).containsEntry("batchIndexAckEnabled", true)
+				.containsEntry("receiverQueueSize", 1)
+				.containsEntry("resetIncludeHead", true)
+				.containsEntry("startPaused", true)
+				.containsEntry("acknowledgementsGroupTimeMicros", 2_000_000L)
+				.containsEntry("negativeAckRedeliveryDelayMicros", 3_000_000L)
+				.containsEntry("ackTimeoutMillis", 6_000L)
+				.containsEntry("tickDurationMillis", 7_000L)
+				.containsEntry("batchIndexAckEnabled", true)
 				.containsEntry("ackReceiptEnabled", true)
 				.containsEntry("expireTimeOfIncompleteChunkedMessageMillis", 12_000L)
 				.containsEntry("autoAckOldestChunkedMessageOnQueueFull", false)
-				.containsEntry("maxPendingChunkedMessage", 11).containsEntry("subscriptionName", "my-subscription")
-				.containsEntry("subscriptionType", SubscriptionType.Shared)
+				.containsEntry("maxPendingChunkedMessage", 11)
 				.hasEntrySatisfying("subscriptionProperties",
 						properties -> assertThat(properties)
 								.asInstanceOf(InstanceOfAssertFactories.map(String.class, String.class))
 								.containsEntry("my-sub-prop", "my-sub-prop-value"))
-				.containsEntry("subscriptionMode", SubscriptionMode.NonDurable)
-				.containsEntry("subscriptionInitialPosition", SubscriptionInitialPosition.Earliest)
-				.containsEntry("regexSubscriptionMode", RegexSubscriptionMode.AllTopics)
 				.containsEntry("replicateSubscriptionState", true);
 	}
 

--- a/binders/pulsar-binder/spring-cloud-stream-binder-pulsar/src/test/java/org/springframework/cloud/stream/binder/pulsar/PulsarBinderIntegrationTests.java
+++ b/binders/pulsar-binder/spring-cloud-stream-binder-pulsar/src/test/java/org/springframework/cloud/stream/binder/pulsar/PulsarBinderIntegrationTests.java
@@ -88,7 +88,7 @@ class PulsarBinderIntegrationTests implements PulsarTestContainerSupport {
 				"--spring.pulsar.producer.name=textSupplierProducer-fromBase",
 				"--spring.cloud.stream.pulsar.binder.producer.name=textSupplierProducer-fromBinder",
 				"--spring.cloud.stream.pulsar.bindings.textSupplier-out-0.producer.name=textSupplierProducer-fromBinding",
-//				"--spring.cloud.stream.pulsar.binder.producer.max-pending-messages=1100",
+				"--spring.cloud.stream.pulsar.binder.producer.max-pending-messages=1100",
 				"--spring.cloud.stream.pulsar.binder.producer.block-if-queue-full=true",
 				"--spring.cloud.stream.pulsar.binder.consumer.subscription.name=textLoggerSub-fromBinder",
 				"--spring.cloud.stream.pulsar.binder.consumer.name=textLogger-fromBinder",
@@ -101,7 +101,7 @@ class PulsarBinderIntegrationTests implements PulsarTestContainerSupport {
 			TrackingProducerFactory producerFactory = context.getBean(TrackingProducerFactory.class);
 			assertThat(producerFactory.producersCreated).isNotEmpty().element(0)
 					.hasFieldOrPropertyWithValue("producerName", "textSupplierProducer-fromBinding")
-//					.hasFieldOrPropertyWithValue("conf.maxPendingMessages", 1100)
+					.hasFieldOrPropertyWithValue("conf.maxPendingMessages", 1100)
 					.hasFieldOrPropertyWithValue("conf.blockIfQueueFull", true);
 
 			TrackingConsumerFactory consumerFactory = context.getBean(TrackingConsumerFactory.class);


### PR DESCRIPTION
Running the Pulsar binder with Java 21 surfaced a bug where the layered binder/binding config props are not properly applied to the targeted consumer/producer builders.

The bug existed before Java 21 and is unrelated.

The binder/binding config props are converted to a Pulsar ProducerConfigurationData object via Jackson. This conversion process iterates over a map of config props. The iteration order of the map changed between Java 17 and 21. This results in object setters getting called in different orders which in turn causes cross field validation errors.

See #2915 for more details