### PR TITLE
#2919 Load eagerly the configuration, even the lazy-init enabled

### DIFF
--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
@@ -128,6 +128,7 @@ import org.springframework.util.StringUtils;
  * @author Chris Bono
  * @author Byungjun You
  * @author Ivan Shapoval
+ * @author Patrik Péter Süli
  * @since 2.1
  */
 @Lazy(false)

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
@@ -85,6 +85,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.env.ConfigurableEnvironment;
@@ -129,6 +130,7 @@ import org.springframework.util.StringUtils;
  * @author Ivan Shapoval
  * @since 2.1
  */
+@Lazy(false)
 @AutoConfiguration
 @EnableConfigurationProperties(StreamFunctionConfigurationProperties.class)
 @Import({ BinderFactoryAutoConfiguration.class })


### PR DESCRIPTION
Load eagerly the `FunctionConfiguration`, even with `spring.main.lazy-initialization` property enabled, because the listeners must initialize at startup, otherwise, they won't work.

fixes #2919 