### PR TITLE
Align sending kafka events from virtual threads

### DIFF
--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/StreamBridge.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/StreamBridge.java
@@ -84,6 +84,7 @@ import org.springframework.util.StringUtils;
  * @author Oleg Zhurakousky
  * @author Soby Chacko
  * @author Byungjun You
+ * @author Michał Rowicki
  * @since 3.0.3
  *
  */


### PR DESCRIPTION
Sending kafka events from virtual thread causes pinning:
```
Thread[#83,ForkJoinPool-1-worker-6,5,CarrierThreads]
    java.base/java.lang.VirtualThread$VThreadContinuation.onPinned(VirtualThread.java:183)
    java.base/jdk.internal.vm.Continuation.onPinned0(Continuation.java:393)
    java.base/java.lang.VirtualThread.parkNanos(VirtualThread.java:621)
    java.base/java.lang.System$2.parkVirtualThread(System.java:2652)
    java.base/jdk.internal.misc.VirtualThreads.park(VirtualThreads.java:67)
    java.base/java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:267)
    java.base/java.util.concurrent.CompletableFuture$Signaller.block(CompletableFuture.java:1866)
    java.base/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3780)
    java.base/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3725)
    java.base/java.util.concurrent.CompletableFuture.timedGet(CompletableFuture.java:1939)
    java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2095)
    org.apache.kafka.common.internals.KafkaFutureImpl.get(KafkaFutureImpl.java:180)
    org.springframework.cloud.stream.binder.kafka.provisioning.KafkaTopicProvisioner.createTopicAndPartitions(KafkaTopicProvisioner.java:413)
    org.springframework.cloud.stream.binder.kafka.provisioning.KafkaTopicProvisioner.createTopicIfNecessary(KafkaTopicProvisioner.java:387)
    org.springframework.cloud.stream.binder.kafka.provisioning.KafkaTopicProvisioner.createTopic(KafkaTopicProvisioner.java:364)
    org.springframework.cloud.stream.binder.kafka.provisioning.KafkaTopicProvisioner.provisionProducerDestination(KafkaTopicProvisioner.java:197)
    org.springframework.cloud.stream.binder.kafka.provisioning.KafkaTopicProvisioner.provisionProducerDestination(KafkaTopicProvisioner.java:96)
    org.springframework.cloud.stream.binder.AbstractMessageChannelBinder.doBindProducer(AbstractMessageChannelBinder.java:297)
    org.springframework.cloud.stream.binder.AbstractMessageChannelBinder.doBindProducer(AbstractMessageChannelBinder.java:102)
    org.springframework.cloud.stream.binder.AbstractBinder.bindProducer(AbstractBinder.java:153)
    org.springframework.cloud.stream.binding.BindingService.doBindProducer(BindingService.java:353)
    org.springframework.cloud.stream.binding.BindingService.bindProducer(BindingService.java:294)
    org.springframework.cloud.stream.function.StreamBridge.resolveDestination(StreamBridge.java:272) <== monitors:1
    org.springframework.cloud.stream.function.StreamBridge.send(StreamBridge.java:168)
    org.springframework.cloud.stream.function.StreamBridge.send(StreamBridge.java:147)
    org.springframework.cloud.stream.function.StreamBridge.send(StreamBridge.java:142)
```
I used ReentrantLock to avoid pinning in this situation.