### PR TITLE
GH-2921: Output-bindings and RabbitMQ r-k-e issues

### DIFF
--- a/core/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/function/StreamBridgeTests.java
+++ b/core/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/function/StreamBridgeTests.java
@@ -217,6 +217,21 @@ class StreamBridgeTests {
 		}
 	}
 
+	// See for more details: https://github.com/spring-cloud/spring-cloud-stream/issues/2921
+	@Test
+	void outputBindingsAndRabbitRoutingKeyExpressionComboDoesNotCauseIssues() {
+		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
+			TestChannelBinderConfiguration.getCompleteConfiguration(
+				EmptyConfiguration.class)).web(WebApplicationType.NONE).run(
+			"--spring.cloud.stream.output-bindings=the-exchange",
+			"--spring.cloud.stream.rabbit.bindings.the-exchange.producer.routing-key-expression=headers['key']")) {
+			// Ensure no exception is thrown from the above properties.
+			// See this issue for more details: https://github.com/spring-cloud/spring-cloud-stream/issues/2921
+			// Without the corresponding chages added in this PR, this config would throw an exception.
+
+		}
+	}
+
 	// Fore more context on this test: https://github.com/spring-cloud/spring-cloud-stream/issues/2848
 	@Test
 	void ensurePartitioningWorksWhenNativeEncodingEnabledAndOutputBindingsExist() {


### PR DESCRIPTION
* When output-bindings config is explicitly used for StreamBridge and the RabbitMQ routing-key-expression is provided, Spring Cloud Stream is throwing an exception due to a proper function is not found in the catalog. Bypassing this step and let the bootstrapping continues if output-bindings and RabbitMQ routing-key-expression combo is used.
* Adding tests to verify

Resolves https://github.com/spring-cloud/spring-cloud-stream/issues/2921