### PR TITLE
GH-2951: Batch consumer and DLQ issues

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 the original author or authors.
+ * Copyright 2014-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1077,6 +1077,11 @@ public class KafkaMessageChannelBinder extends
 		return new RawRecordHeaderErrorMessageStrategy();
 	}
 
+	private Boolean isBatchAndListenerContainerWithDlqAndRetryCustomizer(ExtendedConsumerProperties<KafkaConsumerProperties> properties) {
+		ListenerContainerCustomizer<?> customizer = getContainerCustomizer();
+		return properties.isBatchMode() && customizer instanceof ListenerContainerWithDlqAndRetryCustomizer;
+	}
+
 	@SuppressWarnings("unchecked")
 	@Override
 	protected MessageHandler getErrorMessageHandler(final ConsumerDestination destination,
@@ -1084,7 +1089,7 @@ public class KafkaMessageChannelBinder extends
 			final ExtendedConsumerProperties<KafkaConsumerProperties> properties) {
 
 		KafkaConsumerProperties kafkaConsumerProperties = properties.getExtension();
-		if (kafkaConsumerProperties.isEnableDlq()) {
+		if (kafkaConsumerProperties.isEnableDlq() && !isBatchAndListenerContainerWithDlqAndRetryCustomizer(properties)) {
 			KafkaProducerProperties dlqProducerProperties = kafkaConsumerProperties
 					.getDlqProducerProperties();
 			KafkaAwareTransactionManager<byte[], byte[]> transMan = transactionManager(

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/BatchWithDlqCustomizerDisablesBinderDlqTests.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/BatchWithDlqCustomizerDisablesBinderDlqTests.java
@@ -33,6 +33,7 @@ import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
+import org.springframework.test.annotation.DirtiesContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -44,6 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 	"spring.cloud.stream.bindings.consumer-in-0.group=batchWithDlqCustomizerDisablesBinderDlq",
 	"spring.cloud.stream.kafka.bindings.consumer1-in-0.consumer.enable-dlq=true"})
 @EmbeddedKafka
+@DirtiesContext
 public class BatchWithDlqCustomizerDisablesBinderDlqTests {
 
 	@Autowired


### PR DESCRIPTION
Batch consumer with `ListenerContainerWithDlqAndRetryCustomizer` should disable binder-based DLQ.

Resolves https://github.com/spring-cloud/spring-cloud-stream/issues/2951