### PR TITLE
Simplify outputBindings assignment logic in FunctionConfiguration

### DIFF
--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
@@ -904,9 +904,8 @@ public class FunctionConfiguration {
 			String[] inputBindings = StringUtils.hasText(bindingProperties.getInputBindings())
 					? bindingProperties.getInputBindings().split(";") : new String[0];
 
-			String[] outputBindings = StringUtils.hasText(bindingProperties.getOutputBindings()) ? bindingProperties.getOutputBindings().split(";") : (
-					StringUtils.hasText(bindingProperties.getOutputBindings()) ? bindingProperties.getOutputBindings().split(";") : new String[0]
-					);
+			String[] outputBindings = StringUtils.hasText(bindingProperties.getOutputBindings())
+					? bindingProperties.getOutputBindings().split(";") : new String[0];
 
 			for (String inputBindingName : inputBindings) {
 				FunctionInvocationWrapper sourceFunc = functionCatalog.lookup(inputBindingName);


### PR DESCRIPTION
This PR simplifies the logic for assigning outputBindings in the FunctionConfiguration file by eliminating redundant checks and method calls. The original implementation checked bindingProperties.getOutputBindings() twice, which was unnecessary and could lead to confusion. The updated version performs the check once, reducing the code complexity and improving readability.