### PR TITLE
Ensuring Thread-Safety for BindingServiceProperties.bindings

### DIFF
--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceProperties.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/BindingServiceProperties.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -53,6 +53,7 @@ import org.springframework.util.StringUtils;
  * @author Ilayaperumal Gopinathan
  * @author Oleg Zhurakousky
  * @author Michael Michailidis
+ * @author Kurt Hong
  */
 @ConfigurationProperties("spring.cloud.stream")
 @JsonInclude(Include.NON_DEFAULT)
@@ -115,7 +116,7 @@ public class BindingServiceProperties
 	 * For example; This sets the content-type for the 'input' binding of a Sink
 	 * application: 'spring.cloud.stream.bindings.input.contentType=text/plain'
 	 */
-	private Map<String, BindingProperties> bindings = new TreeMap<>(
+	private Map<String, BindingProperties> bindings = new ConcurrentSkipListMap(
 		String.CASE_INSENSITIVE_ORDER);
 
 	/**


### PR DESCRIPTION
First, thank you for the excellent StreamBridge feature! I’ve found it very useful.
However, I rarely encounter the following exception during race conditions:
```
java.lang.NullPointerException: null
    at java.base/java.util.TreeMap.rotateRight(TreeMap.java:2240)
    at java.base/java.util.TreeMap.fixAfterInsertion(TreeMap.java:2272)
    at java.base/java.util.TreeMap.put(TreeMap.java:580)
    at org.springframework.cloud.stream.config.BindingServiceProperties.bindToDefault(BindingServiceProperties.java:397)
    at org.springframework.cloud.stream.config.BindingServiceProperties.bindIfNecessary(BindingServiceProperties.java:381)
    at org.springframework.cloud.stream.config.BindingServiceProperties.getBindingProperties(BindingServiceProperties.java:301)
    at org.springframework.cloud.stream.function.StreamBridge.send(StreamBridge.java:149)
```
It seems the BindingServiceProperties.bindings property should be thread-safe when utilizing StreamBridge on the producer side to avoid such issues in concurrent scenarios.