### PR TITLE
Change "synchronized" to reentrant lock for virtual-threads

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderMetrics.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/KafkaStreamsBinderMetrics.java
@@ -86,7 +86,7 @@ public class KafkaStreamsBinderMetrics {
 
 	private volatile Set<MetricName> currentMeters = new HashSet<>();
 
-	private static final ReentrantLock lock = new ReentrantLock();
+	private static final ReentrantLock metricsLock = new ReentrantLock();
 
 	public KafkaStreamsBinderMetrics(MeterRegistry meterRegistry) {
 		this.meterRegistry = meterRegistry;
@@ -113,11 +113,11 @@ public class KafkaStreamsBinderMetrics {
 
 	public void addMetrics(Set<StreamsBuilderFactoryBean> streamsBuilderFactoryBeans) {
 		try {
-			lock.lock();
+			metricsLock.lock();
 			this.bindTo(streamsBuilderFactoryBeans);
 		}
 		finally {
-			lock.unlock();
+			metricsLock.unlock();
 		}
 	}
 

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderMetrics.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderMetrics.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.ToDoubleFunction;
 
 import io.micrometer.core.instrument.Gauge;
@@ -68,6 +69,7 @@ import org.springframework.util.ObjectUtils;
  * @author Tomek Szmytka
  * @author Nico Heller
  * @author Kurt Hong
+ * @author Omer Celik
  */
 public class KafkaBinderMetrics
 		implements MeterBinder, ApplicationListener<BindingCreatedEvent>, AutoCloseable {
@@ -96,6 +98,8 @@ public class KafkaBinderMetrics
 	private final Map<String, Long> lastUnconsumedMessagesValues = new ConcurrentHashMap<>();
 
 	ScheduledExecutorService scheduler;
+
+	private final ReentrantLock lock = new ReentrantLock();
 
 	public KafkaBinderMetrics(KafkaMessageChannelBinder binder,
 							KafkaBinderConfigurationProperties binderConfigurationProperties,
@@ -231,27 +235,33 @@ public class KafkaBinderMetrics
 		return lag;
 	}
 
-	private synchronized ConsumerFactory<?, ?> createConsumerFactory() {
-		if (this.defaultConsumerFactory == null) {
-			Map<String, Object> props = new HashMap<>();
-			props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+	private ConsumerFactory<?, ?> createConsumerFactory() {
+		try {
+			lock.lock();
+			if (this.defaultConsumerFactory == null) {
+				Map<String, Object> props = new HashMap<>();
+				props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
 					ByteArrayDeserializer.class);
-			props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+				props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
 					ByteArrayDeserializer.class);
-			Map<String, Object> mergedConfig = this.binderConfigurationProperties
+				Map<String, Object> mergedConfig = this.binderConfigurationProperties
 					.mergedConsumerConfiguration();
-			if (!ObjectUtils.isEmpty(mergedConfig)) {
-				props.putAll(mergedConfig);
-			}
-			if (!props.containsKey(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG)) {
-				props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+				if (!ObjectUtils.isEmpty(mergedConfig)) {
+					props.putAll(mergedConfig);
+				}
+				if (!props.containsKey(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG)) {
+					props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
 						this.binderConfigurationProperties
-								.getKafkaConnectionString());
-			}
-			this.defaultConsumerFactory = new DefaultKafkaConsumerFactory<>(
+							.getKafkaConnectionString());
+				}
+				this.defaultConsumerFactory = new DefaultKafkaConsumerFactory<>(
 					props);
+			}
+			return this.defaultConsumerFactory;
 		}
-		return this.defaultConsumerFactory;
+		finally {
+			lock.unlock();
+		}
 	}
 
 	@Override

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderMetrics.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderMetrics.java
@@ -99,7 +99,7 @@ public class KafkaBinderMetrics
 
 	ScheduledExecutorService scheduler;
 
-	private final ReentrantLock lock = new ReentrantLock();
+	private final ReentrantLock consumerFactoryLock = new ReentrantLock();
 
 	public KafkaBinderMetrics(KafkaMessageChannelBinder binder,
 							KafkaBinderConfigurationProperties binderConfigurationProperties,
@@ -237,7 +237,7 @@ public class KafkaBinderMetrics
 
 	private ConsumerFactory<?, ?> createConsumerFactory() {
 		try {
-			lock.lock();
+			this.consumerFactoryLock.lock();
 			if (this.defaultConsumerFactory == null) {
 				Map<String, Object> props = new HashMap<>();
 				props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
@@ -260,7 +260,7 @@ public class KafkaBinderMetrics
 			return this.defaultConsumerFactory;
 		}
 		finally {
-			lock.unlock();
+			this.consumerFactoryLock.unlock();
 		}
 	}
 

--- a/binders/rabbit-binder/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/provisioning/RabbitExchangeQueueProvisioner.java
+++ b/binders/rabbit-binder/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/provisioning/RabbitExchangeQueueProvisioner.java
@@ -107,7 +107,7 @@ public class RabbitExchangeQueueProvisioner
 
 	private final AtomicInteger producerExchangeBeanNameQualifier = new AtomicInteger();
 
-	private final ReentrantLock lock = new ReentrantLock();
+	private final ReentrantLock autoDeclareContextLock = new ReentrantLock();
 
 	public RabbitExchangeQueueProvisioner(ConnectionFactory connectionFactory) {
 		this(connectionFactory, Collections.emptyList());
@@ -325,13 +325,13 @@ public class RabbitExchangeQueueProvisioner
 						.mapToObj(j -> rk + "-" + j)
 						.collect(Collectors.toList()));
 		try {
-			lock.lock();
+			this.autoDeclareContextLock.lock();
 			if (!this.autoDeclareContext.containsBean(name + ".superStream")) {
 				this.autoDeclareContext.getBeanFactory().registerSingleton(name + ".superStream", ss);
 			}
 		}
 		finally {
-			lock.unlock();
+			this.autoDeclareContextLock.unlock();
 		}
 		try {
 			ss.getDeclarables().forEach(dec -> {
@@ -725,7 +725,7 @@ public class RabbitExchangeQueueProvisioner
 
 	private void addToAutoDeclareContext(String name, Declarable bean) {
 		try {
-			lock.lock();
+			this.autoDeclareContextLock.lock();
 			if (!this.autoDeclareContext.containsBean(name)) {
 				this.autoDeclareContext.getBeanFactory().registerSingleton(name, new Declarables(bean));
 			}
@@ -734,7 +734,7 @@ public class RabbitExchangeQueueProvisioner
 			}
 		}
 		finally {
-			lock.unlock();
+			this.autoDeclareContextLock.unlock();
 		}
 	}
 
@@ -769,7 +769,7 @@ public class RabbitExchangeQueueProvisioner
 			ExtendedConsumerProperties<RabbitConsumerProperties> consumerProperties) {
 
 		try {
-			lock.lock();
+			this.autoDeclareContextLock.lock();
 			Stream.of(StringUtils.tokenizeToStringArray(destination.getName(), ",", true,
 				true)).forEach(name -> {
 				String group = null;
@@ -789,7 +789,7 @@ public class RabbitExchangeQueueProvisioner
 			});
 		}
 		finally {
-			lock.unlock();
+			this.autoDeclareContextLock.unlock();
 		}
 	}
 
@@ -797,7 +797,7 @@ public class RabbitExchangeQueueProvisioner
 			ExtendedProducerProperties<RabbitProducerProperties> properties) {
 
 		try {
-			lock.lock();
+			this.autoDeclareContextLock.lock();
 			if (dest instanceof RabbitProducerDestination rabbitProducerDestination) {
 				String qual = rabbitProducerDestination.getBeanNameQualifier();
 				removeSingleton(dest.getName() + "." + qual + ".exchange");
@@ -829,7 +829,7 @@ public class RabbitExchangeQueueProvisioner
 			}
 		}
 		finally {
-			lock.unlock();
+			this.autoDeclareContextLock.unlock();
 		}
 	}
 

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindableProxyFactory.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindableProxyFactory.java
@@ -103,19 +103,24 @@ public class BindableProxyFactory extends AbstractBindableProxyFactory
 				"'bindingTargetFactories' cannot be empty");
 	}
 
+	/**
+	 * Double-Checked Locking Optimization was used to avoid unnecessary locking overhead.
+	 */
 	@Override
 	public Object getObject() {
-		try {
-			this.lock.lock();
-			if (this.proxy == null && this.type != null) {
-				ProxyFactory factory = new ProxyFactory(this.type, this);
-				this.proxy = factory.getProxy();
+		if (this.proxy == null && this.type != null) {
+			try {
+				this.lock.lock();
+				if (this.proxy == null && this.type != null) {
+					ProxyFactory factory = new ProxyFactory(this.type, this);
+					this.proxy = factory.getProxy();
+				}
 			}
-			return this.proxy;
+			finally {
+				this.lock.unlock();
+			}
 		}
-		finally {
-			this.lock.unlock();
-		}
+		return this.proxy;
 	}
 
 	@Override

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindableProxyFactory.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindableProxyFactory.java
@@ -71,8 +71,8 @@ public class BindableProxyFactory extends AbstractBindableProxyFactory
 			Method method = invocation.getMethod();
 
 			// try to use cached target
-            return this.targetCache.get(method);
-        }
+			return this.targetCache.get(method);
+		}
 		finally {
 			lock.unlock();
 		}

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindableProxyFactory.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindableProxyFactory.java
@@ -67,14 +67,14 @@ public class BindableProxyFactory extends AbstractBindableProxyFactory
 	@Override
 	public Object invoke(MethodInvocation invocation) {
 		try {
-			lock.lock();
+			this.lock.lock();
 			Method method = invocation.getMethod();
 
 			// try to use cached target
 			return this.targetCache.get(method);
 		}
 		finally {
-			lock.unlock();
+			this.lock.unlock();
 		}
 	}
 
@@ -106,7 +106,7 @@ public class BindableProxyFactory extends AbstractBindableProxyFactory
 	@Override
 	public Object getObject() {
 		try {
-			lock.lock();
+			this.lock.lock();
 			if (this.proxy == null && this.type != null) {
 				ProxyFactory factory = new ProxyFactory(this.type, this);
 				this.proxy = factory.getProxy();
@@ -114,7 +114,7 @@ public class BindableProxyFactory extends AbstractBindableProxyFactory
 			return this.proxy;
 		}
 		finally {
-			lock.unlock();
+			this.lock.unlock();
 		}
 	}
 

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindingService.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindingService.java
@@ -472,7 +472,7 @@ public class BindingService {
 
 		public void setDelegate(Binding<T> delegate) {
 			try {
-				lock.lock();
+				this.lock.lock();
 				if (this.unbound) {
 					delegate.unbind();
 				}
@@ -481,21 +481,21 @@ public class BindingService {
 				}
 			}
 			finally {
-				lock.unlock();
+				this.lock.unlock();
 			}
 		}
 
 		@Override
 		public void unbind() {
 			try {
-				lock.lock();
+				this.lock.lock();
 				this.unbound = true;
 				if (this.delegate != null) {
 					this.delegate.unbind();
 				}
 			}
 			finally {
-				lock.unlock();
+				this.lock.unlock();
 			}
 		}
 

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindingService.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindingService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 the original author or authors.
+ * Copyright 2015-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -63,6 +64,7 @@ import org.springframework.validation.DataBinder;
  * @author Chris Bono
  * @author Artem Bilan
  * @author Byungjun You
+ * @author Omer Celik
  */
 public class BindingService {
 
@@ -451,35 +453,49 @@ public class BindingService {
 
 		private final String bindingName;
 
-		private final Object consumerOrProducerproperties;
+		private final Object consumerOrProducerProperties;
 
 		private final boolean isInput;
 
 		final ObjectMapper objectMapper;
 
-		LateBinding(String bindingName, String error, Object consumerOrProducerproperties, boolean isInput, ObjectMapper objectMapper) {
+		private final ReentrantLock lock = new ReentrantLock();
+
+		LateBinding(String bindingName, String error, Object consumerOrProducerProperties, boolean isInput, ObjectMapper objectMapper) {
 			super();
 			this.error = error;
 			this.bindingName = bindingName;
-			this.consumerOrProducerproperties = consumerOrProducerproperties;
+			this.consumerOrProducerProperties = consumerOrProducerProperties;
 			this.isInput = isInput;
 			this.objectMapper = objectMapper;
 		}
 
-		public synchronized void setDelegate(Binding<T> delegate) {
-			if (this.unbound) {
-				delegate.unbind();
+		public void setDelegate(Binding<T> delegate) {
+			try {
+				lock.lock();
+				if (this.unbound) {
+					delegate.unbind();
+				}
+				else {
+					this.delegate = delegate;
+				}
 			}
-			else {
-				this.delegate = delegate;
+			finally {
+				lock.unlock();
 			}
 		}
 
 		@Override
-		public synchronized void unbind() {
-			this.unbound = true;
-			if (this.delegate != null) {
-				this.delegate.unbind();
+		public void unbind() {
+			try {
+				lock.lock();
+				this.unbound = true;
+				if (this.delegate != null) {
+					this.delegate.unbind();
+				}
+			}
+			finally {
+				lock.unlock();
 			}
 		}
 
@@ -507,8 +523,8 @@ public class BindingService {
 		public Map<String, Object> getExtendedInfo() {
 			Map<String, Object> extendedInfo = new LinkedHashMap<>();
 			extendedInfo.put("bindingDestination", this.getBindingName());
-			extendedInfo.put(consumerOrProducerproperties.getClass().getSimpleName(),
-					this.objectMapper.convertValue(consumerOrProducerproperties, Map.class));
+			extendedInfo.put(consumerOrProducerProperties.getClass().getSimpleName(),
+					this.objectMapper.convertValue(consumerOrProducerProperties, Map.class));
 			return extendedInfo;
 		}
 

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/DynamicDestinationsBindable.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/DynamicDestinationsBindable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.springframework.cloud.stream.binder.Binding;
 
@@ -29,6 +30,7 @@ import org.springframework.cloud.stream.binder.Binding;
  *
  * @author Ilayaperumal Gopinathan
  * @author Oleg Zhurakousky
+ * @author Omer Celik
  */
 public final class DynamicDestinationsBindable implements Bindable {
 
@@ -37,21 +39,41 @@ public final class DynamicDestinationsBindable implements Bindable {
 	 */
 	private final Map<String, Binding<?>> outputBindings = new HashMap<>();
 
-	public synchronized void addOutputBinding(String name, Binding<?> binding) {
-		this.outputBindings.put(name, binding);
-	}
+	private static final ReentrantLock lock = new ReentrantLock();
 
-	@Override
-	public synchronized Set<String> getOutputs() {
-		return Collections.unmodifiableSet(this.outputBindings.keySet());
-	}
-
-	@Override
-	public synchronized void unbindOutputs(BindingService adapter) {
-		for (Map.Entry<String, Binding<?>> entry : this.outputBindings.entrySet()) {
-			entry.getValue().unbind();
+	public void addOutputBinding(String name, Binding<?> binding) {
+		try {
+			lock.lock();
+			this.outputBindings.put(name, binding);
 		}
-		this.outputBindings.clear();
+		finally {
+			lock.unlock();
+		}
+	}
+
+	@Override
+	public Set<String> getOutputs() {
+		try {
+			lock.lock();
+			return Collections.unmodifiableSet(this.outputBindings.keySet());
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	@Override
+	public void unbindOutputs(BindingService adapter) {
+		try {
+			lock.lock();
+			for (Map.Entry<String, Binding<?>> entry : this.outputBindings.entrySet()) {
+				entry.getValue().unbind();
+			}
+			this.outputBindings.clear();
+		}
+		finally {
+			lock.unlock();
+		}
 	}
 
 }

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/DynamicDestinationsBindable.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/DynamicDestinationsBindable.java
@@ -39,40 +39,40 @@ public final class DynamicDestinationsBindable implements Bindable {
 	 */
 	private final Map<String, Binding<?>> outputBindings = new HashMap<>();
 
-	private static final ReentrantLock lock = new ReentrantLock();
+	private static final ReentrantLock outputBindingsLock = new ReentrantLock();
 
 	public void addOutputBinding(String name, Binding<?> binding) {
 		try {
-			lock.lock();
+			outputBindingsLock.lock();
 			this.outputBindings.put(name, binding);
 		}
 		finally {
-			lock.unlock();
+			outputBindingsLock.unlock();
 		}
 	}
 
 	@Override
 	public Set<String> getOutputs() {
 		try {
-			lock.lock();
+			outputBindingsLock.lock();
 			return Collections.unmodifiableSet(this.outputBindings.keySet());
 		}
 		finally {
-			lock.unlock();
+			outputBindingsLock.unlock();
 		}
 	}
 
 	@Override
 	public void unbindOutputs(BindingService adapter) {
 		try {
-			lock.lock();
+			outputBindingsLock.lock();
 			for (Map.Entry<String, Binding<?>> entry : this.outputBindings.entrySet()) {
 				entry.getValue().unbind();
 			}
 			this.outputBindings.clear();
 		}
 		finally {
-			lock.unlock();
+			outputBindingsLock.unlock();
 		}
 	}
 


### PR DESCRIPTION
**invoke** and **getObject** method in **BindableProxyFactory** class
**setDelegate** and **unbind** method in **LateBinding(in BindingService)** class
**addOutputBinding**, **getOutputs** and **unbindOutputs** method in **DynamicDestinationsBindable** class
**createConsumerFactory** method in **KafkaBinderMetrics** class
**addMetrics** method in **KafkaStreamsBinderMetrics** class
**provisionSuperStream**, **addToAutoDeclareContext** and **cleanAutoDeclareContext** method in **RabbitExchangeQueueProvisioner** class
**register** method in **ServerController** class

were made thread-safe using ReentrantLock. This commit ensures that the method is friendly for virtual threads to avoid blocking and pinning. The lock is acquired at the beginning of the method and released in a finally block to ensure it is always released, even if an exception occurs.