### PR TITLE
Update docs to show correct prefix for connection-name-prefix

### DIFF
--- a/docs/modules/ROOT/pages/rabbit/rabbit_overview/binder-properties.adoc
+++ b/docs/modules/ROOT/pages/rabbit/rabbit_overview/binder-properties.adoc
@@ -29,7 +29,7 @@ The compression level for compressed bindings.
 See `java.util.zip.Deflater`.
 +
 Default: `1` (BEST_LEVEL).
-spring.cloud.stream.binder.connection-name-prefix::
+spring.cloud.stream.rabbit.binder.connection-name-prefix::
 A connection name prefix used to name the connection(s) created by this binder.
 The name is this prefix followed by `#n`, where `n` increments each time a new connection is opened.
 +


### PR DESCRIPTION
Currently docs display the correct prefix as spring.cloud.stream.binder where it should be spring.cloud.stream.rabbit.binder