### PR TITLE
Docs: Update timeout default

### DIFF
--- a/docs/modules/ROOT/pages/kafka/kafka-binder/config-options.adoc
+++ b/docs/modules/ROOT/pages/kafka/kafka-binder/config-options.adoc
@@ -38,7 +38,7 @@ spring.cloud.stream.kafka.binder.healthTimeout::
 The time to wait to get partition information, in seconds.
 Health reports as down if this timer expires.
 +
-Default: 10.
+Default: 60.
 spring.cloud.stream.kafka.binder.requiredAcks::
 The number of required acks on the broker.
 See the Kafka documentation for the producer `acks` property.


### PR DESCRIPTION
I'm pretty sure it's 60:
https://github.com/spring-cloud/spring-cloud-stream/blob/main/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java#L122 (and in my tests too).