### PR TITLE
Fix typo in overview-error-handling.adoc

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-stream/overview-error-handling.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-stream/overview-error-handling.adoc
@@ -47,7 +47,7 @@ While acceptable in some cases, for most cases, it is not, and we need some reco
 == Handle Error Messages
 
 In the previous section we mentioned that by default messages that resulted in error are effectively logged and dropped. The framework also exposes mechanism for you
-to provide custom error handler (i.e., to send notification or write to database, etc). You can do so by adding `Consumer` that is specifically designed to accept `ErrorMessage` which aside form all the information about the error (e.g., stack trace etc) contains the original message (the one that triggered the error).
+to provide custom error handler (i.e., to send notification or write to database, etc). You can do so by adding `Consumer` that is specifically designed to accept `ErrorMessage` which aside from all the information about the error (e.g., stack trace etc) contains the original message (the one that triggered the error).
 NOTE: Custom error handler is mutually exclusive with framework provided error handlers (i.e., logging and binder error handler - see previous section) to ensure that they do not interfere. 
 
 [source,java]


### PR DESCRIPTION
Fixes a typo in the Spring Cloud Stream documentation.