### PR TITLE
Fix problem configuring conditional sources for binder context with the DefaultCustomBinderFactory

### DIFF
--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/DefaultBinderFactory.java
@@ -446,23 +446,6 @@ public class DefaultBinderFactory implements BinderFactory, DisposableBean, Appl
 			binderProducingContext.getBeanFactory().setConversionService(this.context.getBeanFactory().getConversionService());
 		}
 
-		List<Class> sourceClasses = new ArrayList<>();
-		sourceClasses.addAll(Arrays.asList(binderType.getConfigurationClasses()));
-		if (binderProperties.containsKey("spring.main.sources")) {
-			String sources = (String) binderProperties.get("spring.main.sources");
-			if (StringUtils.hasText(sources)) {
-				Stream.of(sources.split(",")).forEach(source -> {
-					try {
-						sourceClasses.add(Thread.currentThread().getContextClassLoader().loadClass(source.trim()));
-					}
-					catch (Exception e) {
-						throw new IllegalStateException("Failed to load class " + source, e);
-					}
-				});
-			}
-		}
-
-		binderProducingContext.register(sourceClasses.toArray(new Class[] {}));
 		MapPropertySource binderPropertySource = new MapPropertySource(configurationName, binderProperties);
 		binderProducingContext.getEnvironment().getPropertySources().addFirst(binderPropertySource);
 		binderProducingContext.setDisplayName(configurationName + "_context");
@@ -501,6 +484,23 @@ public class DefaultBinderFactory implements BinderFactory, DisposableBean, Appl
 					Collections.singletonMap("spring.main.web-application-type", "NONE")));
 			}
 		}
+
+		// Register the sources classes to the specific binder context after configuring the environment property sources
+		List<Class> sourceClasses = new ArrayList<>(Arrays.asList(binderType.getConfigurationClasses()));
+		if (binderProperties.containsKey("spring.main.sources")) {
+			String sources = (String) binderProperties.get("spring.main.sources");
+			if (StringUtils.hasText(sources)) {
+				Stream.of(sources.split(",")).forEach(source -> {
+					try {
+						sourceClasses.add(Thread.currentThread().getContextClassLoader().loadClass(source.trim()));
+					}
+					catch (Exception e) {
+						throw new IllegalStateException("Failed to load class " + source, e);
+					}
+				});
+			}
+		}
+		binderProducingContext.register(sourceClasses.toArray(new Class[] {}));
 
 		if (refresh) {
 			if (!useApplicationContextAsParent || "integration".equals(binderType.getDefaultName())) {


### PR DESCRIPTION
Fixes #3031.

Change order of the registry of sources classes after configuring Environment with all property sources, so that sources classes can resolve conditions configurations correctly.