### PR TITLE
fix(observability): register ObservationRegistry for dynamic MessageChannels in StreamBridge (#3033)

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-reactive/src/test/java/org/springframework/cloud/stream/binder/reactorkafka/ReactorKafkaBinderObservationTests.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-reactive/src/test/java/org/springframework/cloud/stream/binder/reactorkafka/ReactorKafkaBinderObservationTests.java
@@ -100,7 +100,7 @@ public class ReactorKafkaBinderObservationTests {
 		streamBridge.send("rkbot-in-topic", MessageBuilder.withPayload("data")
 			.build());
 
-		await().timeout(Duration.ofSeconds(10)).untilAsserted(() -> assertThat(SPANS.spans()).hasSize(3));
+		await().timeout(Duration.ofSeconds(10)).untilAsserted(() -> assertThat(SPANS.spans()).hasSize(4));
 		SpansAssert.assertThat(SPANS.spans().stream().map(BraveFinishedSpan::fromBrave).collect(Collectors.toList()))
 			.haveSameTraceId();
 	}

--- a/binders/rabbit-binder/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/integration/RabbitMultiBinderObservationTests.java
+++ b/binders/rabbit-binder/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/integration/RabbitMultiBinderObservationTests.java
@@ -84,7 +84,7 @@ public class RabbitMultiBinderObservationTests {
 		// There is a race condition when we already have a reply, but the span in the
 		// Rabbit listener is not closed yet.
 		// parent -> StreamBridge -> RabbitTemplate -> Rabbit Listener -> Consumer
-		await().untilAsserted(() -> assertThat(SPANS.spans()).hasSize(5));
+		await().untilAsserted(() -> assertThat(SPANS.spans()).hasSize(6));
 		SpansAssert.assertThat(SPANS.spans().stream().map(BraveFinishedSpan::fromBrave).collect(Collectors.toList()))
 			.haveSameTraceId();
 	}

--- a/core/spring-cloud-stream-test-binder/pom.xml
+++ b/core/spring-cloud-stream-test-binder/pom.xml
@@ -24,6 +24,14 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-tracing-bridge-brave</artifactId>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/core/spring-cloud-stream-test-binder/src/main/java/org/springframework/cloud/stream/binder/test/TestChannelBinderConfiguration.java
+++ b/core/spring-cloud-stream-test-binder/src/main/java/org/springframework/cloud/stream/binder/test/TestChannelBinderConfiguration.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import io.micrometer.observation.ObservationRegistry;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cloud.stream.binder.Binder;
@@ -107,4 +109,8 @@ public class TestChannelBinderConfiguration<T> {
 		return new TestChannelBinderProvisioner();
 	}
 
+	@Bean
+	public ObservationRegistry observationRegistry() {
+		return ObservationRegistry.create();
+	}
 }

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
@@ -36,6 +36,7 @@ import java.util.function.Supplier;
 import java.util.stream.StreamSupport;
 
 import io.micrometer.context.ContextSnapshotFactory;
+import io.micrometer.observation.ObservationRegistry;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.reactivestreams.Publisher;
@@ -46,6 +47,7 @@ import reactor.util.function.Tuples;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -132,6 +134,7 @@ import org.springframework.util.StringUtils;
  * @author Ivan Shapoval
  * @author Patrik Péter Süli
  * @author Artem Bilan
+ * @author Agustino Lim
  * @since 2.1
  */
 @Lazy(false)
@@ -151,8 +154,10 @@ public class FunctionConfiguration {
 	@Bean
 	public StreamBridge streamBridgeUtils(FunctionCatalog functionCatalog,
 			BindingServiceProperties bindingServiceProperties, ConfigurableApplicationContext applicationContext,
-			@Nullable NewDestinationBindingCallback callback) {
-		return new StreamBridge(functionCatalog, bindingServiceProperties, applicationContext, callback);
+			@Nullable NewDestinationBindingCallback callback,
+			ObjectProvider<ObservationRegistry> observationRegistries) {
+		return new StreamBridge(functionCatalog, bindingServiceProperties, applicationContext, callback,
+				observationRegistries);
 	}
 
 	@Bean

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/StreamBridge.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/StreamBridge.java
@@ -29,10 +29,12 @@ import java.util.function.Function;
 
 import io.micrometer.context.ContextExecutorService;
 import io.micrometer.context.ContextSnapshotFactory;
+import io.micrometer.observation.ObservationRegistry;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.cloud.function.context.FunctionCatalog;
 import org.springframework.cloud.function.context.FunctionRegistration;
@@ -89,6 +91,7 @@ import static org.springframework.cloud.stream.utils.CacheKeyCreatorUtils.create
  * @author Byungjun You
  * @author Michał Rowicki
  * @author Omer Celik
+ * @author Agustino Lim
  * @since 3.0.3
  *
  */
@@ -126,6 +129,7 @@ public final class StreamBridge implements StreamOperations, SmartInitializingSi
 
 	private static final ReentrantLock lock = new ReentrantLock();
 
+	private ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
 	/**
 	 *
 	 * @param functionCatalog instance of {@link FunctionCatalog}
@@ -133,7 +137,7 @@ public final class StreamBridge implements StreamOperations, SmartInitializingSi
 	 * @param applicationContext instance of {@link ConfigurableApplicationContext}
 	 */
 	StreamBridge(FunctionCatalog functionCatalog, BindingServiceProperties bindingServiceProperties,
-		ConfigurableApplicationContext applicationContext, @Nullable NewDestinationBindingCallback destinationBindingCallback) {
+		ConfigurableApplicationContext applicationContext, @Nullable NewDestinationBindingCallback destinationBindingCallback, ObjectProvider<ObservationRegistry> observationRegistries) {
 		this.executorService = Executors.newCachedThreadPool();
 		Assert.notNull(functionCatalog, "'functionCatalog' must not be null");
 		Assert.notNull(applicationContext, "'applicationContext' must not be null");
@@ -158,6 +162,7 @@ public final class StreamBridge implements StreamOperations, SmartInitializingSi
 		};
 		this.functionInvocationHelper = applicationContext.getBean(FunctionInvocationHelper.class);
 		this.streamBridgeFunctionCache = new HashMap<>();
+		observationRegistries.ifAvailable(registry -> this.observationRegistry = registry);
 	}
 
 	@Override
@@ -288,6 +293,7 @@ public final class StreamBridge implements StreamOperations, SmartInitializingSi
 					messageChannel = this.isAsync() ? new ExecutorChannel(this.executorService) : new DirectWithAttributesChannel();
 					((AbstractSubscribableChannel) messageChannel).setApplicationContext(applicationContext);
 					((AbstractSubscribableChannel) messageChannel).setComponentName(destinationName);
+					((AbstractSubscribableChannel) messageChannel).registerObservationRegistry(observationRegistry);
 
 					BinderWrapper binderWrapper = bindingService.createBinderWrapper(binderName, destinationName, messageChannel.getClass());
 					if (this.destinationBindingCallback != null) {


### PR DESCRIPTION
This PR addresses issue #3033 by ensuring ObservationRegistry is registered for dynamically created MessageChannel in StreamBridge