### PR TITLE
GH-3062: Fix `KafkaBinderMetrics` for resource leaks

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderMetricsTest.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 the original author or authors.
+ * Copyright 2016-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,7 @@ import static org.mockito.Mockito.mock;
  * @author Tomek Szmytka
  * @author Nico Heller
  * @author Kurt Hong
+ * @author Artem Bilan
  */
 class KafkaBinderMetricsTest {
 
@@ -346,10 +347,11 @@ class KafkaBinderMetricsTest {
 	}
 
 	@Test
-	public void shouldShutdownSchedulerOnClose() throws Exception {
+	public void shouldShutdownSchedulerOnClose() {
 		metrics.bindTo(meterRegistry);
+		assertThat(metrics.scheduler).isNotNull();
 		metrics.close();
-		assertThat(metrics.scheduler.isShutdown()).isTrue();
+		assertThat(metrics.scheduler).isNull();
 	}
 
 	@Test


### PR DESCRIPTION
Fixes: https://github.com/spring-cloud/spring-cloud-stream/issues/3062

The `KafkaBinderMetrics` creates `KafkaConsumer` instances and schedule the fix rate task for them, but never closes them even when the `scheduler` is shut downed

* Implement a `Lifecycle` contract in the `KafkaBinderMetrics` and call `close()` from the `stop()` to satisfy CRaC resource management expectations.
* Also close all the `KafkaConsumer` instances from the `metadataConsumers`

**Cherry-pick to `4.1.x`**