### PR TITLE
Revert the #2989, it may cause unexpected results.

### DIFF
--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/SpelExpressionConverterConfiguration.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/config/SpelExpressionConverterConfiguration.java
@@ -69,7 +69,7 @@ public class SpelExpressionConverterConfiguration {
 	@Bean
 	@ConfigurationPropertiesBinding
 	@IntegrationConverter
-	public Converter<Object, Expression> spelConverter(ConfigurableApplicationContext context) {
+	public Converter<String, Expression> spelConverter(ConfigurableApplicationContext context) {
 		SpelConverter converter = new SpelConverter();
 		ConfigurableConversionService cs = (ConfigurableConversionService) context.getBeanFactory().getConversionService();
 		if (cs != null) {
@@ -83,7 +83,7 @@ public class SpelExpressionConverterConfiguration {
 	 *
 	 * @author Eric Bottard
 	 */
-	public static class SpelConverter implements Converter<Object, Expression> {
+	public static class SpelConverter implements Converter<String, Expression> {
 
 		private SpelExpressionParser parser = new SpelExpressionParser();
 
@@ -93,12 +93,9 @@ public class SpelExpressionConverterConfiguration {
 		private EvaluationContext evaluationContext;
 
 		@Override
-		public Expression convert(Object source) {
+		public Expression convert(String source) {
 			try {
-				if (!(source instanceof String)) {
-					source = String.valueOf(source); // see https://github.com/spring-cloud/spring-cloud-stream/issues/2989
-				}
-				Expression expression = this.parser.parseExpression((String) source);
+				Expression expression = this.parser.parseExpression(source);
 				if (expression instanceof SpelExpression) {
 					((SpelExpression) expression)
 							.setEvaluationContext(this.evaluationContext);


### PR DESCRIPTION
In spring-core `GenericConversionService` contains dozens converters and if nothing is matched, the `NoOpConverter` will be used. The `SpelConverter` of Object -> Expression is too general, and cause for some type conversions instead of picking `NoOpConverter` the `SpelConverter` be selected.

Using String.valueOf(object) is not safe and for classes that do not override `toString` or their `toString` is not Spel compatible cause to throw Exception. e.g., LiteralExpression -> Expression used NoOpConverter but after the #2989 change it will pick SpelConverter and causes problem. It is better to save the previous application.yml behaviour for expressions and change `spring-core` if this functionality is needed.