### PR TITLE
fix #3066: default-retryable & retryable-exceptions together with transactions

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -165,6 +165,7 @@ import org.springframework.util.backoff.FixedBackOff;
  * @author Byungjun You
  * @author Oliver Führer
  * @author Omer Celik
+ * @author Didier Loiseau
  */
 public class KafkaMessageChannelBinder extends
 		// @checkstyle:off
@@ -566,8 +567,14 @@ public class KafkaMessageChannelBinder extends
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	protected MessageProducer createConsumerEndpoint(
+			final ConsumerDestination destination, final String group,
+			final ExtendedConsumerProperties<KafkaConsumerProperties> extendedConsumerProperties) {
+		return createConsumerEndpointCaptureHelper(destination, group, extendedConsumerProperties);
+	}
+
+	@SuppressWarnings("unchecked")
+	private <K, V> MessageProducer createConsumerEndpointCaptureHelper(
 			final ConsumerDestination destination, final String group,
 			final ExtendedConsumerProperties<KafkaConsumerProperties> extendedConsumerProperties) {
 
@@ -577,7 +584,7 @@ public class KafkaMessageChannelBinder extends
 				"DLQ support is not available for anonymous subscriptions");
 		String consumerGroup = anonymous ? "anonymous." + UUID.randomUUID().toString()
 				: group;
-		final ConsumerFactory<?, ?> consumerFactory = createKafkaConsumerFactory(
+		final ConsumerFactory<K, V> consumerFactory = (ConsumerFactory<K, V>) createKafkaConsumerFactory(
 				anonymous, consumerGroup, extendedConsumerProperties, destination.getName() + ".consumer", destination.getName());
 		int partitionCount = extendedConsumerProperties.getInstanceCount()
 				* extendedConsumerProperties.getConcurrency();
@@ -647,9 +654,8 @@ public class KafkaMessageChannelBinder extends
 		}
 		resetOffsetsForAutoRebalance(extendedConsumerProperties, consumerFactory, containerProperties);
 		containerProperties.setAuthExceptionRetryInterval(this.configurationProperties.getAuthorizationExceptionRetryInterval());
-		@SuppressWarnings("rawtypes")
-		final ConcurrentMessageListenerContainer<?, ?> messageListenerContainer = new ConcurrentMessageListenerContainer(
-				consumerFactory, containerProperties) {
+		final ConcurrentMessageListenerContainer<K, V> messageListenerContainer =
+			new ConcurrentMessageListenerContainer<>(consumerFactory, containerProperties) {
 
 			@Override
 			public void stop(Runnable callback) {
@@ -677,8 +683,7 @@ public class KafkaMessageChannelBinder extends
 		ContainerProperties.AckMode ackMode = extendedConsumerProperties.getExtension().getAckMode();
 
 		if (ackMode != null) {
-			if ((extendedConsumerProperties.isBatchMode() && ackMode != ContainerProperties.AckMode.RECORD) ||
-					!extendedConsumerProperties.isBatchMode()) {
+			if (!extendedConsumerProperties.isBatchMode() || ackMode != ContainerProperties.AckMode.RECORD) {
 				messageListenerContainer.getContainerProperties()
 						.setAckMode(ackMode);
 			}
@@ -715,7 +720,7 @@ public class KafkaMessageChannelBinder extends
 			}
 		}
 		else if (!extendedConsumerProperties.isBatchMode() && transMan != null) {
-			messageListenerContainer.setAfterRollbackProcessor(new DefaultAfterRollbackProcessor<>(
+			var afterRollbackProcessor = new DefaultAfterRollbackProcessor<K, V>(
 					(record, exception) -> {
 						MessagingException payload =
 								new MessagingException(((RecordMessageConverter) messageConverter)
@@ -740,7 +745,31 @@ public class KafkaMessageChannelBinder extends
 						}
 					}, createBackOff(extendedConsumerProperties),
 					new KafkaTemplate<>(transMan.getProducerFactory()),
-					extendedConsumerProperties.getExtension().isTxCommitRecovered()));
+					extendedConsumerProperties.getExtension().isTxCommitRecovered());
+			if (!CollectionUtils.isEmpty(extendedConsumerProperties.getRetryableExceptions())) {
+				// mimic AbstractBinder.buildRetryTemplate(properties)’s retryPolicy
+				if (!extendedConsumerProperties.isDefaultRetryable()) {
+					afterRollbackProcessor.defaultFalse(true);
+				}
+				extendedConsumerProperties.getRetryableExceptions()
+						.forEach((t, retry) -> {
+							if (Exception.class.isAssignableFrom(t)) {
+								var ex = t.asSubclass(Exception.class);
+								if (retry) {
+									afterRollbackProcessor.addRetryableExceptions(ex);
+								}
+								else {
+									afterRollbackProcessor.addNotRetryableExceptions(ex);
+								}
+							}
+							else {
+								throw new IllegalArgumentException(
+										"Only Exception types can be configured as retryable-exceptions together with transactions. "
+												+ "Unsupported type: " + t.getName());
+							}
+						});
+			}
+			messageListenerContainer.setAfterRollbackProcessor(afterRollbackProcessor);
 		}
 		else {
 			kafkaMessageDrivenChannelAdapter.setErrorChannel(errorInfrastructure.getErrorChannel());


### PR DESCRIPTION
Implements a fix for #3066.

Known differences compared to the non-transactional case:
* custom `RetryTemplate` are still not supported
* I set `retainStandardFatal` to `true` to align with the “default true” case. Not too sure what’s best.
* `DefaultAfterRollbackProcessor` only supports `Exception` classifying and not `Throwable` so I preferred to throw an exception if someone tries to configure that (not sure why you would want to configure `Error` or other non-`Exception` types as `retryable-exception`)

I didn’t find tests for `default-retryable: false` / `retryable-exceptions` in the non-transactional case, so I didn’t add any for the new code either.

(I also simplified an `if` that IntelliJ was warning about but I can revert it if desired)