### PR TITLE
Enhance Function<List<T>, List<R>> to Publish Individual Messages with splitMode=true

### DIFF
--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ProducerProperties.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/ProducerProperties.java
@@ -83,6 +83,8 @@ public class ProducerProperties {
 
 	private boolean dynamicPartitionUpdatesEnabled = false;
 
+	private boolean splitMode = false;
+
 	public String getBindingName() {
 		return bindingName;
 	}
@@ -213,6 +215,14 @@ public class ProducerProperties {
 	 */
 	public void setDynamicPartitionUpdatesEnabled(boolean enabled) {
 		this.dynamicPartitionUpdatesEnabled = enabled;
+	}
+
+	public boolean isSplitMode() {
+		return splitMode;
+	}
+
+	public void setSplitMode(boolean splitMode) {
+		this.splitMode = splitMode;
 	}
 
 	static class ExpressionSerializer extends JsonSerializer<Expression> {

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -614,6 +615,13 @@ public class FunctionConfiguration {
 				});
 			}
 			else {
+				boolean isSplitMode = outputBindingNames.stream()
+					.map(bindingName -> this.serviceProperties.getBindings().get(bindingName).getProducer())
+					.filter(Objects::nonNull)
+					.anyMatch(ProducerProperties::isSplitMode);
+
+				function.setEnableSplitting(isSplitMode);
+
 				String outputDestinationName = this.determineOutputDestinationName(0, bindableProxyFactory, function.isConsumer());
 				if (!ObjectUtils.isEmpty(inputBindingNames)) {
 					String inputDestinationName = inputBindingNames.iterator().next();


### PR DESCRIPTION
Currently, when registering a Function<List<T>, List<R>> as a bean in Spring Cloud Function, Spring Cloud Stream publishes the entire list as a single message instead of splitting it into individual messages, even when the producer sets splitMode=true.

I have opened a related issue in Spring Cloud Function: [Issue #1242](https://github.com/spring-cloud/spring-cloud-function/issues/1242). If this feature is improved in Spring Cloud Function and subsequently applied to Spring Cloud Stream, it would enhance message processing efficiency.

With this enhancement:
- Before: 
   - Consumed messages were aggregated into a single list and published as a single message.
- After: 
   - By enabling splitMode=true, each element in the list can be published as an individual message automatically, eliminating the need for additional handling via StreamBridge.

This is a test in a local Kafka setup.

🖼️ Before applying splitMode:
![image](https://github.com/user-attachments/assets/64a440ee-a524-4869-8d54-cdf931687b76)

🖼️ After applying splitMode:
![image](https://github.com/user-attachments/assets/196c59f1-6899-43c4-a188-c4c4719bbd84)

Spring Boot Server Configuration
(This setup references locally modified versions of Spring Cloud Function and Spring Cloud Stream, which I updated and installed in the .m2 folder.)
```
spring:
  cloud:
    function:
      definition: eventStream
    stream:
      bindings:
        eventStream-in-0:
          destination: prev-topic
          group: test-group-unique
          consumer:
            batch-mode: true
        eventStream-out-0:
          destination: next-topic
          producer:
            split-mode: true
      kafka:
        binder:
          brokers: localhost:9092
          auto-create-topics: true
```

```java
@Bean
public Function<List<String>, List<String>> eventStream() {
      return messages -> messages
            .stream()
            .map(String::toUpperCase)
            .toList();
}
```
