### PR TITLE
https://github.com/spring-cloud/spring-cloud-stream/issues/3103

### DIFF
--- a/schema-registry/spring-cloud-stream-schema-registry-client/src/main/java/org/springframework/cloud/stream/schema/registry/client/ConfluentSchemaRegistryClient.java
+++ b/schema-registry/spring-cloud-stream-schema-registry-client/src/main/java/org/springframework/cloud/stream/schema/registry/client/ConfluentSchemaRegistryClient.java
@@ -16,14 +16,8 @@
 
 package org.springframework.cloud.stream.schema.registry.client;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.springframework.cloud.stream.schema.registry.SchemaNotFoundException;
 import org.springframework.cloud.stream.schema.registry.SchemaReference;
 import org.springframework.cloud.stream.schema.registry.SchemaRegistrationResponse;
@@ -36,6 +30,11 @@ import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author Vinicius Carvalho
@@ -102,11 +101,12 @@ public class ConfluentSchemaRegistryClient implements SchemaRegistryClient {
 
 		try {
 			ResponseEntity<List> response = this.template.getForEntity(
-					this.endpoint + "/subjects/" + subject + "/versions", List.class);
+					this.endpoint + "/schemas/ids/" + id + "/versions", List.class);
 
 			final List body = response.getBody();
 			if (!CollectionUtils.isEmpty(body)) {
-				version = (Integer) body.get(body.size() - 1);
+				// Assume only a single version is registered for this ID
+				version = (Integer) ((Map<String, Object>) body.get(0)).get("version");
 			}
 		}
 		catch (HttpStatusCodeException httpException) {

--- a/schema-registry/spring-cloud-stream-schema-registry-client/src/test/java/org/springframework/cloud/stream/schema/avro/client/ConfluentSchemaRegistryClientTests.java
+++ b/schema-registry/spring-cloud-stream-schema-registry-client/src/test/java/org/springframework/cloud/stream/schema/avro/client/ConfluentSchemaRegistryClientTests.java
@@ -66,9 +66,9 @@ class ConfluentSchemaRegistryClientTests {
 				.andRespond(withSuccess("{\"id\":101,\"version\":1}", MediaType.APPLICATION_JSON));
 
 		this.mockRestServiceServer
-				.expect(requestTo("http://localhost:8081/subjects/user/versions"))
+				.expect(requestTo("http://localhost:8081/schemas/ids/101/versions"))
 				.andExpect(method(HttpMethod.GET))
-				.andRespond((withSuccess("[1]", MediaType.APPLICATION_JSON)));
+				.andRespond((withSuccess("[{\"subject\":\"user\",\"version\":1}]", MediaType.APPLICATION_JSON)));
 
 		ConfluentSchemaRegistryClient client = new ConfluentSchemaRegistryClient(
 				this.restTemplate);


### PR DESCRIPTION
Fix the retrieval of the schema version registered on serializing an Avro message with the ConfluentSchemaRegistryClient

The current code assumes that the producer is using the latest version of the Avro schema registered with the schema registry, but that might not be the case. This can lead to the writer schema being different from the reader schema, and be the cause of deserialization issues

This change ensures that the schema ID returned when the schema is registered is used to retrieve the actual schema version that is being used to serialize the Message

Resolves https://github.com/spring-cloud/spring-cloud-stream/issues/3103