### PR TITLE
Replace deprecated CLA section with DCO in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -185,13 +185,9 @@ tracker for issues and merging pull requests into master. If you want
 to contribute even something trivial please do not hesitate, but
 follow the guidelines below.
 
-=== Sign the Contributor License Agreement
-Before we accept a non-trivial patch or pull request we will need you to sign the
-https://cla.pivotal.io/sign/spring[Contributor License Agreement].
-Signing the contributor's agreement does not grant anyone commit rights to the main
-repository, but it does mean that we can accept your contributions, and you will get an
-author credit if we do.  Active contributors might be asked to join the core team, and
-given the ability to merge pull requests.
+=== Developer Certificate of Origin (DCO)
+All commits must include a `Signed-off-by` trailer at the end of each commit message to indicate the contributor agrees to the `Developer Certificate of Origin`.
+For additional details please review the following https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring[blog post]
 
 === Code of Conduct
 This project adheres to the Contributor Covenant https://github.com/spring-cloud/spring-cloud-build/blob/master/docs/src/main/asciidoc/code-of-conduct.adoc[code of


### PR DESCRIPTION
Changes:
* Removes reference to the old `Contributor License Agreement`
* Introduces `Developer Certificate of Origin` as documentation for contributing

Follows the same format as other Spring Cloud projects:
* https://github.com/spring-cloud/spring-cloud-gateway?tab=readme-ov-file#contributing
* https://github.com/spring-cloud/spring-cloud-commons?tab=readme-ov-file#contributing