### PR TITLE
fix: remove unnecessary cast

### DIFF
--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/RoutingFunctionEnvironmentPostProcessor.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/RoutingFunctionEnvironmentPostProcessor.java
@@ -38,11 +38,11 @@ class RoutingFunctionEnvironmentPostProcessor implements EnvironmentPostProcesso
 				name.contains(RoutingFunction.FUNCTION_NAME + "|") ||
 				name.contains("|" + RoutingFunction.FUNCTION_NAME)
 			)) {
-			((StandardEnvironment) environment).getSystemProperties()
+			environment.getSystemProperties()
 				.putIfAbsent("spring.cloud.function.routing.enabled", "true");
 		}
 		// perhaps mpve it to separate class as it doesn't have much to do with RoutingFunction
-		((StandardEnvironment) environment).getSystemProperties()
+		environment.getSystemProperties()
 			.putIfAbsent("spring.cloud.function.configuration.default.copy-input-headers", "true");
 	}
 


### PR DESCRIPTION
The cast here is unnecessary, and in some cases can cause a ClassCastException particularly when the environment created is a different type (as is the case with Spring Cloud Bootstrap)