### PR TITLE
Updated documentation producer/consumer default binder property paths

### DIFF
--- a/docs/modules/ROOT/pages/rabbit/rabbit_overview/prod-props.adoc
+++ b/docs/modules/ROOT/pages/rabbit/rabbit_overview/prod-props.adoc
@@ -5,7 +5,7 @@ The following properties are available for Rabbit producers only and must be pre
 
 However if the same set of properties needs to be applied to most bindings, to
 avoid repetition, Spring Cloud Stream supports setting values for all channels,
-in the format of `spring.cloud.stream.rabbit.default.<property>=<value>`.
+in the format of `spring.cloud.stream.rabbit.default.producer.<property>=<value>`.
 
 Also, keep in mind that binding specific property will override its equivalent in the default.
 

--- a/docs/modules/ROOT/pages/rabbit/rabbit_overview/rabbitmq-consumer-properties.adoc
+++ b/docs/modules/ROOT/pages/rabbit/rabbit_overview/rabbitmq-consumer-properties.adoc
@@ -5,7 +5,7 @@ The following properties are available for Rabbit consumers only and must be pre
 
 However if the same set of properties needs to be applied to most bindings, to
 avoid repetition, Spring Cloud Stream supports setting values for all channels,
-in the format of `spring.cloud.stream.rabbit.default.<property>=<value>`.
+in the format of `spring.cloud.stream.rabbit.default.consumer.<property>=<value>`.
 
 Also, keep in mind that binding specific property will override its equivalent in the default.
 


### PR DESCRIPTION
I was recently looking into how to enable quorum queue creation for all bindings by default and noticed that the documentation did not accurately specify the path.

According to the current documentation:

`spring.cloud.stream.rabbit.default.quorum.enabled=true`

But it is actually:

`spring.cloud.stream.rabbit.default.consumer.quorum.enabled=true` for consumers

OR

`spring.cloud.stream.rabbit.default.producer.quorum.enabled=true` for producers.

Source: https://github.com/cosmin-enache/spring-cloud-stream/blob/main/binders/rabbit-binder/spring-cloud-stream-binder-rabbit-core/src/main/java/org/springframework/cloud/stream/binder/rabbit/properties/RabbitBindingProperties.java#L27-L29