### PR TITLE
GH-3170: Change default requiredAcks to all

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationProperties.java
@@ -110,7 +110,7 @@ public class KafkaBinderConfigurationProperties {
 
 	private boolean considerDownWhenAnyPartitionHasNoLeader = true;
 
-	private String requiredAcks = "1";
+	private String requiredAcks = "all";
 
 	private short replicationFactor = -1;
 

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/test/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationPropertiesTest.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/test/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaBinderConfigurationPropertiesTest.java
@@ -39,6 +39,16 @@ class KafkaBinderConfigurationPropertiesTest {
 
 	@Test
 	@SuppressWarnings("unchecked")
+	void defaultRequiredAcksIsAll() {
+		KafkaProperties kafkaProperties = new KafkaProperties();
+		KafkaBinderConfigurationProperties kafkaBinderConfigurationProperties =
+				new KafkaBinderConfigurationProperties(kafkaProperties, mock(ObjectProvider.class));
+
+		assertThat(kafkaBinderConfigurationProperties.getRequiredAcks()).isEqualTo("all");
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
 	void mergedConsumerConfigurationFiltersGroupIdFromKafkaProperties() {
 		KafkaProperties kafkaProperties = new KafkaProperties();
 		kafkaProperties.getConsumer().setGroupId("group1");

--- a/docs/modules/ROOT/pages/kafka/kafka-binder/config-options.adoc
+++ b/docs/modules/ROOT/pages/kafka/kafka-binder/config-options.adoc
@@ -43,7 +43,7 @@ spring.cloud.stream.kafka.binder.requiredAcks::
 The number of required acks on the broker.
 See the Kafka documentation for the producer `acks` property.
 +
-Default: `1`.
+Default: `all`.
 spring.cloud.stream.kafka.binder.minPartitionCount::
 Effective only if `autoCreateTopics` or `autoAddPartitions` is set.
 The global minimum number of partitions that the binder configures on topics on which it produces or consumes data.

--- a/docs/modules/ROOT/pages/kafka/kafka_overview.adoc
+++ b/docs/modules/ROOT/pages/kafka/kafka_overview.adoc
@@ -83,7 +83,7 @@ spring.cloud.stream.kafka.binder.requiredAcks::
 The number of required acks on the broker.
 See the Kafka documentation for the producer `acks` property.
 +
-Default: `1`.
+Default: `all`.
 spring.cloud.stream.kafka.binder.minPartitionCount::
 Effective only if `autoCreateTopics` or `autoAddPartitions` is set.
 The global minimum number of partitions that the binder configures on topics on which it produces or consumes data.


### PR DESCRIPTION
This PR changes the default value of `spring.cloud.stream.kafka.binder.requiredAcks`
from `1` to `all`.

Rationale:
- Kafka producer idempotence requires `acks=all`
- Kafka producer defaults use `acks=all` and `enable.idempotence=true`
- Binder default `requiredAcks=1` may introduce a conflicting configuration and disable idempotence-by-default behavior.

Users can keep the legacy behavior by explicitly setting:
`spring.cloud.stream.kafka.binder.requiredAcks=1`

Closes #3170 