### PR TITLE
Make BinderHeaders.BATCH_HEADERS final (fixes #3182)

### DIFF
--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderHeaders.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderHeaders.java
@@ -43,7 +43,7 @@ public final class BinderHeaders {
 	/**
 	 * Name of the Message header identifying structure for batch Message headers.
 	 */
-	public static String BATCH_HEADERS = PREFIX + "batchHeaders";
+	public static final String BATCH_HEADERS = PREFIX + "batchHeaders";
 
 	/**
 	 * Indicates the name of the target destination the binder should use if they


### PR DESCRIPTION
Fixes #3182

## Problem

`BinderHeaders.BATCH_HEADERS` is a `public static String` and is not `final`, so the header key could be reassigned by callers.

## Solution

Mark `BATCH_HEADERS` as `final`, consistent with other constants in `BinderHeaders` (e.g. `TARGET_DESTINATION`, `PARTITION_HEADER`). This keeps the header name immutable and prevents accidental modification.

## Changes

- `core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/BinderHeaders.java`: `public static String BATCH_HEADERS` → `public static final String BATCH_HEADERS`