### PR TITLE
fix(core): correct retry semantics for consumer maxAttempts configuration

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
@@ -1309,8 +1309,7 @@ class KafkaBinderTests extends
 			boolean shouldHaveRetried = withRetry && !useConfiguredRetryableException;
 			assertThat(handler.getInvocationCount())
 					.isEqualTo(
-							shouldHaveRetried ? consumerProperties.getMaxAttempts() + 1 : 1);
-
+							shouldHaveRetried ? consumerProperties.getMaxAttempts() : 1);
 			assertThat(receivedMessage.getHeaders()
 					.get(KafkaMessageChannelBinder.X_ORIGINAL_TOPIC))
 							.isEqualTo(producerName.getBytes(StandardCharsets.UTF_8));
@@ -1422,7 +1421,7 @@ class KafkaBinderTests extends
 				new String((byte[]) handledMessage.getPayload(), StandardCharsets.UTF_8))
 						.isEqualTo(testMessagePayload);
 		assertThat(handler.getInvocationCount())
-				.isEqualTo(consumerProperties.getMaxAttempts() + 1);
+				.isEqualTo(consumerProperties.getMaxAttempts());
 		binderBindUnbindLatency();
 		dlqConsumerBinding.unbind();
 		consumerBinding.unbind();
@@ -1484,7 +1483,7 @@ class KafkaBinderTests extends
 		// Since we don't have a DLQ, assert that we are invoking the handler exactly the same number of times
 		// as set in consumerProperties.maxAttempt and not the default set by Spring Kafka (10 times).
 		assertThat(handler.getInvocationCount())
-				.isEqualTo(consumerProperties.getMaxAttempts() + 1);
+				.isEqualTo(consumerProperties.getMaxAttempts());
 		binderBindUnbindLatency();
 		consumerBinding.unbind();
 		producerBinding.unbind();
@@ -1609,7 +1608,7 @@ class KafkaBinderTests extends
 				new String((byte[]) handledMessage.getPayload(), StandardCharsets.UTF_8))
 				.isEqualTo(testMessagePayload);
 		assertThat(handler.getInvocationCount())
-				.isEqualTo(consumerProperties.getMaxAttempts() + 1);
+				.isEqualTo(consumerProperties.getMaxAttempts());
 		binderBindUnbindLatency();
 		dlqConsumerBinding.unbind();
 		consumerBinding.unbind();
@@ -1689,7 +1688,7 @@ class KafkaBinderTests extends
 				new String((byte[]) handledMessage.getPayload(), StandardCharsets.UTF_8))
 						.isEqualTo(testMessagePayload);
 		assertThat(handler.getInvocationCount())
-				.isEqualTo(consumerProperties.getMaxAttempts() + 1);
+				.isEqualTo(consumerProperties.getMaxAttempts());
 		binderBindUnbindLatency();
 		dlqConsumerBinding.unbind();
 		consumerBinding.unbind();

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractBinder.java
@@ -209,7 +209,7 @@ public abstract class AbstractBinder<T, C extends ConsumerProperties, P extends 
 			}
 			RetryPolicy retryPolicy =
 				RetryPolicy.builder()
-					.maxRetries(properties.getMaxAttempts())
+					.maxRetries(Math.max(0, properties.getMaxAttempts() - 1))
 					.delay(Duration.ofMillis(properties.getBackOffInitialInterval()))
 					.multiplier(properties.getBackOffMultiplier())
 					.maxDelay(Duration.ofMillis(properties.getBackOffMaxInterval()))

--- a/core/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/MaxAttemptsRetryTests.java
+++ b/core/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/MaxAttemptsRetryTests.java
@@ -1,0 +1,49 @@
+package org.springframework.cloud.stream.binder;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.retry.RetryTemplate;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MaxAttemptsRetryTests {
+
+	@Test
+	void maxAttemptsShouldNotExceedConfiguredAttempts() {
+
+		ConsumerProperties props = new ConsumerProperties();
+		props.setMaxAttempts(2);
+
+		TestBinder binder = new TestBinder();
+
+		RetryTemplate retryTemplate = binder.buildRetryTemplate(props);
+
+		AtomicInteger attempts = new AtomicInteger();
+
+		try {
+			retryTemplate.execute(() -> {
+				attempts.incrementAndGet();
+				throw new RuntimeException("fail");
+			});
+		} catch (Exception ignored) {
+		}
+
+		assertThat(attempts.get()).isEqualTo(2);
+	}
+
+	static class TestBinder extends AbstractBinder<Object, ConsumerProperties, ProducerProperties> {
+
+		@Override
+		protected Binding<Object> doBindConsumer(String name, String group, Object inboundBindTarget,
+												 ConsumerProperties consumerProperties) {
+			return null;
+		}
+
+		@Override
+		protected Binding<Object> doBindProducer(String name, Object outboundBindTarget,
+												 ProducerProperties producerProperties) {
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
Fix off-by-one retry behavior for `maxAttempts` configuration.

Currently, the retry policy is configured as:

    maxRetries(properties.getMaxAttempts())

However, `maxRetries` represents the number of retries, while
`maxAttempts` is expected to represent the total number of delivery attempts.

This results in an off-by-one behavior:

Example:

maxAttempts = 2

Expected behavior:
2 executions (1 initial + 1 retry)

Actual behavior:
3 executions (1 initial + 2 retries)

This PR corrects the calculation by converting total attempts to retry count:

    maxRetries = maxAttempts - 1

In addition, existing tests (particularly in Kafka binder) have been updated
to reflect the corrected semantics, where `maxAttempts` now consistently
represents total delivery attempts rather than retry count.

This aligns behavior across binders and resolves the issue where it was not
possible to configure exactly N delivery attempts.

Fixes #3183

Thanks for reviewing this contribution.