### PR TITLE
Register Expression serializer on binder ObjectMapper

### DIFF
--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinder.java
@@ -157,7 +157,7 @@ public abstract class AbstractMessageChannelBinder<C extends ConsumerProperties,
 //		}
 		SimpleModule module = new SimpleModule();
 		module.addSerializer(Expression.class, new ExpressionSerializer(Expression.class));
-		this.objectMapper = this.objectMapper.rebuild().build();
+		this.objectMapper = this.objectMapper.rebuild().addModule(module).build();
 	}
 
 	public AbstractMessageChannelBinder(String[] headersToEmbed, PP provisioningProvider,

--- a/core/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinderTests.java
+++ b/core/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binder/AbstractMessageChannelBinderTests.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.cloud.stream.provisioning.ConsumerDestination;
 import org.springframework.cloud.stream.provisioning.ProducerDestination;
 import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.integration.core.MessageProducer;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
@@ -58,6 +60,24 @@ public class AbstractMessageChannelBinderTests {
 		final Map<String, Object> convertedMap = objectMapper.convertValue(properties, Map.class);
 
 		assertThat(convertedMap).isNotEmpty();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void serializeExpressionOnObjectMapperInAMCB() throws Exception {
+		AbstractMessageChannelBinder<?, ?, ?> binder = createBinderInstance();
+
+		Field objectMapperField = ReflectionUtils.findField(AbstractMessageChannelBinder.class, "objectMapper");
+		assertThat(objectMapperField).isNotNull();
+		ReflectionUtils.makeAccessible(objectMapperField);
+		ObjectMapper objectMapper = (ObjectMapper) ReflectionUtils.getField(objectMapperField, binder);
+		assertThat(objectMapper).isNotNull();
+
+		Expression expression = new SpelExpressionParser().parseExpression("'routing.key'");
+		Map<String, Object> properties = Map.of("routingKeyExpression", expression);
+		Map<String, Object> convertedMap = objectMapper.convertValue(properties, Map.class);
+
+		assertThat(convertedMap).containsEntry("routingKeyExpression", "'routing.key'");
 	}
 
 	@NotNull


### PR DESCRIPTION
Fixes #3175.

### Description

The bindings actuator endpoint can fail when binder extension properties contain SpEL `Expression` values, such as Rabbit `routingKeyExpression` or `delayExpression`.

`AbstractMessageChannelBinder` already defines an `ExpressionSerializer`, but the serializer module was created without being registered on the binder `ObjectMapper`. As a result, the endpoint could still try to serialize `Expression` internals and hit Jackson self-reference/cycle errors.

This change registers the existing serializer module when rebuilding the binder `ObjectMapper`, so SpEL expressions are rendered as their expression string.

### Verification

- Added coverage for serializing an `Expression` through the binder `ObjectMapper`.
- Ran `./mvnw -pl core/spring-cloud-stream -Dtest=AbstractMessageChannelBinderTests test`.