### PR TITLE
Use Rabbit 4.2 to work around queue_master_locator deprecation

### DIFF
--- a/binders/rabbit-binder/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitTestContainer.java
+++ b/binders/rabbit-binder/spring-cloud-stream-binder-rabbit/src/test/java/org/springframework/cloud/stream/binder/rabbit/RabbitTestContainer.java
@@ -30,7 +30,7 @@ public final class RabbitTestContainer {
 
 	private static final RabbitMQContainer RABBITMQ;
 	static {
-		String image = "rabbitmq:management";
+		String image = "rabbitmq:4.2-management";
 		String cache = System.getenv().get("IMAGE_CACHE");
 		if (cache != null) {
 			image = cache + image;


### PR DESCRIPTION
operation queue.declare caused a connection exception internal_error: "Feature `queue_master_locator` is deprecated.By default, this feature is not permitted anymore."