### PR TITLE
GH-3195 Mark new Kotlin runtime dependencies as optional

### DIFF
--- a/core/spring-cloud-stream/pom.xml
+++ b/core/spring-cloud-stream/pom.xml
@@ -105,11 +105,13 @@
 				<groupId>org.jetbrains.kotlin</groupId>
 				<artifactId>kotlin-reflect</artifactId>
 				<scope>runtime</scope>
+				<optional>true</optional>
 			</dependency>
 			<dependency>
 				<groupId>org.jetbrains.kotlinx</groupId>
 				<artifactId>kotlinx-coroutines-reactor</artifactId>
 				<scope>runtime</scope>
+				<optional>true</optional>
 			</dependency>
     </dependencies>
 


### PR DESCRIPTION
Fixes #3195

## Summary

`kotlin-reflect` and `kotlinx-coroutines-reactor` were added to `core/spring-cloud-stream/pom.xml` (commit 11d5fb37 "Adjusted Kotlin dependencies") with `<scope>runtime</scope>` but without `<optional>true</optional>`. As a result, Java-only Spring Cloud Stream consumers transitively pull these Kotlin artifacts into their fat jars.

This mirrors the situation that #3128 addressed for `kotlin-stdlib-jdk8`, which sits a few lines above in the same POM and is already marked optional. The fix is to add `<optional>true</optional>` to both new dependencies, matching that established precedent.

## Change

```diff
 		<dependency>
 				<groupId>org.jetbrains.kotlin</groupId>
 				<artifactId>kotlin-reflect</artifactId>
 				<scope>runtime</scope>
+				<optional>true</optional>
 			</dependency>
 			<dependency>
 				<groupId>org.jetbrains.kotlinx</groupId>
 				<artifactId>kotlinx-coroutines-reactor</artifactId>
 				<scope>runtime</scope>
+				<optional>true</optional>
 			</dependency>
```

The two dependencies remain runtime-scoped and are still available to applications that opt in (Kotlin consumers add them explicitly, or pick them up via `spring-boot-starter-webflux` or similar). Consumers that do not use Kotlin are no longer forced to ship them.

## Test evidence

POM-only change — no source files touched.

- `./mvnw -N validate` on `core/spring-cloud-stream` — BUILD SUCCESS.
- `./mvnw -N help:effective-pom -Doutput=/tmp/eff-pom.xml` on the same module; resolved dependencies on the project:
  ```
  org.jetbrains.kotlin:kotlin-stdlib-jdk8       scope=compile optional=true   (pre-existing)
  org.jetbrains.kotlin:kotlin-reflect           scope=runtime optional=true   (this PR)
  org.jetbrains.kotlinx:kotlinx-coroutines-reactor scope=runtime optional=true   (this PR)
  ```

Skipped the full multi-module build because the change is pure POM metadata (the `optional` flag does not affect compilation or test behavior of this module — only how the dependency is propagated transitively to downstream consumers).

Verification done: (1) `gh pr list` for "kotlin-reflect optional", "3195 kotlin" — no in-flight PR; (2) issue #3195 has zero comments, no self-claim; (3) confirmed fix touches POM only and follows the established `<optional>true</optional>` pattern set by #3128 in the same file; (4) ran `mvn help:effective-pom` to confirm `optional=true` resolves on both dependencies in the project view; (5) reviewed git history — commit 11d5fb37 introduced the new deps without the optional flag, and no follow-up commit fixed it.