### PR TITLE
GH-3142: Clarify republishToDlq default behaviour in docs

### DIFF
--- a/docs/modules/ROOT/pages/rabbit/rabbit_overview/rabbitmq-consumer-properties.adoc
+++ b/docs/modules/ROOT/pages/rabbit/rabbit_overview/rabbitmq-consumer-properties.adoc
@@ -272,9 +272,8 @@ When `republishToDlq` is `true`, specifies the delivery mode of the republished 
 +
 Default: `DeliveryMode.PERSISTENT`
 republishToDlq::
-By default, messages that fail after retries are exhausted are rejected.
-If a dead-letter queue (DLQ) is configured, RabbitMQ routes the failed message (unchanged) to the DLQ.
-If set to `true`, the binder republishs failed messages to the DLQ with additional headers, including the exception message and stack trace from the cause of the final failure.
+When set to `true` (the default), the binder republishes failed messages to the dead-letter queue (DLQ) with additional headers, including the exception message and stack trace from the cause of the final failure.
+When set to `false`, messages that fail after retries are exhausted are rejected; if a dead-letter queue is configured, RabbitMQ then routes the rejected message (unchanged, without extra headers) to the DLQ.
 Also see the xref:rabbit/rabbit_overview/rabbitmq-consumer-properties.adoc#spring-cloud-stream-rabbit-frame-max-headroom[frameMaxHeadroom property].
 +
 Default: `true`


### PR DESCRIPTION
## Summary

Fixes #3142.

The previous description of `republishToDlq` opened with:

> By default, messages that fail after retries are exhausted are rejected.

This sentence implies the default is `false` (reject on failure). However the actual default is `true` (republish to the DLQ with additional error headers). The misleading opening was a carry-over from when the default was `false` and was later changed.

This PR rewrites the description to:
1. Lead with the `true` (default) behaviour: binder republishes with extra headers.
2. Describe the `false` behaviour explicitly: rejected; RabbitMQ routes unchanged to DLQ if one is configured.

No code changes — docs only.

## Test plan

- [ ] Verify rendered docs show `Default: true` with a matching prose description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)