### PR TITLE
GH-3203 Skip standalone bindings in supplierInitializer to avoid ClassCastException for output-only bindings

### DIFF
--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
@@ -190,6 +190,14 @@ public class FunctionConfiguration {
 
 		return () -> {
 			for (BindableFunctionProxyFactory proxyFactory : proxyFactories) {
+				// see https://github.com/spring-cloud/spring-cloud-stream/issues/3203
+				// A standalone output-/input-binding has no backing function, yet its
+				// function definition is now the binding name (since gh-3166 stopped
+				// null-ing it out in getFunctionDefinition()). Skip such bindings here so
+				// that a plain output channel is never resolved and treated as a Supplier.
+				if (!proxyFactory.isFunctionExist()) {
+					continue;
+				}
 				FunctionInvocationWrapper functionWrapper = functionCatalog.lookup(proxyFactory.getFunctionDefinition());
 				if (functionWrapper != null && functionWrapper.isSupplier()) {
 					// gather output content types

--- a/core/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/function/OutputOnlyBindingSupplierTests.java
+++ b/core/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/function/OutputOnlyBindingSupplierTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.function;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for gh-3203: an output-only binding that has no backing
+ * {@code Supplier}/{@code Function} bean must not be treated as a {@code Supplier}.
+ * Prior to the fix the standalone output binding (whose function definition is the
+ * binding name) reached {@code supplierInitializer}, which built a
+ * {@link SourcePollingChannelAdapter} on top of the plain output channel and threw a
+ * {@code ClassCastException} (the channel cannot be cast to {@code Supplier}) on the
+ * first poll.
+ *
+ * @author Spring Cloud Stream contributors
+ */
+class OutputOnlyBindingSupplierTests {
+
+	@Test
+	void outputOnlyBindingIsNotTreatedAsSupplier() {
+		try (ConfigurableApplicationContext context = new SpringApplication(EmptyConfiguration.class).run(
+				"--spring.cloud.stream.output-bindings=testOutput",
+				"--spring.jmx.enabled=false",
+				"--spring.main.web-application-type=none",
+				"--spring.cloud.stream.default-binder=mock")) {
+
+			Map<String, SourcePollingChannelAdapter> pollingAdapters =
+					context.getBeansOfType(SourcePollingChannelAdapter.class);
+
+			assertThat(pollingAdapters)
+					.as("No SourcePollingChannelAdapter must be created for an output-only "
+							+ "binding without a backing Supplier")
+					.isEmpty();
+		}
+	}
+
+	@EnableAutoConfiguration
+	@Configuration
+	public static class EmptyConfiguration {
+
+	}
+
+}


### PR DESCRIPTION
Fixes #3203

### Problem

After upgrading to 5.0.2, an **output-only binding** (e.g. `spring.cloud.stream.output-bindings=testOutput`) with no backing `Supplier`/`Function` bean intermittently fails on startup with:

```
java.lang.ClassCastException: class ...DirectWithAttributesChannel$$SpringCGLIB$$0 cannot be cast to class java.util.function.Supplier
	at ...SimpleFunctionRegistry$FunctionInvocationWrapper.doApply(SimpleFunctionRegistry.java:826)
	...
	at ...AbstractPollingEndpoint.pollForMessage
```

### Root cause

Commit f042adbc (GH-3166) changed `BindableFunctionProxyFactory.getFunctionDefinition()` to always return the function definition instead of `isFunctionExist() ? functionDefinition : null`:

```java
public String getFunctionDefinition() {
    //return this.isFunctionExist() ? this.functionDefinition : null;
    return this.functionDefinition;
}
```

For a standalone output binding the "function definition" is the binding name, so `supplierInitializer` now does `functionCatalog.lookup("testOutput")`, which resolves the plain output channel bean. `isSupplier()` reports `true`, a `SourcePollingChannelAdapter` is built on top of the channel, and the first poll casts the channel to `Supplier` → `ClassCastException`. In 5.0.1 `getFunctionDefinition()` returned `null` for these bindings, so `lookup(null)` returned `null` and they were skipped.

### Fix

Guard the supplier initialization loop with `proxyFactory.isFunctionExist()`. Standalone bindings are constructed with `functionExist == false` (see `createStandAloneBindingsIfNecessary`, where `new BindableFunctionProxyFactory(..., sourceFunc != null)` and `sourceFunc == null` for a binding without a backing function), so they are now skipped — exactly the 5.0.1 behavior. Declared functions are constructed with `functionExist == true`, so real suppliers are unaffected. The change is local to `supplierInitializer` and does **not** revert the `getFunctionDefinition()` change that GH-3166 relies on for dynamic binding creation.

### Test evidence

Added `OutputOnlyBindingSupplierTests` which starts an app with an output-only binding and asserts no `SourcePollingChannelAdapter` is created.

- Without the fix the test fails: `Expecting empty but was: {"testOutput_spca"=bean 'testOutput_spca'}` (the SPCA that triggers the CCE on poll).
- With the fix the test passes.
- Full `core/spring-cloud-stream` module test suite is green: `Tests run: 32, Failures: 0, Errors: 0, Skipped: 1` (pre-existing skip).

Verification done: (1) no in-flight PR (`gh pr list` search empty); (2) no self-claim on the issue; (4) grepped `main` and confirmed the commented-out guard in `getFunctionDefinition()` and the unguarded `supplierInitializer`; reproduced the `SourcePollingChannelAdapter` creation deterministically in a test on current `main`.
