### PR TITLE
Unbind consumers after binding startup failure

### DIFF
--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/AbstractBindingLifecycle.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/AbstractBindingLifecycle.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.stream.binding;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,7 +59,17 @@ public abstract class AbstractBindingLifecycle implements SmartLifecycle {
 				this.bindables.putAll(context.getBeansOfType(Bindable.class));
 			}
 
-			this.bindables.values().forEach(this::doStartWithBindable);
+			List<Bindable> startedBindables = new ArrayList<>();
+			try {
+				for (Bindable bindable : this.bindables.values()) {
+					startedBindables.add(bindable);
+					this.doStartWithBindable(bindable);
+				}
+			}
+			catch (RuntimeException ex) {
+				this.stopStartedBindables(startedBindables, ex);
+				throw ex;
+			}
 			this.running = true;
 		}
 	}
@@ -95,7 +107,25 @@ public abstract class AbstractBindingLifecycle implements SmartLifecycle {
 		if (bindable instanceof BindableFunctionProxyFactory functionProxy) {
 			this.bindables.put(functionProxy.getFunctionDefinition(), bindable);
 		}
-		this.doStartWithBindable(bindable);
+		try {
+			this.doStartWithBindable(bindable);
+		}
+		catch (RuntimeException ex) {
+			this.stopStartedBindables(List.of(bindable), ex);
+			throw ex;
+		}
+	}
+
+	private void stopStartedBindables(List<Bindable> startedBindables,
+			RuntimeException exception) {
+		for (int i = startedBindables.size() - 1; i >= 0; i--) {
+			try {
+				this.doStopWithBindable(startedBindables.get(i));
+			}
+			catch (RuntimeException stopException) {
+				exception.addSuppressed(stopException);
+			}
+		}
 	}
 
 	abstract void doStartWithBindable(Bindable bindable);

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindingService.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/binding/BindingService.java
@@ -126,48 +126,54 @@ public class BindingService {
 		String bindingTarget = this.bindingServiceProperties
 				.getBindingDestination(inputName);
 
-		if (consumerProperties.isMultiplex()) {
-			bindings.add(doBindConsumer(input, inputName, binder, consumerProperties,
-					bindingTarget));
-		}
-		else {
-			String[] bindingTargets = StringUtils
-					.commaDelimitedListToStringArray(bindingTarget);
-			for (String target : bindingTargets) {
-				if (!consumerProperties.isPartitioned() || consumerProperties.getInstanceIndexList().isEmpty()) {
-					Binding<T> binding = input instanceof PollableSource
-						? doBindPollableConsumer(input, inputName, binder,
-						consumerProperties, target)
-						: doBindConsumer(input, inputName, binder, consumerProperties,
-						target);
-
-					bindings.add(binding);
-				}
-				else {
-					for (Integer index : consumerProperties.getInstanceIndexList()) {
-						if (index < 0) {
-							continue;
-						}
-
-						Object extension = consumerProperties instanceof ExtendedConsumerProperties extendedProperties
-								? extendedProperties.getExtension()
-										: null;
-
-						ConsumerProperties consumerPropertiesTemp = new ExtendedConsumerProperties<>(extension);
-						BeanUtils.copyProperties(consumerProperties, consumerPropertiesTemp);
-
-						consumerPropertiesTemp.setInstanceIndex(index);
-
+		try {
+			if (consumerProperties.isMultiplex()) {
+				bindings.add(doBindConsumer(input, inputName, binder, consumerProperties,
+						bindingTarget));
+			}
+			else {
+				String[] bindingTargets = StringUtils
+						.commaDelimitedListToStringArray(bindingTarget);
+				for (String target : bindingTargets) {
+					if (!consumerProperties.isPartitioned() || consumerProperties.getInstanceIndexList().isEmpty()) {
 						Binding<T> binding = input instanceof PollableSource
 							? doBindPollableConsumer(input, inputName, binder,
-							consumerPropertiesTemp, target)
-							: doBindConsumer(input, inputName, binder, consumerPropertiesTemp,
+							consumerProperties, target)
+							: doBindConsumer(input, inputName, binder, consumerProperties,
 							target);
 
 						bindings.add(binding);
 					}
+					else {
+						for (Integer index : consumerProperties.getInstanceIndexList()) {
+							if (index < 0) {
+								continue;
+							}
+
+							Object extension = consumerProperties instanceof ExtendedConsumerProperties extendedProperties
+									? extendedProperties.getExtension()
+											: null;
+
+							ConsumerProperties consumerPropertiesTemp = new ExtendedConsumerProperties<>(extension);
+							BeanUtils.copyProperties(consumerProperties, consumerPropertiesTemp);
+
+							consumerPropertiesTemp.setInstanceIndex(index);
+
+							Binding<T> binding = input instanceof PollableSource
+								? doBindPollableConsumer(input, inputName, binder,
+								consumerPropertiesTemp, target)
+								: doBindConsumer(input, inputName, binder, consumerPropertiesTemp,
+								target);
+
+							bindings.add(binding);
+						}
+					}
 				}
 			}
+		}
+		catch (RuntimeException ex) {
+			this.unbindConsumerBindings(bindings, ex);
+			throw ex;
 		}
 		bindings = Collections.unmodifiableCollection(bindings);
 		this.consumerBindings.put(inputName, new ArrayList<>(bindings));
@@ -383,14 +389,28 @@ public class BindingService {
 	public void unbindConsumers(String inputName) {
 		List<Binding<?>> bindings = this.consumerBindings.remove(inputName);
 		if (bindings != null && !CollectionUtils.isEmpty(bindings)) {
-			for (Binding<?> binding : bindings) {
+			this.unbindConsumerBindings(bindings, null);
+		}
+		else if (this.log.isWarnEnabled()) {
+			this.log.warn("Trying to unbind '" + inputName + "', but no binding found.");
+		}
+	}
+
+	private void unbindConsumerBindings(
+			Collection<? extends Binding<?>> bindings,
+			@Nullable RuntimeException exception) {
+		for (Binding<?> binding : bindings) {
+			try {
 				binding.stop();
 				//then
 				binding.unbind();
 			}
-		}
-		else if (this.log.isWarnEnabled()) {
-			this.log.warn("Trying to unbind '" + inputName + "', but no binding found.");
+			catch (RuntimeException unbindException) {
+				if (exception == null) {
+					throw unbindException;
+				}
+				exception.addSuppressed(unbindException);
+			}
 		}
 	}
 

--- a/core/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binding/BindingLifecycleTests.java
+++ b/core/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binding/BindingLifecycleTests.java
@@ -18,7 +18,9 @@ package org.springframework.cloud.stream.binding;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -27,7 +29,10 @@ import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.cloud.stream.binder.Binding;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Oleg Zhurakousky
@@ -68,6 +73,32 @@ class BindingLifecycleTests {
 				lifecycle).getPropertyValue("inputBindings");
 		assertThat(lifecycleInputBindings.size() == 5).isTrue();
 		lifecycle.stop();
+	}
+
+	@Test
+	void inputBindingLifecycleUnbindsStartedBindablesAfterStartFailure() {
+		Map<String, Bindable> bindables = new LinkedHashMap<>();
+		BindingService bindingService = mock(BindingService.class);
+		Binding<Object> binding = mock(Binding.class);
+		Bindable started = mock(Bindable.class);
+		Bindable failing = mock(Bindable.class);
+		RuntimeException failure = new RuntimeException("fail");
+
+		when(started.createAndBindInputs(bindingService))
+				.thenReturn(Collections.singletonList(binding));
+		when(failing.createAndBindInputs(bindingService)).thenThrow(failure);
+
+		bindables.put("started", started);
+		bindables.put("failing", failing);
+
+		InputBindingLifecycle lifecycle = new InputBindingLifecycle(bindingService,
+				bindables);
+
+		assertThatThrownBy(lifecycle::start).isSameAs(failure);
+
+		verify(failing).unbindInputs(bindingService);
+		verify(started).unbindInputs(bindingService);
+		assertThat(lifecycle.isRunning()).isFalse();
 	}
 
 	@Test

--- a/core/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binding/BindingServiceTests.java
+++ b/core/spring-cloud-stream/src/test/java/org/springframework/cloud/stream/binding/BindingServiceTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2015-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binding;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import tools.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+import org.springframework.cloud.stream.binder.Binder;
+import org.springframework.cloud.stream.binder.BinderFactory;
+import org.springframework.cloud.stream.binder.Binding;
+import org.springframework.cloud.stream.binder.ConsumerProperties;
+import org.springframework.cloud.stream.config.BindingProperties;
+import org.springframework.cloud.stream.config.BindingServiceProperties;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.messaging.MessageChannel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+class BindingServiceTests {
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	void unbindsConsumerBindingsIfLaterConsumerBindingFails() {
+		BindingServiceProperties properties = new BindingServiceProperties();
+		properties.setBindingRetryInterval(0);
+		Map<String, BindingProperties> bindingProperties = new HashMap<>();
+		BindingProperties props = new BindingProperties();
+		props.setDestination("foo,bar");
+		String inputChannelName = "input";
+		bindingProperties.put(inputChannelName, props);
+		properties.setBindings(bindingProperties);
+
+		Binder<MessageChannel, ConsumerProperties, ?> binder = Mockito.mock(Binder.class);
+		BinderFactory binderFactory = Mockito.mock(BinderFactory.class);
+		MessageChannel inputChannel = new DirectChannel();
+		doReturn(binder).when(binderFactory).getBinder(isNull(), eq(DirectChannel.class));
+		BindingService service = new BindingService(properties, binderFactory, new ObjectMapper());
+		Binding<MessageChannel> mockBinding = Mockito.mock(Binding.class);
+
+		when(binder.bindConsumer(eq("foo"), isNull(), same(inputChannel),
+				any(ConsumerProperties.class))).thenReturn(mockBinding);
+		when(binder.bindConsumer(eq("bar"), isNull(), same(inputChannel),
+				any(ConsumerProperties.class)))
+			.thenThrow(new RuntimeException("fail"));
+
+		assertThatThrownBy(() -> service.bindConsumer(inputChannel, inputChannelName))
+			.isInstanceOf(RuntimeException.class)
+			.hasMessage("fail");
+
+		InOrder inOrder = Mockito.inOrder(mockBinding);
+		inOrder.verify(mockBinding).stop();
+		inOrder.verify(mockBinding).unbind();
+		assertThat(service.getConsumerBindings(inputChannelName)).isEmpty();
+	}
+
+}


### PR DESCRIPTION
## Summary
- Stop and unbind bindings that were already started when binding lifecycle startup fails.
- Stop and unbind consumer bindings created earlier in a multi-target consumer binding call if a later target fails.
- Add focused regressions for startup cleanup and partial consumer binding cleanup.

## Testing
- `./mvnw -pl core/spring-cloud-stream -Dtest=BindingLifecycleTests,BindingServiceTests test`
- `./mvnw -pl core/spring-cloud-stream test`

Fixes gh-3205