### PR TITLE
Use configured JsonMapper bean when resolving JacksonJsonSerde

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/SerdeResolverUtils.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/main/java/org/springframework/cloud/stream/binder/kafka/streams/SerdeResolverUtils.java
@@ -36,10 +36,13 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.ResolvableType;
 import org.springframework.kafka.support.serializer.JacksonJsonSerde;
 
+import tools.jackson.databind.json.JsonMapper;
+
 /**
  * Utility class that contains various methods to help resolve {@link Serde Serdes}.
  *
  * @author Chris Bono
+ * @author adityaanikam
  * @since 4.0
  */
 abstract class SerdeResolverUtils {
@@ -102,7 +105,8 @@ abstract class SerdeResolverUtils {
 
 		// Use JsonSerde if type is not exactly Object
 		if (!genericRawClazz.isAssignableFrom((Object.class))) {
-			return new JacksonJsonSerde<>(genericRawClazz);
+			JsonMapper jsonMapper = context.getBeanProvider(JsonMapper.class).getIfUnique();
+			return jsonMapper != null ? new JacksonJsonSerde<>(genericRawClazz, jsonMapper) : new JacksonJsonSerde<>(genericRawClazz);
 		}
 
 		// Finally, just resort to using the fallback

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/SerdeResolverUtilsTests.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-streams/src/test/java/org/springframework/cloud/stream/binder/kafka/streams/SerdeResolverUtilsTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.stream.binder.kafka.streams;
 
+import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.util.Date;
 import java.util.UUID;
@@ -40,6 +41,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.ResolvableType;
 import org.springframework.kafka.support.serializer.JacksonJsonSerde;
+import org.springframework.kafka.support.serializer.JacksonJsonSerializer;
+
+import tools.jackson.databind.json.JsonMapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
@@ -49,6 +53,7 @@ import static org.mockito.Mockito.mock;
  * Unit tests for {@link SerdeResolverUtils}.
  *
  * @author Chris Bono
+ * @author adityaanikam
  */
 @SuppressWarnings({ "rawtypes", "unchecked" })
 class SerdeResolverUtilsTests {
@@ -156,6 +161,38 @@ class SerdeResolverUtilsTests {
 						assertThat(SerdeResolverUtils.resolveForType(context, ResolvableType.forClass(Object.class), null))
 							.isNull());
 				}
+			}
+
+			@Nested
+			class WithJsonMapperBean {
+
+				@Test
+				void usesConfiguredJsonMapperBeanWhenPresent() throws Exception {
+					new ApplicationContextRunner()
+						.withPropertyValues("spring.cloud.function.ineligible-definitions: sendToDlqAndContinue")
+						.withUserConfiguration(SerdeResolverJsonMapperTestApp.class)
+						.run((context) -> {
+							Serde<?> serde = SerdeResolverUtils.resolveForType(context, ResolvableType.forClass(Foo.class), null);
+							assertThat(serde).isInstanceOf(JacksonJsonSerde.class);
+
+							JsonMapper expectedMapper = context.getBean(JsonMapper.class);
+							JacksonJsonSerializer<?> serializer = (JacksonJsonSerializer<?>) serde.serializer();
+							Field mapperField = JacksonJsonSerializer.class.getDeclaredField("jsonMapper");
+							mapperField.setAccessible(true);
+							assertThat(mapperField.get(serializer)).isSameAs(expectedMapper);
+						});
+				}
+
+				@EnableAutoConfiguration
+				static class SerdeResolverJsonMapperTestApp {
+
+					@Bean
+					public JsonMapper customJsonMapper() {
+						return JsonMapper.builder().build();
+					}
+
+				}
+
 			}
 		}
 	}


### PR DESCRIPTION
Fixes gh-3231

## What / why

`SerdeResolverUtils.resolveForType()` falls back to `new JacksonJsonSerde<>(genericRawClazz)` (the no-arg-mapper constructor) whenever no matching `Serde` bean and no valid fallback are found. This means any `JsonMapper` bean configured in the application context — for `spring.jackson.*` customization or otherwise — is never picked up for Serdes created through this path, even though `JacksonJsonSerde` has a `(Class, JsonMapper)` constructor that supports exactly this.

## Fix

Look up a `JsonMapper` bean from the context (`context.getBeanProvider(JsonMapper.class).getIfUnique()`) and pass it into `JacksonJsonSerde`'s constructor when exactly one unambiguous bean is present, falling back to today's no-arg behavior otherwise (zero or multiple candidates).

## Testing

Added `SerdeResolverUtilsTests.ResolveForType.NoMatchingSerdeBeans.WithJsonMapperBean`, which registers a custom `JsonMapper` bean and verifies (via the `JacksonJsonSerializer` internal field) that the exact same instance is wired into the resolved Serde. Ran the full `spring-cloud-stream-binder-kafka-streams` test suite locally (122 tests, 0 failures, 0 errors) to confirm no regressions.
