### PR TITLE
GH-3242: Key StreamBridge function cache by binding name

### DIFF
--- a/core/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/function/StreamBridgeTests.java
+++ b/core/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/function/StreamBridgeTests.java
@@ -47,6 +47,8 @@ import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.cloud.function.cloudevent.CloudEventMessageBuilder;
 import org.springframework.cloud.function.cloudevent.CloudEventMessageUtils;
 import org.springframework.cloud.function.context.catalog.SimpleFunctionRegistry.FunctionInvocationWrapper;
+import org.springframework.cloud.stream.binder.BinderHeaders;
+import org.springframework.cloud.stream.binder.PartitionKeyExtractorStrategy;
 import org.springframework.cloud.stream.binder.test.InputDestination;
 import org.springframework.cloud.stream.binder.test.OutputDestination;
 import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
@@ -484,6 +486,67 @@ class StreamBridgeTests {
 		}
 		finally {
 			executor.shutdownNow();
+		}
+	}
+
+	/*
+	 * Two bindings whose properties hash alike must still get their own function, which is why the
+	 * cache is keyed by value rather than by a hash of those properties. This pair collides under
+	 * Objects.hash(contentType, nativeEncoding, partitioned, partitionCount, bindingName): with a
+	 * cache keyed by that hash, the non-partitioned send picks up the function left partition-aware
+	 * by the previous send and fails with "Partition key cannot be null" as in GH-3242.
+	 */
+	@SuppressWarnings("rawtypes")
+	@Test
+	void partitionedBindingIsNotSharedWithHashCollidingBinding() throws Exception {
+		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
+			TestChannelBinderConfiguration.getCompleteConfiguration(
+				PartitionKeyExtractorConfiguration.class)).web(WebApplicationType.NONE).run(
+			"--spring.cloud.stream.source=nonPartitioned",
+			"--spring.cloud.stream.bindings[A>].producer.partition-count=120",
+			"--spring.cloud.stream.bindings[A>].producer.partition-key-extractor-name=partitionKeyExtractor",
+			"--spring.cloud.stream.bindings.nonPartitioned-out-0.producer.partition-count=1",
+			"--spring.jmx.enabled=false")) {
+			StreamBridge streamBridge = context.getBean(StreamBridge.class);
+			Field field = ReflectionUtils.findField(StreamBridge.class, "streamBridgeFunctionCache");
+			Objects.requireNonNull(field).setAccessible(true);
+			Map functionCache = (Map) field.get(streamBridge);
+
+			streamBridge.send("A>", MessageBuilder.withPayload("partitioned").setHeader("partitionKey", "key").build());
+			streamBridge.send("nonPartitioned-out-0", MessageBuilder.withPayload("nonPartitioned").build());
+
+			assertThat(functionCache.size()).isEqualTo(2);
+
+			OutputDestination output = context.getBean(OutputDestination.class);
+			assertThat(output.receive(1000, "A>").getHeaders()
+				.containsKey(BinderHeaders.PARTITION_HEADER)).isTrue();
+			assertThat(output.receive(1000, "nonPartitioned-out-0").getHeaders()
+				.containsKey(BinderHeaders.PARTITION_HEADER)).isFalse();
+		}
+	}
+
+	// See https://github.com/spring-cloud/spring-cloud-stream/issues/3242
+	@Test
+	void test_3242() {
+		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
+			TestChannelBinderConfiguration.getCompleteConfiguration(
+				PartitionKeyExtractorConfiguration.class)).web(WebApplicationType.NONE).run(
+			"--spring.cloud.stream.source=partitioned;nonPartitioned",
+			"--spring.cloud.stream.bindings.partitioned-out-0.producer.partition-count=7",
+			"--spring.cloud.stream.bindings.partitioned-out-0.producer.partition-key-extractor-name=partitionKeyExtractor",
+			"--spring.cloud.stream.bindings.nonPartitioned-out-0.producer.partition-count=1",
+			"--spring.jmx.enabled=false")) {
+			StreamBridge streamBridge = context.getBean(StreamBridge.class);
+
+			streamBridge.send("partitioned-out-0",
+				MessageBuilder.withPayload("partitioned").setHeader("partitionKey", "key").build());
+			streamBridge.send("nonPartitioned-out-0", MessageBuilder.withPayload("nonPartitioned").build());
+
+			OutputDestination output = context.getBean(OutputDestination.class);
+			assertThat(output.receive(1000, "partitioned-out-0").getHeaders()
+				.containsKey(BinderHeaders.PARTITION_HEADER)).isTrue();
+			assertThat(output.receive(1000, "nonPartitioned-out-0").getHeaders()
+				.containsKey(BinderHeaders.PARTITION_HEADER)).isFalse();
 		}
 	}
 
@@ -927,6 +990,16 @@ class StreamBridgeTests {
 
 	@EnableAutoConfiguration
 	public static class EmptyConfiguration {
+
+	}
+
+	@EnableAutoConfiguration
+	public static class PartitionKeyExtractorConfiguration {
+
+		@Bean
+		public PartitionKeyExtractorStrategy partitionKeyExtractor() {
+			return message -> message.getHeaders().get("partitionKey");
+		}
 
 	}
 

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/StreamBridge.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/StreamBridge.java
@@ -117,7 +117,7 @@ public final class StreamBridge implements StreamOperations, SmartInitializingSi
 
 	private final BindingService bindingService;
 
-	private final Map<Integer, FunctionInvocationWrapper> streamBridgeFunctionCache;
+	private final Map<StreamBridgeFunctionKey, FunctionInvocationWrapper> streamBridgeFunctionCache;
 
 	private final FunctionInvocationHelper<?> functionInvocationHelper;
 
@@ -196,7 +196,7 @@ public final class StreamBridge implements StreamOperations, SmartInitializingSi
 		ProducerProperties producerProperties = this.bindingServiceProperties.getProducerProperties(bindingName);
 		MessageChannel messageChannel = this.resolveDestination(bindingName, producerProperties, binderName);
 
-		Function functionToInvoke = this.getStreamBridgeFunction(outputContentType.toString(), producerProperties);
+		Function functionToInvoke = this.getStreamBridgeFunction(bindingName, outputContentType.toString(), producerProperties);
 
 		if (producerProperties != null && producerProperties.isPartitioned()) {
 			functionToInvoke = new PartitionAwareFunctionWrapper(functionToInvoke, this.applicationContext, producerProperties);
@@ -232,21 +232,12 @@ public final class StreamBridge implements StreamOperations, SmartInitializingSi
 		return messageChannel.send(resultMessage);
 	}
 
-	private int hashProducerProperties(ProducerProperties producerProperties, String outputContentType) {
-		int hash = outputContentType.hashCode()
-				+ Boolean.hashCode(producerProperties.isUseNativeEncoding())
-				+ Boolean.hashCode(producerProperties.isPartitioned())
-				+ producerProperties.getPartitionCount();
-
-		if (producerProperties.getPartitionKeyExpression() != null && producerProperties.getBindingName() != null) {
-			hash += producerProperties.getBindingName().hashCode();
-		}
-
-		return hash;
-	}
-
-	private FunctionInvocationWrapper getStreamBridgeFunction(String outputContentType, ProducerProperties producerProperties) {
-		int streamBridgeFunctionKey = this.hashProducerProperties(producerProperties, outputContentType);
+	private FunctionInvocationWrapper getStreamBridgeFunction(String bindingName, String outputContentType, ProducerProperties producerProperties) {
+		StreamBridgeFunctionKey streamBridgeFunctionKey = new StreamBridgeFunctionKey(outputContentType,
+				producerProperties.isUseNativeEncoding(),
+				producerProperties.isPartitioned(),
+				producerProperties.getPartitionCount(),
+				producerProperties.isPartitioned() ? bindingName : null);
 
 		return this.streamBridgeFunctionCache.computeIfAbsent(streamBridgeFunctionKey, key -> {
 			FunctionInvocationWrapper functionToInvoke = this.functionCatalog.lookup(STREAM_BRIDGE_FUNC_NAME, outputContentType.toString());
@@ -391,6 +382,19 @@ public final class StreamBridge implements StreamOperations, SmartInitializingSi
 				}
 			}
 		});
+	}
+
+	/*
+	 * Identifies the function cached for a send(..). A partitioned binding mutates the cached
+	 * function by setting the partition enhancer on it, so it must not share that function with
+	 * another binding; its binding name is therefore part of the key. The name is taken from the
+	 * send(..) argument, since ProducerProperties#getBindingName() is only populated for binders
+	 * that are not an ExtendedPropertiesBinder (see GH-3242). Non-partitioned bindings leave it
+	 * null and keep sharing a single function. Equality rather than a computed hash decides cache
+	 * hits, so two distinct bindings can never be conflated by a hash collision.
+	 */
+	private record StreamBridgeFunctionKey(String outputContentType, boolean useNativeEncoding,
+			boolean partitioned, int partitionCount, String bindingName) {
 	}
 
 	private static final class ContextPropagationHelper {


### PR DESCRIPTION
Fixes #3242

### What

`StreamBridge.send(..)` caches the `FunctionInvocationWrapper` under a hash of the producer properties. The binding name only entered that hash when `partitionKeyExpression` and `ProducerProperties#getBindingName()` were both non-null, and `getBindingName()` is never populated on the instance `StreamBridge` reads: `BindingService#bindProducer` calls `populateBindingName(..)` on the extended copy it builds for an `ExtendedPropertiesBinder`, while `StreamBridge` reads the original from `BindingServiceProperties#getProducerProperties(bindingName)`.

So a partitioned binding can share its cached function with another binding. `PartitionAwareFunctionWrapper` sets the partition enhancer on that shared function and only clears it when the result carries no `scst_partition` header, so after a successful partitioned send the enhancer stays on the cached function. The next send on the colliding binding then runs through `PartitionHandler` without a partition key and fails with `IllegalArgumentException: Partition key cannot be null`.

The hash also summed its components, so `Boolean.hashCode(true) + partitionCount` and `Boolean.hashCode(false) + partitionCount` collide whenever the partitioned binding's count is 6 higher than the other one's.

### Change

The cache is keyed by a record of `outputContentType`, `useNativeEncoding`, `partitioned`, `partitionCount` and `bindingName` instead of by a computed `int`, so `ConcurrentHashMap` distinguishes bindings by equality and no hash collision can make two of them share a function. The binding name comes from the `send(..)` argument, which is always available, and is only part of the key for partitioned bindings, so non-partitioned bindings keep sharing one cached function and the behaviour asserted by `test_2783` is unchanged.

### Verification

`test_3242` in `StreamBridgeTests` reproduces the failure: a binding partitioned via `partition-key-extractor-name` (which leaves `partitionKeyExpression` null, so the old guard never added the binding name) with `partition-count: 7`, and a non-partitioned binding with `partition-count: 1`. On `main` the second send fails with `Partition key cannot be null`; with this change both sends succeed and only the partitioned message carries `scst_partition`.

`partitionedBindingIsNotSharedWithHashCollidingBinding` covers the collision case: two accepted configurations whose properties hash alike under `Objects.hash(..)` (both `682613285`). A cache keyed by that hash hands the partition-aware function to the non-partitioned send, which then fails the same way; with the value key both sends succeed and the cache holds two entries.

- `./mvnw -f core/pom.xml clean install` (the build CI runs): BUILD SUCCESS.
- `StreamBridgeTests`: 41 tests, 1 failure. The failure is `test_3033`, which fails the same way on `main` at a2bbc439, before this change (that module is currently commented out of the `core` reactor).
- Whole `spring-cloud-stream-integration-tests` module, this branch versus its base a2bbc439: 13 tests fail here and 14 on the base, and the set here is a subset of the base's. The one extra failure on the base (`MultipleInputOutputFunctionTests.multiInputSingleOutputWithCustomContentType2`) passes when run on its own, so it is flaky in the full run.
