### PR TITLE
GH-3211: Restore timestamp header on consumed messages

### DIFF
--- a/core/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/function/HeaderTests.java
+++ b/core/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/function/HeaderTests.java
@@ -129,6 +129,24 @@ public class HeaderTests {
 		assertThat(headers.get(MessageHeaders.CONTENT_TYPE)).isEqualTo("application/json");
 	}
 
+	@Test
+	void timestampHeaderIsPresentOnConsumedMessage() {
+		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(
+			TestChannelBinderConfiguration.getCompleteConfiguration(FunctionUpperCaseConfiguration.class))
+			.web(WebApplicationType.NONE)
+			.run("--spring.jmx.enabled=false",
+				"--spring.cloud.function.definition=uppercase")) {
+
+			InputDestination input = context.getBean(InputDestination.class);
+			input.send(new GenericMessage<>("hello".getBytes()), "uppercase-in-0");
+
+			OutputDestination output = context.getBean(OutputDestination.class);
+			Message<byte[]> result = output.receive(1000, "uppercase-out-0");
+
+			assertThat(result.getHeaders().getTimestamp()).isNotNull();
+		}
+	}
+
 	@EnableAutoConfiguration
 	public static class EmptyConfiguration {
 

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/FunctionConfiguration.java
@@ -113,6 +113,7 @@ import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.SubscribableChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.GenericMessage;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.Trigger;
 import org.springframework.scheduling.support.CronTrigger;
@@ -409,12 +410,19 @@ public class FunctionConfiguration {
 	}
 
 	private static <P> Message<P> sanitize(Message<P> inputMessage) {
-		return MessageBuilder
+		Message<P> sanitized = MessageBuilder
 			.fromMessage(inputMessage)
 			.removeHeader("spring.cloud.stream.sendto.destination")
-//			.setHeader(MessageUtils.SOURCE_TYPE, inputMessage.getHeaders().get(MessageUtils.TARGET_PROTOCOL))
-//			.removeHeader(MessageUtils.TARGET_PROTOCOL)
 			.build();
+		if (sanitized == inputMessage) {
+			// MessageBuilder.build() returns the same instance when no header was
+			// actually modified (fast-path in BaseMessageBuilder), which skips the
+			// GenericMessage constructor and therefore skips stamping a "timestamp"
+			// header. Force a fresh GenericMessage so the header is always present,
+			// restoring pre-4.3.3 behavior. See GH-3211.
+			sanitized = new GenericMessage<>(inputMessage.getPayload(), inputMessage.getHeaders());
+		}
+		return sanitized;
 	}
 
 	private static class FunctionToDestinationBinder implements InitializingBean, ApplicationContextAware {


### PR DESCRIPTION
What changed

FunctionConfiguration#sanitize() was relying on MessageBuilder's internal "no-op fast path" to always construct a fresh GenericMessage. Since GH-2222 removed the SOURCE_TYPE/TARGET_PROTOCOL header manipulation from this method, headerAccessor.isModified() now returns false when no other header changes occur, causing MessageBuilder.build() to return the original Message instance instead of constructing a new GenericMessage. Since only the GenericMessage constructor stamps a timestamp header, this silently removed the timestamp header from every consumed message starting in 4.3.3.

This PR fixes sanitize() to explicitly construct a GenericMessage whenever the fast path is taken, restoring the pre-4.3.3 behavior of always stamping a timestamp header.

What did not change

The TARGET_PROTOCOL/SOURCE_TYPE header logic removed in GH-2222 is intentionally left untouched — that removal fixed a separate bug (incorrect target-protocol values for non-Kafka/Rabbit binders) and reintroducing it was out of scope here.

Testing

Added timestampHeaderIsPresentOnConsumedMessage() in HeaderTests, which sends a message through a functional binding and asserts MessageHeaders.getTimestamp() is non-null on the consumed message. Ran the full spring-cloud-stream and spring-cloud-stream-integration-tests module test suites locally — all passing, no regressions in existing header-related tests.

Fixes #3211