### PR TITLE
GH-3193 Add ackCount and ackTime to KafkaConsumerProperties

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaConsumerProperties.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka-core/src/main/java/org/springframework/cloud/stream/binder/kafka/properties/KafkaConsumerProperties.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.stream.binder.kafka.properties;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -98,6 +99,24 @@ public class KafkaConsumerProperties {
 	 * container instead of the deprecated autoCommitOffset property.
 	 */
 	private ContainerProperties.AckMode ackMode;
+
+	/**
+	 * Consumer ack count. When set, the container will send an acknowledgment after the specified number
+	 * of messages have been consumed. Only applicable for COUNT or COUNT_TIME ack modes.
+	 * <p>
+	 * This property is binding-level and takes precedence over the global
+	 * {@code spring.kafka.listener.ackCount} when explicitly configured on the binding.
+	 */
+	private Integer ackCount;
+
+	/**
+	 * Consumer ack time. When set, the container will send an acknowledgment after the specified duration
+	 * has elapsed since the last message was consumed. Only applicable for TIME or COUNT_TIME ack modes.
+	 * <p>
+	 * This property is binding-level and takes precedence over the global
+	 * {@code spring.kafka.listener.ackTime} when explicitly configured on the binding.
+	 */
+	private Duration ackTime;
 
 	/**
 	 * Flag to enable auto commit on error in polled consumers.
@@ -221,6 +240,34 @@ public class KafkaConsumerProperties {
 
 	public void setAckMode(ContainerProperties.AckMode ackMode) {
 		this.ackMode = ackMode;
+	}
+
+	/**
+	 * @return consumer ack count, or null if not set at the binding level.
+	 * <p>
+	 * Binding-level value takes precedence over the global
+	 * {@code spring.kafka.listener.ackCount} when explicitly configured.
+	 */
+	public Integer getAckCount() {
+		return this.ackCount;
+	}
+
+	public void setAckCount(Integer ackCount) {
+		this.ackCount = ackCount;
+	}
+
+	/**
+	 * @return consumer ack time, or null if not set at the binding level.
+	 * <p>
+	 * Binding-level value takes precedence over the global
+	 * {@code spring.kafka.listener.ackTime} when explicitly configured.
+	 */
+	public Duration getAckTime() {
+		return this.ackTime;
+	}
+
+	public void setAckTime(Duration ackTime) {
+		this.ackTime = ackTime;
 	}
 
 	/**

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/KafkaMessageChannelBinder.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -708,6 +709,18 @@ public class KafkaMessageChannelBinder extends
 				messageListenerContainer.getContainerProperties()
 						.setAckMode(ackMode);
 			}
+		}
+
+		// Apply binding-level ackCount and ackTime after global propagation
+		// These take precedence over global spring.kafka.listener values when explicitly set
+		KafkaConsumerProperties consumerExt = extendedConsumerProperties.getExtension();
+		Integer bindingAckCount = consumerExt.getAckCount();
+		if (bindingAckCount != null) {
+			messageListenerContainer.getContainerProperties().setAckCount(bindingAckCount);
+		}
+		Duration bindingAckTime = consumerExt.getAckTime();
+		if (bindingAckTime != null) {
+			messageListenerContainer.getContainerProperties().setAckTime(bindingAckTime.toMillis());
 		}
 
 		if (this.logger.isDebugEnabled()) {

--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/test/java/org/springframework/cloud/stream/binder/kafka/KafkaBinderTests.java
@@ -2016,6 +2016,29 @@ class KafkaBinderTests extends
 	}
 
 	@Test
+	void bindingAckCountAndAckTimeAreAppliedToContainerProperties() {
+		Binder<MessageChannel, ExtendedConsumerProperties<KafkaConsumerProperties>, ExtendedProducerProperties<KafkaProducerProperties>> binder = getBinder();
+		var moduleInputChannel = new QueueChannel();
+		ExtendedConsumerProperties<KafkaConsumerProperties> consumerProperties = createConsumerProperties();
+		consumerProperties.getExtension().setAckCount(10);
+		consumerProperties.getExtension().setAckTime(Duration.ofSeconds(5));
+
+		Binding<MessageChannel> consumerBinding = binder.bindConsumer(
+				"testBindingAckCountAndAckTime" + UUID.randomUUID(), "test", moduleInputChannel,
+				consumerProperties);
+		try {
+			AbstractMessageListenerContainer<?, ?> container = TestUtils.getPropertyValue(
+					consumerBinding, "lifecycle.messageListenerContainer",
+					AbstractMessageListenerContainer.class);
+			assertThat(container.getContainerProperties().getAckCount()).isEqualTo(10);
+			assertThat(container.getContainerProperties().getAckTime()).isEqualTo(5000L);
+		}
+		finally {
+			consumerBinding.unbind();
+		}
+	}
+
+	@Test
 	@Override
 	@SuppressWarnings("unchecked")
 	public void testTwoRequiredGroups(TestInfo testInfo) throws Exception {

--- a/docs/modules/ROOT/pages/kafka/kafka-binder/config-options.adoc
+++ b/docs/modules/ROOT/pages/kafka/kafka-binder/config-options.adoc
@@ -189,6 +189,16 @@ ackMode::
 Specify the container ack mode.
 This is based on the AckMode enumeration defined in Spring Kafka.
 If `ackEachRecord` property is set to `true` and consumer is not in batch mode, then this will use the ack mode of `RECORD`, otherwise, use the provided ack mode using this property.
+ackCount::
+The number of records that must be processed before pending offsets are committed when the `ackMode` is `COUNT` or `COUNT_TIME`.
+When set, this binding-level value takes precedence over the global `spring.kafka.listener.ackCount`.
++
+Default: not set.
+ackTime::
+The time after which pending offsets are committed when the `ackMode` is `TIME` or `COUNT_TIME`.
+When set, this binding-level value takes precedence over the global `spring.kafka.listener.ackTime`.
++
+Default: not set.
 
 autoCommitOnError::
 In pollable consumers, if set to `true`, it always auto commits on error.


### PR DESCRIPTION
Add binding-level `ackCount` and `ackTime` options to `KafkaConsumerProperties`.

Currently, users who need to set `ackCount`/`ackTime` per binding have to do so globally
via `spring.kafka.listener` or through a `ListenerContainerCustomizer`. This change exposes
both properties at the binding level, e.g.:

```yaml
spring:
  cloud:
    stream:
      kafka:
        bindings:
          my-binding:
            consumer:
              ackCount: 10
              ackTime: 5s
```

When unset, the binding-level properties stay null so the global `spring.kafka.listener`
values and any `ListenerContainerCustomizer` behavior are preserved.

Resolves: https://github.com/spring-cloud/spring-cloud-stream/issues/3193