### PR TITLE
Add reflection hints for Kafka serializers

### DIFF
--- a/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/aot/KafkaBinderRuntimeHints.java
+++ b/binders/kafka-binder/spring-cloud-stream-binder-kafka/src/main/java/org/springframework/cloud/stream/binder/kafka/aot/KafkaBinderRuntimeHints.java
@@ -18,6 +18,9 @@ package org.springframework.cloud.stream.binder.kafka.aot;
 
 import java.util.stream.Stream;
 
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.ReflectionHints;
 import org.springframework.aot.hint.RuntimeHints;
@@ -47,5 +50,9 @@ public class KafkaBinderRuntimeHints implements RuntimeHintsRegistrar {
 				KafkaBindingProperties.class)
 			.forEach(type -> reflectionHints.registerType(type,
 				builder -> builder.withMembers(MemberCategory.INVOKE_DECLARED_METHODS)));
+		// KafkaBinderEnvironmentPostProcessor sets these as default (de)serializers by
+		// class name, so they are only ever resolved reflectively via Class.forName.
+		Stream.of(ByteArrayDeserializer.class, ByteArraySerializer.class)
+			.forEach(type -> reflectionHints.registerType(type, MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS));
 	}
 }


### PR DESCRIPTION
Should fix the [`cloud-stream-kafka` AOT smoke tests](https://github.com/spring-projects/spring-aot-smoke-tests/actions/runs/33139113379) (and the `cloud-stream-kafka-streams` AOT smoke test).

Not sure if adding hints for Kafka here is the right place.