### PR TITLE
GH-3257: Preserve configured bindings when StreamBridge evicts a channel

### DIFF
--- a/core/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/function/StreamBridgeTests.java
+++ b/core/spring-cloud-stream-integration-tests/src/test/java/org/springframework/cloud/stream/function/StreamBridgeTests.java
@@ -645,6 +645,32 @@ class StreamBridgeTests {
 	}
 
 	@Test
+	void configuredBindingsAreNotRemovedWithCache() {
+		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(TestChannelBinderConfiguration
+			.getCompleteConfiguration(InterceptorConfiguration.class))
+			.web(WebApplicationType.NONE).run(
+				"--spring.jmx.enabled=false",
+				"--spring.cloud.stream.dynamic-destination-cache-size=1",
+				"--spring.cloud.stream.bindings.foo-out-0.destination=fooDestination"
+			)) {
+			StreamBridge bridge = context.getBean(StreamBridge.class);
+			BindingServiceProperties bindingServiceProp = context.getBean(BindingServiceProperties.class);
+
+			bridge.send("foo-out-0", "hello foo");
+			bridge.send("a", "hello a");
+			bridge.send("b", "hello b");
+
+			// foo-out-0 was configured by the application, so cache eviction must leave
+			// its properties alone; otherwise the destination silently reverts to the
+			// binding name the next time the binding is resolved.
+			assertThat(bindingServiceProp.getBindings()).containsKey("foo-out-0");
+			assertThat(bindingServiceProp.getBindings().get("foo-out-0").getDestination())
+				.isEqualTo("fooDestination");
+			assertThat(bindingServiceProp.getBindingDestination("foo-out-0")).isEqualTo("fooDestination");
+		}
+	}
+
+	@Test
 	void withInterceptorsRegisteredOnlyOnOutputChannel() throws InterruptedException {
 		try (ConfigurableApplicationContext context = new SpringApplicationBuilder(TestChannelBinderConfiguration
 			.getCompleteConfiguration(GH2180Configuration.class))

--- a/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/StreamBridge.java
+++ b/core/spring-cloud-stream/src/main/java/org/springframework/cloud/stream/function/StreamBridge.java
@@ -19,6 +19,8 @@ package org.springframework.cloud.stream.function;
 import java.lang.reflect.Type;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -147,6 +149,11 @@ public final class StreamBridge implements StreamOperations, SmartInitializingSi
 		this.applicationContext = applicationContext;
 		this.bindingServiceProperties = bindingServiceProperties;
 		this.destinationBindingCallback = destinationBindingCallback;
+		// Binding names present before any dynamic destination is resolved are the ones
+		// the application configured itself. Evicting a channel must not discard their
+		// configuration, only that of destinations this bridge created on demand.
+		Set<String> configuredBindingNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+		configuredBindingNames.addAll(bindingServiceProperties.getBindings().keySet());
 		this.channelCache = new LinkedHashMap<String, MessageChannel>() {
 			@Override
 			protected boolean removeEldestEntry(Map.Entry<String, MessageChannel> eldest) {
@@ -155,7 +162,9 @@ public final class StreamBridge implements StreamOperations, SmartInitializingSi
 					if (logger.isDebugEnabled()) {
 						logger.debug("Removing message channel from cache " + eldest.getKey());
 					}
-					bindingServiceProperties.getBindings().remove(eldest.getKey());
+					if (!configuredBindingNames.contains(eldest.getKey())) {
+						bindingServiceProperties.getBindings().remove(eldest.getKey());
+					}
 					bindingService.unbindProducers(eldest.getKey());
 				}
 				return remove;


### PR DESCRIPTION
Fixes gh-3257

## Problem

`StreamBridge`'s channel cache evicts its eldest entry once it exceeds `dynamic-destination-cache-size`, and since 07eb699 the eviction also removes the binding from `BindingServiceProperties`:

```java
protected boolean removeEldestEntry(Map.Entry<String, MessageChannel> eldest) {
    boolean remove = size() > bindingServiceProperties.getDynamicDestinationCacheSize();
    if (remove) {
        ...
        bindingServiceProperties.getBindings().remove(eldest.getKey());
        bindingService.unbindProducers(eldest.getKey());
    }
    return remove;
}
```

Removing bindings the bridge created for dynamic destinations is the point of that change, but the removal is unconditional, so it also discards bindings the application configured.

The consequence is not just a missing map entry. `BindingServiceProperties#getBindingProperties` recreates a missing entry and then defaults its destination to the binding name:

```java
public BindingProperties getBindingProperties(String bindingName) {
    this.bindIfNecessary(bindingName);
    BindingProperties bindingProperties = this.bindings.get(bindingName);
    if (bindingProperties.getDestination() == null) {
        bindingProperties.setDestination(bindingName);
    }
    return bindingProperties;
}
```

So after eviction, a binding configured as

```yaml
spring.cloud.stream.bindings.foo-out-0.destination: fooDestination
```

silently resolves to destination `foo-out-0`, and messages go there instead. Any application with more bindings than `dynamic-destination-cache-size` (default 10) hits this once enough distinct bindings are used, which matches the regression reported against 5.0.3.

## Fix

Capture the binding names present when `StreamBridge` is constructed. At that point `BindingServiceProperties` has been bound from configuration and the bridge has not resolved any dynamic destination yet, so those names are exactly the application's own. Eviction then skips them:

```java
if (!configuredBindingNames.contains(eldest.getKey())) {
    bindingServiceProperties.getBindings().remove(eldest.getKey());
}
```

Dynamic destinations are still removed, so the cleanup 07eb699 added keeps working. The set is a `TreeSet` with `String.CASE_INSENSITIVE_ORDER` to match the key semantics of the `bindings` map itself. `unbindProducers` is left as-is for every eviction; it predates the regression and is not implicated here.

## Testing

`configuredBindingsAreNotRemovedWithCache` in `StreamBridgeTests` configures one binding with an explicit destination, sets the cache size to 1, then sends through enough further destinations to evict it, and asserts the configured binding and its destination survive.

Verified with a negative control: reverting only `StreamBridge.java` (keeping the test, and reinstalling the module so the test ran against the reverted code) fails it with

```
Expecting actual:
  {"b"=BindingProperties{destination=b,group=null,contentType=application/json}}
to contain key:
  "foo-out-0"
```

which is the reported symptom. The existing `bindingsAreRemovedWithCache` passes in both directions, confirming dynamic-binding cleanup is unaffected.

One note on running these: `spring-cloud-stream-integration-tests` is currently commented out of `core/pom.xml`, and the module does not compile as it stands — `PollableSourceTests` has an ambiguous `assertThat` overload and `KotlinConfigurationTests` cannot resolve `KotlinTestConfiguration`. Both are unrelated to this change and predate it. I ran the module directly with `-f core/spring-cloud-stream-integration-tests/pom.xml`, with those two files temporarily set aside, to execute the test above. I put the new test beside `bindingsAreRemovedWithCache` since it covers the same eviction path, but happy to move it if you would rather it live somewhere that currently runs in CI.
